### PR TITLE
Fix HTML help system

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,6 @@ install:
     - python3 -mpip install flake8
     - python3 -mpip install random2
     - python3 -mpip install py2exe
-    - python3 -mpip install sgmllib3k
     - python3 -mpip install six
     - perl -v
     - copy C:\msys64\mingw64\bin\mingw32-make.exe C:\msys64\mingw64\bin\make.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 install:
     - sudo cpanm Test::Differences Test::TrailingSpace
     - "`which python3` -m pip install --upgrade --user flake8 random2 six"
-    - "sudo /usr/bin/python3 -m pip install --upgrade random2 sgmllib3k six"
+    - "sudo /usr/bin/python3 -m pip install --upgrade random2 six"
     - "`which python` -m pip install --upgrade --user random2 six"
     - which python
 script: "sh -x scripts/travis-ci-build"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ sudo urpmi pygtk2
 $ sudo urpmi pygtk2.0-libglade
 $ sudo urpmi gnome-python-canvas
 $ gmake test
-$ ln -s html-src html
+$ gmake rules
 $ ln -s data/images images
 $ tar -xvf PySolFC-Cardsets-2.0.tar.bz2 # Need to be downloaded from sourceforge
 $ mkdir -p ~/.PySolFC

--- a/html-src/credits.html
+++ b/html-src/credits.html
@@ -1,119 +1,98 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h2>PySol credits go to</h2>
 <ul>
-<li>Volker Weidner for getting me into Solitaire</li>
-<li>Guido van Rossum for the initial example program</li>
-<li><a href="http://www.inetarena.com/~grania/">T. Kirk</a> for
-lots of contributed games and cardsets</li>
-<li>the Gnome AisleRiot team for parts of the documentation</li>
-<li>the AfterStep and KDE teams for some icons</li>
-<li>the Python, Tcl/Tk &amp; Linux crews for making this program
-possible</li>
+<li> Volker Weidner for getting me into Solitaire
+<li> Guido van Rossum for the initial example program
+<li> <a href="http://www.inetarena.com/~grania/">T. Kirk</a> for lots of contributed games and cardsets
+<li> the Gnome AisleRiot team for parts of the documentation
+<li> the AfterStep and KDE teams for some icons
+<li> the Python, Tcl/Tk &amp; Linux crews for making this program possible
 </ul>
+
 <h2>Game contributors are</h2>
 <ul>
-<li>T. Kirk &lt;grania@mailcity.com&gt;<br />
-lots of Ganjifa <a href="ganjifa.html">Ganjifa</a>, <a href=
-"hanafuda.html">Hanafuda</a> and Tarock type games.</li>
-<li>Andrew Csillag &lt;andrew@starmedia.net&gt;
-<ul>
-<li><a href="rules/canfield.html">Canfield</a></li>
+<li> T. Kirk &lt;grania@mailcity.com&gt;<br>
+  lots of Ganjifa
+  <a href="ganjifa.html">Ganjifa</a>,
+  <a href="hanafuda.html">Hanafuda</a>
+  and Tarock type games.
+<li> Andrew Csillag &lt;andrew@starmedia.net&gt;
+  <ul>
+     <li> <a href="rules/canfield.html">Canfield</a>
+  </ul>
+<li> Deon Ramsey &lt;miavir@furry.de&gt;
+  <ul>
+     <li> <a href="rules/nomad.html">Nomad</a>
+  </ul>
+<li> Galen Brooks &lt;galen@nine.com&gt;
+  <ul>
+     <li> <a href="rules/numerica.html">Numerica</a>
+  </ul>
+<li> Matthew Hohlfeld &lt;hohlfeld@cs.ucsd.edu&gt;
+  <ul>
+     <li> <a href="rules/larasgame.html">Lara's Game</a>
+  </ul>
 </ul>
-</li>
-<li>Deon Ramsey &lt;miavir@furry.de&gt;
-<ul>
-<li><a href="rules/nomad.html">Nomad</a></li>
-</ul>
-</li>
-<li>Galen Brooks &lt;galen@nine.com&gt;
-<ul>
-<li><a href="rules/numerica.html">Numerica</a></li>
-</ul>
-</li>
-<li>Matthew Hohlfeld &lt;hohlfeld@cs.ucsd.edu&gt;
-<ul>
-<li><a href="rules/larasgame.html">Lara's Game</a></li>
-</ul>
-</li>
-</ul>
+
 <h2>Cardset contributors are</h2>
 <ul>
-<li>Bao Trinh &lt;bao@cs.umd.edu&gt;</li>
-<li>DJ Delorie &lt;dj@delorie.com&gt;</li>
-<li>Donald R. Woods &lt;woods@sun.com&gt;</li>
-<li>Felix Bellaby &lt;felix@pooh.u-net.com&gt;</li>
-<li>Heiko Eissfeldt &lt;heiko@colossus.escape.de&gt;</li>
-<li>Jochen Tuchbreiter &lt;whynot@mabi.de&gt;</li>
-<li>John Fitzgibbon</li>
-<li>John Heidemann &lt;johnh@isi.edu&gt;</li>
-<li>Jonathan Blandford &lt;jrb@mit.edu&gt;</li>
-<li>Joseph L. Traub &lt;jtraub@zso.dec.com&gt;</li>
-<li>Michael Bischoff &lt;mbi@mo.math.nat.tu-bs.de&gt;</li>
-<li>Mike Naylor &lt;mike.naylor@5x5poker.com&gt;</li>
-<li>Oliver Xymoron &lt;oxymoron@waste.org&gt;</li>
-<li>Rene Seindal &lt;rene@seindal.dk&gt;</li>
-<li>Rudy Muller &lt;rudy.muller@net.HCC.nl&gt;</li>
-<li>Ryu Changwoo &lt;cwryu@eve.kaist.ac.kr&gt;</li>
-<li>T. Kirk &lt;grania@mailcity.com&gt;</li>
-<li>The Papa &lt;papalini@biancaneve.ing.unifi.it&gt;</li>
+<li> Bao Trinh &lt;bao@cs.umd.edu&gt;
+<li> DJ Delorie &lt;dj@delorie.com&gt;
+<li> Donald R. Woods &lt;woods@sun.com&gt;
+<li> Felix Bellaby &lt;felix@pooh.u-net.com&gt;
+<li> Heiko Eissfeldt &lt;heiko@colossus.escape.de&gt;
+<li> Jochen Tuchbreiter &lt;whynot@mabi.de&gt;
+<li> John Fitzgibbon
+<li> John Heidemann &lt;johnh@isi.edu&gt;
+<li> Jonathan Blandford &lt;jrb@mit.edu&gt;
+<li> Joseph L. Traub &lt;jtraub@zso.dec.com&gt;
+<li> Michael Bischoff &lt;mbi@mo.math.nat.tu-bs.de&gt;
+<li> Mike Naylor &lt;mike.naylor@5x5poker.com&gt;
+<li> Oliver Xymoron &lt;oxymoron@waste.org&gt;
+<li> Rene Seindal &lt;rene@seindal.dk&gt;
+<li> Rudy Muller &lt;rudy.muller@net.HCC.nl&gt;
+<li> Ryu Changwoo &lt;cwryu@eve.kaist.ac.kr&gt;
+<li> T. Kirk &lt;grania@mailcity.com&gt;
+<li> The Papa &lt;papalini@biancaneve.ing.unifi.it&gt;
 </ul>
+
 <h2>Music contributors are</h2>
 <ul>
-<li><a href="http://hem.passagen.se/dachande/">Carl Larsson</a> aka
-<i>Nightbeat</i> &lt;nightbeat@traxinspace.com&gt;</li>
+<li> <a href="http://hem.passagen.se/dachande/">Carl Larsson</a> aka <i>Nightbeat</i>
+     &lt;nightbeat@traxinspace.com&gt;
 </ul>
+
 <h2>Special thanks to</h2>
 <ul>
-<li>Andy Markebo &lt;flognat@fukt.hk-r.se&gt;</li>
-<li>Charles B. Dorsett</li>
-<li>Christian Tismer &lt;tismer@tismer.com&gt;</li>
-<li>Dylan Thurston &lt;Dylan.Thurston@math.unige.ch&gt;</li>
-<li>Jan Nijtmans &lt;j.nijtmans@chello.nl&gt;</li>
-<li>Jordan Russel &lt;jordanr@iname.com&gt;</li>
-<li>Kevin O'Connor &lt;koconnor@cse.Buffalo.EDU&gt;</li>
-<li>Marc-Andre Lemburg &lt;mal@lemburg.com&gt;</li>
-<li>Mark Hammond &lt;MHammond@skippinet.com.au&gt;</li>
-<li>Neil Schemenauer &lt;nascheme@enme.ucalgary.ca&gt;</li>
-<li>Thomas Gellekum &lt;tg@ihf.rwth-aachen.de&gt;</li>
-<li>Vladimir Marangozov
-&lt;Vladimir.Marangozov@inrialpes.fr&gt;</li>
-<li>Zachary Roadhouse &lt;Zachary_Roadhouse@brown.edu&gt;</li>
-<li>Natascha</li>
+<li> Andy Markebo &lt;flognat@fukt.hk-r.se&gt;
+<li> Charles B. Dorsett
+<li> Christian Tismer &lt;tismer@tismer.com&gt;
+<li> Dylan Thurston &lt;Dylan.Thurston@math.unige.ch&gt;
+<li> Jan Nijtmans &lt;j.nijtmans@chello.nl&gt;
+<li> Jordan Russel &lt;jordanr@iname.com&gt;
+<li> Kevin O'Connor &lt;koconnor@cse.Buffalo.EDU&gt;
+<li> Marc-Andre Lemburg &lt;mal@lemburg.com&gt;
+<li> Mark Hammond &lt;MHammond@skippinet.com.au&gt;
+<li> Neil Schemenauer &lt;nascheme@enme.ucalgary.ca&gt;
+<li> Thomas Gellekum &lt;tg@ihf.rwth-aachen.de&gt;
+<li> Vladimir Marangozov &lt;Vladimir.Marangozov@inrialpes.fr&gt;
+<li> Zachary Roadhouse &lt;Zachary_Roadhouse@brown.edu&gt;
+<li> Natascha
 </ul>
+
 <h2>PySol uses the following OpenSource technologies</h2>
 <ul>
-<li><a href="http://www.python.org/">The Python Programming
-Language</a></li>
-<li><a href="http://www.scriptics.com/">The Tcl/Tk GUI
-Toolkit</a></li>
-<li><a href=
-"http://www.devolution.com/~slouken/projects/SDL/index.html">The
-SDL Simple DirectMedia Layer</a></li>
-<li><a href="http://www.lokigames.com/development/smpeg.php3">The
-SDL MPEG Player Library</a></li>
-<li><a href="http://mikmod.darkorb.net/">The MikMod Sound
-Library</a></li>
+<li> <a href="http://www.python.org/">The Python Programming Language</a>
+<li> <a href="http://www.scriptics.com/">The Tcl/Tk GUI Toolkit</a>
+<li> <a href="http://www.devolution.com/~slouken/projects/SDL/index.html">The SDL Simple DirectMedia Layer</a>
+<li> <a href="http://www.lokigames.com/development/smpeg.php3">The SDL MPEG Player Library</a>
+<li> <a href="http://mikmod.darkorb.net/">The MikMod Sound Library</a>
 </ul>
-<h2>PySol was created using the following OpenSource
-technologies</h2>
+
+<h2>PySol was created using the following OpenSource technologies</h2>
 <ul>
-<li><a href="http://www.linux.org/">The Linux Operating
-System</a></li>
-<li><a href="http://www.xfree86.org/">The XFree86 X Window
-System</a></li>
-<li><a href="http://www.kde.org/">The KDE Desktop
-Environment</a></li>
-<li><a href="http://fte.sourceforge.net/">The FTE Text
-Editor</a></li>
-<li><a href="http://www.jordanr.dhs.org/">The Inno Setup Win32
-Installer</a></li>
+<li> <a href="http://www.linux.org/">The Linux Operating System</a>
+<li> <a href="http://www.xfree86.org/">The XFree86 X Window System</a>
+<li> <a href="http://www.kde.org/">The KDE Desktop Environment</a>
+<li> <a href="http://fte.sourceforge.net/">The FTE Text Editor</a>
+<li> <a href="http://www.jordanr.dhs.org/">The Inno Setup Win32 Installer</a>
 </ul>
-</body>
-</html>

--- a/html-src/ganjifa.html
+++ b/html-src/ganjifa.html
@@ -1,25 +1,13 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>General Ganjifa Card Rules</h1>
-Ganjifa are playing cards from India and other nations in the
-region. Usually round, some rectangular decks have been produced.
-The most significant difference between Ganjifa and other types of
-cards is that Ganjifa cards have traditionally been individually
-hand painted. There are any where from eight to twelve or more
-suits per deck, each suit having usually twelve ranks. The two most
-common Ganjifa decks are the Mughal which has eight suits and the
-Dashavatara which has ten. The suits have pip cards numbered from
-Ace through ten and two court cards, the Wazir and the Mir. Ganjifa
-solitaire games play the same as games that use the standard deck
-but the larger number of different cards in a deck (96 or 120) adds
-an element of complexity. The fact that each suit has it's own
-color makes things quite interesting in games that use "Alternate
-Color" row stacks.
-</body>
-</html>
+Ganjifa are playing cards from India and other nations in the region.
+Usually round, some rectangular decks have been produced.  The most significant
+difference between Ganjifa and other types of cards is that Ganjifa cards have
+traditionally been individually hand painted.  There are any where from eight
+to twelve or more suits per deck, each suit having usually twelve ranks.  The
+two most common Ganjifa decks are the Mughal which has eight suits and the
+Dashavatara which has ten.  The suits have pip cards numbered from Ace through
+ten and two court cards, the Wazir and the Mir.  Ganjifa solitaire games play
+the same as games that use the standard deck but the larger number of different
+cards in a deck (96 or 120) adds an element of complexity.  The fact that each
+suit has it's own color makes things quite interesting in games that use
+"Alternate Color" row stacks.

--- a/html-src/gen-html.py
+++ b/html-src/gen-html.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import os
 import re
-import __builtin__
+import builtins
 from pysollib.mygettext import fix_gettext
 
 from pysollib.gamedb import GAME_DB
@@ -13,8 +13,8 @@ from pysollib.mfxutil import latin1_to_ascii
 pysollib_dir = '../'
 
 
-__builtin__._ = lambda x: x
-__builtin__.n_ = lambda x: x
+builtins._ = lambda x: x
+builtins.n_ = lambda x: x
 
 import pysollib.games
 import pysollib.games.mahjongg
@@ -139,12 +139,14 @@ def getGameRulesFilename(n):
 def gen_main_html():
     for infile, title in files:
         outfile = open(os.path.join('html', infile), 'w')
-        print >> outfile, main_header % title
-        print >> outfile, open(infile).read()
+        print(main_header % title, file=outfile)
+        with open(infile, 'r') as file:
+            print(file.read(), file=outfile)
         s = '<a href="index.html">Back to the index</a>'
         if infile == 'index.html':
             s = ''
-        print >> outfile, main_footer % s
+        print(main_footer % s, file=outfile)
+        outfile.close()
 
 
 def gen_rules_html():
@@ -167,8 +169,9 @@ def gen_rules_html():
 
     # open file of list of all rules
     out_rules = open(os.path.join('html', 'rules.html'), 'w')
-    print >> out_rules, main_header % 'PySol - a Solitaire Game Collection'
-    print >> out_rules, open('rules.html').read()
+    print(main_header % 'PySol - a Solitaire Game Collection', file=out_rules)
+    with open('rules.html', 'r') as file:
+        print(file.read(), file=out_rules)
 
     for id in games:
         # create list of rules
@@ -188,7 +191,7 @@ def gen_rules_html():
             rules_dir = 'wikipedia'
         else:
             print('missing rules for %s (file: %s)'
-                  % (gi.name.encode('utf-8'), rules_fn))
+                  % (gi.name, rules_fn))
             continue
 
         # print '>>>', rules_fn
@@ -208,34 +211,41 @@ def gen_rules_html():
         rules_list.append((rules_dir, rules_fn, title, s))
         files_list.append(rules_fn)
         # rules_list.append((rules_fn, gi.name))
-        print >> out_rules, '<li><a href="rules/%s">%s</a>' \
-            % (rules_fn, gi.name.encode('utf-8'))
+        print('<li><a href="rules/%s">%s</a>' \
+            % (rules_fn, gi.name), file=out_rules)
         for n in gi.altnames:
             altnames.append((n, rules_fn))
 
-    print >> out_rules, '</ul>\n' + \
-        main_footer % '<a href="index.html">Back to the index</a>'
+    print('</ul>\n' + main_footer % \
+        '<a href="index.html">Back to the index</a>', file=out_rules)
+
+    out_rules.close()
 
     # create file of altnames
     out_rules_alt = open(os.path.join('html', 'rules_alternate.html'), 'w')
-    print >> out_rules_alt, main_header % 'PySol - a Solitaire Game Collection'
-    print >> out_rules_alt, open('rules_alternate.html').read()
+    print(main_header % 'PySol - a Solitaire Game Collection',
+          file=out_rules_alt)
+    with open('rules_alternate.html', 'r') as file:
+        print(file.read(), file=out_rules_alt)
     altnames.sort()
     for name, fn in altnames:
-        print >> out_rules_alt, '<li> <a href="rules/%s">%s</a>' \
-              % (fn, name.encode('utf-8'))
-    print >> out_rules_alt, '</ul>\n' + \
-        main_footer % '<a href="index.html">Back to the index</a>'
+        print('<li> <a href="rules/%s">%s</a>' \
+              % (fn, name), file=out_rules_alt)
+    print('</ul>\n' + main_footer % \
+        '<a href="index.html">Back to the index</a>', file=out_rules_alt)
+    out_rules_alt.close()
 
     # create rules
     for dir, filename, title, footer in rules_list:
-        outfile = open(os.path.join('html', 'rules', filename), 'w')
+        outfile = open(os.path.join('html', 'rules', filename), 'w', encoding='utf-8')
         if dir == 'rules':
-            print >> outfile, (rules_header % title).encode('utf-8')
+            print(rules_header % title, file=outfile)
         else:  # d == 'wikipedia'
-            print >> outfile, (wikipedia_header % title).encode('utf-8')
-        print >> outfile, open(os.path.join(dir, filename)).read()
-        print >> outfile, rules_footer % footer
+            print(wikipedia_header % title, file=outfile)
+        with open(os.path.join(dir, filename), 'r', encoding='utf-8') as file:
+            print(file.read(), file=outfile)
+        print(rules_footer % footer, file=outfile)
+        outfile.close()
 
 
 gen_main_html()

--- a/html-src/general_rules.html
+++ b/html-src/general_rules.html
@@ -1,42 +1,38 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>General Rules</h1>
-<p>There are some characteristics common to all the games in this
-package. Most of them are played with standard 52-card decks,
-either one or two. The cards in each suit are ranked King high. K
-stands for King, Q stands for Queen and J stands for Jack. In each
-game, the cards are piled up in either ascending or descending
-order, on stacks in the main playing area, called the Tableau, or
-piles off to the side, called Foundations. Some piles must be built
-up in sequence within the same suit, and others are built up in
-suits of alternating colors.</p>
-<p>The Talon is the stack of cards remaining in the deck, not yet
-played upon any of the piles, and not yet placed in the discard
-pile. Some people also call it the Stock or the Hand.</p>
-<p>The object of each of these games is to use up all the cards in
-building Foundations, or to use up all cards in the Talon according
-to the rules of the particular game. If all the cards are used up,
-you win. If not, you lose.</p>
-<p>In all of the games, you deal cards from the Talon to the
-discard pile by clicking once on the Talon with the left mouse
-button, or pressing &lt;D&gt;. Where permitted by the rules, you
-can turn over any face-down card with a single click of the left
-mouse button. You pick up and move a card by clicking on it and
-holding the button down while you drag it to its intended
-destination. If the move would violate the rules, the card will not
-go anywhere. If any card or cards can be put on a Foundation, or in
-the Ace discard pile of Picture Gallery, a single press of the
-&lt;A&gt; key will do all of them, a handy way to quickly finish
-certain games. Sometimes the &lt;A&gt; key will build up the
-Foundations more than you would like, and these rules allow you to
-put cards back into the Tableau from the Foundations. Of course,
-you can also use the Undo key &lt;Z&gt;.</p>
-<p>If you're confused by all this, just watch a demo game :-)</p>
-</body>
-</html>
+<p>
+There are some characteristics common to all the games in this package.
+Most of them are played with standard 52-card decks, either one or two.  The
+cards in each suit are ranked King high. K stands for King, Q stands for
+Queen and J stands for Jack. In each game, the cards are piled up in either
+ascending or descending order, on stacks in the main playing area, called
+the Tableau, or piles off to the side, called Foundations.  Some piles must
+be built up in sequence within the same suit, and others are built up in
+suits of alternating colors.
+
+<p>
+The Talon is the stack of cards remaining in the deck, not yet played
+upon any of the piles, and not yet placed in the discard pile.  Some people
+also call it the Stock or the Hand.
+
+<p>
+The object of each of these games is to use up all the cards in
+building Foundations, or to use up all cards in the Talon according to the
+rules of the particular game.  If all the cards are used up, you win.  If
+not, you lose.
+
+<p>
+In all of the games, you deal cards from the Talon to the discard pile
+by clicking once on the Talon with the left mouse button, or pressing &lt;D&gt;.
+Where permitted by the rules, you can turn over any face-down card with a
+single click of the left mouse button.  You pick up and move a card by
+clicking on it and holding the button down while you drag it to its intended
+destination.  If the move would violate the rules, the card will not go
+anywhere.  If any card or cards can be put on a
+Foundation, or in the Ace discard pile of Picture Gallery, a single press of
+the &lt;A&gt; key will do all of them, a handy way to quickly finish certain
+games.  Sometimes the &lt;A&gt; key will build up the Foundations more than you
+would like, and these rules allow you to put cards back into the Tableau
+from the Foundations. Of course, you can also use the Undo key &lt;Z&gt;.
+
+<p>
+If you're confused by all this, just watch a demo game :-)

--- a/html-src/glossary.html
+++ b/html-src/glossary.html
@@ -1,87 +1,106 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Glossary</h1>
+
 <p>Author's note: These definitions are meant as a guideline only.
 See individual game rules as any game has the right to redefine or
 modify the rules to make it fun.</p>
+
 <dl>
 <dt><b>BASE CARD</b></dt>
+
 <dd>
 <p>The first card dealt into a foundation pile. Other foundations
 usually have to start with a card of this rank. See: FOUNDATION</p>
 </dd>
+
 <dt><b>BUILD BY ALTERNATE COLOR</b></dt>
+
 <dd>
 <p>Building by placing a card on to another card of the opposite
 color is permitted. Example: Placing a Diamond on a Spade is good,
 but placing a Diamond on a Heart is not.</p>
 </dd>
+
 <dt><b>BUILD BY ANY SUIT BUT OWN</b></dt>
+
 <dd>
 <p>Building by placing a card on to another card of any suit but
 the suit of the original card is permitted. Example: Placing a
 Diamond on a Heart is good, but placing a Heart on a Heart is
 not.</p>
 </dd>
+
 <dt><b>BUILD BY COLOR</b></dt>
+
 <dd>
 <p>Building by placing a card on to another card of the same color
 is permitted. Example: Placing a Diamond on a Heart is good, but
 Placing a Diamond on a Club is not.</p>
 </dd>
+
 <dt><b>BUILD BY RANK</b></dt>
+
 <dd>
 <p>BUILD DOWN or UP ignoring color and suit.</p>
 </dd>
+
 <dt><b>BUILD REGARDLESS OF SUIT</b></dt>
+
 <dd>
 <p>See BUILD BY RANK.</p>
 </dd>
+
 <dt><b>BUILD BY SUIT</b></dt>
+
 <dd>
 <p>Building by placing a card on to another card of the same suit
 is permitted. Example: Placing a Spade on a Spade is good, but
 placing a Spade on a Club is not.</p>
 </dd>
+
 <dt><b>BUILD DOWN</b></dt>
+
 <dd>
 <p>Building by placing a card of a lower rank on to a card of a
 higher rank is permitted. Usually implies a difference of only one
 ranking between the two cards. Example: Placing a 10 on a Jack is
 good, but placing a 10 on a 9 is not.</p>
 </dd>
+
 <dt><b>BUILD DOWN BY *</b></dt>
+
 <dd>
 <p>Building by placing a card of a lower rank on to a card of a
 higher rank by * is permitted. Example: If * is 2, placing a 10 on
 a Queen is good, but placing a 10 on a Jack is not.</p>
 </dd>
+
 <dt><b>BUILD UP</b></dt>
+
 <dd>
 <p>Building by placing a card of a higher rank on to a card of a
 lower rank is permitted. Usually implies a difference of only one
 ranking between the two cards. Example: Placing a Queen on a Jack
 is good, but placing a Queen on a King is not.</p>
 </dd>
+
 <dt><b>BUILD UP BY *</b></dt>
+
 <dd>
 <p>Building by placing a card of a higher rank on to a card of a
 lower rank by * is permitted. Example: If * is 2, placing a 10 on
 an 8 is good, but placing a 10 on a 9 is not.</p>
 </dd>
+
 <dt><b>BUILD UP OR DOWN</b></dt>
+
 <dd>
 <p>Building by placing a card on to a card of one higher or one
 lower rank is permitted. Example: Placing a Jack on a Queen or a 10
 is good, but placing a 10 on a Queen is not.</p>
 </dd>
+
 <dt><b>BUILDING</b></dt>
+
 <dd>
 <p>The ability to place a card (or group of cards) on another card.
 In regards to rank, you can BUILD UP, BUILD DOWN, or BUILD UP/DOWN
@@ -90,32 +109,44 @@ COLOR, BUILD BY ALTERNATE COLOR, BUILD BY ANY SUIT BUT OWN, or
 BUILD REGARDLESS OF SUIT. Note that all games that build will
 follow two of these rules, one from each list.</p>
 </dd>
+
 <dt><b>DECK</b></dt>
+
 <dd>
 <p>The set of cards used. Most games use a STANDARD DECK, but games
 that use a DOUBLE DECK, a JOKER DECK, or a STRIPPED DECK are not
 uncommon.</p>
 </dd>
+
 <dt><b>DOUBLE DECK</b></dt>
+
 <dd>
 <p>A deck of cards consisting of two STANDARD DECKS making a total
 of 104 cards.</p>
 </dd>
+
 <dt><b>FOUNDATION</b></dt>
+
 <dd>
 <p>If a game has a foundation, the game is usually won by placing
 all the cards in the foundation pile(s).</p>
 </dd>
+
 <dt><b>JOKER DECK</b></dt>
+
 <dd>
 <p>A deck of cards consisting of a STANDARD DECK and two jokers
 making a total of 54 cards.</p>
 </dd>
+
 <dt><b>PILE</b></dt>
+
 <dd>
 <p>A designated area where cards can exist.</p>
 </dd>
+
 <dt><b>RANK</b></dt>
+
 <dd>
 <p>The value of the card. Numbered cards usually have the rank of
 the associated number. Aces can either be high or low. If high,
@@ -124,65 +155,86 @@ usually ranked 11, 12, and 13 respectively. However, some games may
 rank these cards as 10. In such a case, a high ace might be ranked
 as 11.</p>
 </dd>
+
 <dt><b>RESERVE</b></dt>
+
 <dd>
 <p>Cards in the reserve are usually available to play anywhere.
 Usually cannot be built on.</p>
 </dd>
+
 <dt><b>SLOT</b></dt>
+
 <dd>
 <p>See PILE.</p>
 </dd>
+
 <dt><b>STANDARD DECK</b></dt>
+
 <dd>
-<p>A 52 card deck. There are four suits of thirteen cards each.
-Each suit contains an Ace, 2 through 10, Jack, Queen, and King.
-These suits are usually Clubs, Spades, Hearts and Diamonds. These
-suits can be grouped into two colors, usually black and red. The
-Clubs and the Spaces are black while the Hearts and the Diamonds
-are red. PySol allows the possibility of using different decks. In
-this case, the new colors and/or suits are substituted into this
-paradigm.</p>
+<p>A 52 card deck. There are four suits of thirteen cards
+each. Each suit contains an Ace, 2 through 10, Jack, Queen, and
+King. These suits are usually Clubs, Spades, Hearts and Diamonds.
+These suits can be grouped into two colors, usually black and red.
+The Clubs and the Spaces are black while the Hearts and the
+Diamonds are red. PySol allows the possibility of using
+different decks. In this case, the new colors and/or suits are
+substituted into this paradigm.</p>
 </dd>
+
 <dt><b>STRIPPED DECK</b></dt>
+
 <dd>
-<p>A 32 card deck. There are four suits of eight cards each. Each
-suit contains an Ace, 7 through 10, Jack, Queen, and King.</p>
+<p>A 32 card deck. There are four suits of eight cards
+each. Each suit contains an Ace, 7 through 10, Jack, Queen, and
+King.</p>
 </dd>
+
 <dt><b>STOCK</b></dt>
+
 <dd>
 <p>See TALON.</p>
 </dd>
+
 <dt><b>SUIT</b></dt>
+
 <dd>
 <p>Four different kinds in a STANDARD DECK. Usually Clubs, Spades,
 Hearts, and Diamonds.</p>
 </dd>
+
 <dt><b>TABLEAU</b></dt>
+
 <dd>
 <p>The playing field, where the main action occurs. Usually allows
 building.</p>
 </dd>
+
 <dt><b>TALON</b></dt>
+
 <dd>
 <p>The remainder of the deck after all the original cards have been
 dealt and are usually kept faced down.</p>
 </dd>
+
 <dt><b>VALUE</b></dt>
+
 <dd>
 <p>See RANK.</p>
 </dd>
+
 <dt><b>WASTE</b></dt>
+
 <dd>
 <p>A stack of cards face up, usually next to the TALON. Top card
 usually in play.</p>
 </dd>
+
 <dt><b>WRAP AROUND</b></dt>
+
 <dd>
-<p>In some games card sequences may wrap around. When BUILDING UP
-this means you can place an Ace on a King. When BUILDING DOWN this
-means you can place a King on an Ace.</p>
+<p>In some games card sequences may wrap around.
+When BUILDING UP this means you can place an Ace on a King.
+When BUILDING DOWN this means you can place a King on an Ace.</p>
 </dd>
 </dl>
-</body>
-</html>

--- a/html-src/hanafuda.html
+++ b/html-src/hanafuda.html
@@ -1,30 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>General Flower Card Rules</h1>
-<p>There are some characteristics common to all the games played
-with Hanafuda cards. They are all played with one or more of the
-Asian flower card decks. This deck is common in a number of Pacific
-regions including Hawaii. There are twelve suits of four cards
-each. The suits are associated with the twelve months of the year.
-For a good explanation of what the suits are, try <a href=
-"http://hanafubuki.org/">Graham Leonard's Hanafuda and Kabufuda
-site</a>.</p>
-<p>Most of the flower card solitaire games are played like western
-deck games with minor changes. See the <a href=
-"general_rules.html">General Rules</a> for basic instructions on
-how to play solitaire. The object in most cases is to move all the
-cards from the tableau to the foundations. Probably the most
-difficult part of learning to play with hanafuda cards is learning
-which cards belong in which suits and what their ranking is. The
-ranking of the suits is sometimes as important as the ranking of
-the cards in the suit. Try keeping this hanafuda help image
-displayed where you can refer to it as you play. <img alt="" src=
-"images/hanahelp.gif" /></p>
-</body>
-</html>
+
+<p>
+There are some characteristics common to all the games played with Hanafuda
+cards. They are all played with one or more of the Asian flower card decks.
+This deck is common in a number of Pacific regions including Hawaii. There are
+twelve suits of four cards each. The suits are associated with the twelve
+months of the year. For a good explanation of what the suits are,
+try <a href="http://hanafubuki.org/">Graham Leonard's Hanafuda and Kabufuda
+site</a>.
+
+<p>
+Most of the flower card solitaire games are played like western deck games
+with minor changes. See the <a href="general_rules.html">General Rules</a> for
+basic instructions on how to play solitaire. The object in most cases is to
+move all the cards from the tableau to the foundations. Probably the most
+difficult part of learning to play with hanafuda cards is learning which cards
+belong in which suits and what their ranking is. The ranking of the suits is
+sometimes as important as the ranking of the cards in the suit. Try keeping
+this hanafuda help image displayed where you can refer to it as you play.
+<img alt="" src="images/hanahelp.gif">

--- a/html-src/hexadeck.html
+++ b/html-src/hexadeck.html
@@ -1,34 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>General Hex A Deck Card Rules</h1>
-The Hex A Deck is similar to a few card packs published in the
-early 20th century that had sixteen cards in each suit. Those decks
-were intended to be used when popular games of the period such as
-Whist were played by five or more players. The extra cards meant
-that each player had more cards in their hand which added interest
-to the play. The Wizards in the Hex A Deck corresponds to the
-Jokers in a regular pack. Their main purpose in most Hex A Deck
-games is to show up at the worst possible time. Either that or at
-the best possible time. They're very successful at doing that. In
-games that use alternate color stacks they may be played as either
-color. They have ranks from one through four and sometimes can only
-be played in rank order. The ranks may or may not be indicated on
-the cards. If they are not indicated there is usually a way to tell
-which is which. The rank can be determined by comparing some
-distinctive element of the images. The first rank Wizard will be
-the most elaborate in some way such as the fattest, having the
-tallest hat etc. They play on their foundation (if any) in
-descending order of rank. That is first through fourth. In some
-games the Wizards will not move off of the tableau until all the
-other cards have been moved to the foundations. In some games they
-don't actually enter into play at all. They are just there to make
-things interesting. Which is to say make things difficult. And they
-are very good at doing that.
-</body>
-</html>
+The Hex A Deck is similar to a few card packs published in the early 20th
+century that had sixteen cards in each suit.  Those decks were intended to
+be used when popular games of the period such as Whist were played by five
+or more players.  The extra cards meant that each player had more cards in their
+hand which added interest to the play.  The Wizards in the Hex A Deck corresponds
+to the Jokers in a regular pack.  Their main purpose in most Hex A Deck games
+is to show up at the worst possible time.  Either that or at the best possible
+time.  They're very successful at doing that.  In games that use alternate
+color stacks they may be played as either color.  They have ranks from one
+through four and sometimes can only be played in rank order.  The ranks may
+or may not be indicated on the cards.  If they are not indicated there is
+usually a way to tell which is which.  The rank can be determined by comparing
+some distinctive element of the images.  The first rank Wizard will be the most
+elaborate in some way such as the fattest, having the tallest hat etc.  They
+play on their foundation (if any) in descending order of rank.  That is first
+through fourth.  In some games the Wizards will not move off of the tableau
+until all the other cards have been moved to the foundations.  In some games
+they don't actually enter into play at all.  They are just there to make
+things interesting.  Which is to say make things difficult.  And they are
+very good at doing that.

--- a/html-src/howtoplay.html
+++ b/html-src/howtoplay.html
@@ -1,118 +1,131 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>How to play PySol</h1>
+
 <h2>Mouse Usage</h2>
-<p>Left mouse button:</p>
+<p>
+Left mouse button:
 <ul type="disc">
-<li>Drag cards around</li>
-<li>Click on the Talon to deal new cards</li>
+<li> Drag cards around
+<li> Click on the Talon to deal new cards
 </ul>
-<p>Right mouse button (or double-click the left button):</p>
+<p>
+Right mouse button (or double-click the left button):
 <ul type="disc">
-<li>Drop cards to the Foundations</li>
-<li>Quick play (if enabled)</li>
+<li> Drop cards to the Foundations
+<li> Quick play (if enabled)
 </ul>
-<p>Middle mouse button (or Ctrl-click the right button):</p>
+<p>
+Middle mouse button (or Ctrl-click the right button):
 <ul type="disc">
-<li>View partially overlapped cards</li>
+<li> View partially overlapped cards
 </ul>
-<p>Ctrl-click the left mouse button:</p>
+<p>
+Ctrl-click the left mouse button:
 <ul type="disc">
-<li>Highlight all matching cards on the table</li>
+<li> Highlight all matching cards on the table
 </ul>
-<p>Shift-click the left mouse button:</p>
+<p>
+Shift-click the left mouse button:
 <ul type="disc">
-<li>Highlight all cards with the same rank.</li>
+<li> Highlight all cards with the same rank.
 </ul>
+
+
 <h2>Two-handed play</h2>
-<p>Put three fingers of one hand on '<i>A</i>' (auto drop),
-'<i>S</i>' (undo) and '<i>D</i>' (deal). You can also reach
-'<i>R</i>' (redo) from there.</p>
-<p>Left-handed people may prefer using '<i>L</i>' (auto drop),
-'<i>K</i>' (undo) and '<i>J</i>' (deal). <!--
+<p>
+Put three fingers of one hand on '<i>A</i>' (auto drop),
+'<i>S</i>' (undo) and '<i>D</i>' (deal).
+You can also reach '<i>R</i>' (redo) from there.
+<p>
+Left-handed people may prefer using '<i>L</i>' (auto drop),
+'<i>K</i>' (undo) and '<i>J</i>' (deal).
+
+<!--
 <h2>Point-and-Click play</h2>
 <p>
 If you prefer Point-and-Click over Drag-and-Drop you can enable
 <i>Quick play</i> and use the right mouse button. See below.
---></p>
+-->
+
 <h2>Automatic play</h2>
-<p>Note that automatic play can spoil the gameplay, so purists
-should not enable any option but maybe <i>Auto face up</i>. Also,
-some games disable certain features as they would be trivial
-otherwise.</p>
-<p>Auto face up</p>
+<p>
+Note that automatic play can spoil the gameplay, so purists should
+not enable any option but maybe <i>Auto face up</i>. Also, some games
+disable certain features as they would be trivial otherwise.
+<p>
+Auto face up
 <ul type="disc">
-<li>Automatically face up all cards.</li>
+<li> Automatically face up all cards.
 </ul>
 Auto drop
 <ul type="disc">
-<li>Automatically drop cards to the Foundations.</li>
+<li> Automatically drop cards to the Foundations.
 </ul>
 Auto deal
 <ul type="disc">
-<li>Automatically deal cards to the Waste stack if it is
-empty.</li>
+<li> Automatically deal cards to the Waste stack if it is empty.
 </ul>
 Quick play
 <ul type="disc">
-<li>Use the right mouse button to move piles around quickly. The
-logic involved is not too clever on purpose (i.e. it does not
-consult the hint system).</li>
+<li> Use the right mouse button to move piles around quickly.
+     The logic involved is not too clever on purpose
+     (i.e. it does not consult the hint system).
 </ul>
+
+
 <h2>The animation is too slow...</h2>
-<p>Unfortunately the Tcl/Tk toolkit lacks a sprite concept, so
-there is a lot of (invisible double-buffered) redraw going on when
-dragging cards around.</p>
-<p>Disabling <i>Card shadow</i>, <i>Shade legal moves</i>,
-background table tiles and sound will somewhat improve the display
-speed.</p>
+<p>
+Unfortunately the Tcl/Tk toolkit lacks a sprite concept, so
+there is a lot of (invisible double-buffered) redraw going on
+when dragging cards around.
+<p>
+Disabling <i>Card shadow</i>, <i>Shade legal moves</i>,
+background table tiles and sound will somewhat improve the display speed.
+
+
 <h2>The table tiles look strange</h2>
-<p>Background table tiles should only be enabled when using a
-true-color video mode - otherwise they may look bad because of
-dithering.</p>
-<p>BTW, you can add your own background tiles by copying the images
-to the main <i>data/tiles</i> or your home <i>~/.PySolFC/tiles</i>
-directory. <!-- They must be in GIF or PPM format. --></p>
+<p>
+Background table tiles should only be enabled when using
+a true-color video mode - otherwise they may look bad
+because of dithering.
+<p>
+BTW, you can add your own background tiles by copying the images
+to the main <i>data/tiles</i> or your home <i>~/.PySolFC/tiles</i> directory.
+<!-- They must be in GIF or PPM format. -->
+
+
 <h2>Some notes about scoring</h2>
+<p>
 <ul type="disc">
-<li>Scoring only begins after you make your first move. Also, if
-you undo all your moves back to the start the game won't score
-either.</li>
-<li>You will lose a game if you consume a hint or start demo
-mode.</li>
-<li>You can restart any time to get another chance to win this
-game.</li>
-<li>If you don't want to score a lost game you can temporarily
-change the player options.</li>
-<li>Loaded games don't count.</li>
-<li>If you win a game without using <i>Undo</i>, <i>Quick play</i>
-and any other of the assist functions you will be given special
-awards. <!--
+<li> Scoring only begins after you make your first move.
+     Also, if you undo all your moves back to the start
+     the game won't score either.
+<li> You will lose a game if you consume a hint or start demo mode.
+<li> You can restart any time to get another chance to win this game.
+<li> If you don't want to score a lost game you can temporarily change
+     the player options.
+<li> Loaded games don't count.
+<li> If you win a game without using <i>Undo</i>, <i>Quick play</i> and
+     any other of the assist functions you will be given special awards.
+<!--
 <li> There are no score values in PySol - you win a game, or you lose it.
      And don't even think about asking me to implement this nonsense - get
      a nice pinball game if you're a highscore freak...
---></li>
-<li>And finally always remember that this is a <b>Patience</b>
-game. Relax and enjoy.</li>
+-->
+<li> And finally always remember that this is a <b>Patience</b> game.
+     Relax and enjoy.
 </ul>
+
+
 <h2>Undocumented key bindings</h2>
 <ul type="disc">
-<li><i>Space</i> - Deal</li>
-<li><i>S</i> - Undo</li>
-<li><i>Backspace</i> - Undo</li>
-<li><i>Ctrl-A</i> - Auto drop and face up cards in one step</li>
-<li><i>Ctrl-B</i> - Change card background</li>
-<li><i>Ctrl-H</i> - Show internal rating when giving a hint</li>
-<li><i>Ctrl-I</i> - Change table tile</li>
-<li><i>Ctrl-N</i> - Start a new game with the next game number</li>
-<li><i>Ctrl-P</i> - Change player name</li>
-<li><i>Ctrl-U</i> - Play the next music song</li>
+<li> <i>Space</i> - Deal
+<li> <i>S</i> - Undo
+<li> <i>Backspace</i> - Undo
+<li> <i>Ctrl-A</i> - Auto drop and face up cards in one step
+<li> <i>Ctrl-B</i> - Change card background
+<li> <i>Ctrl-H</i> - Show internal rating when giving a hint
+<li> <i>Ctrl-I</i> - Change table tile
+<li> <i>Ctrl-N</i> - Start a new game with the next game number
+<li> <i>Ctrl-P</i> - Change player name
+<li> <i>Ctrl-U</i> - Play the next music song
 </ul>
-</body>
-</html>

--- a/html-src/index.html
+++ b/html-src/index.html
@@ -1,35 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>PySol - a Solitaire Game Collection</h1>
-<p><a href="intro.html">Introduction</a></p>
-<p><a href="install.html">Installation</a></p>
-<p><a href="howtoplay.html">How to play</a></p>
+
+<p> <a href="intro.html">Introduction</a>
+<p> <a href="install.html">Installation</a>
+<p> <a href="howtoplay.html">How to play</a>
+
 <h2>Rules</h2>
 <ul>
-<li><a href="glossary.html">Glossary</a></li>
-<li><a href="general_rules.html">General Rules</a></li>
-<li><a href="rules.html">Individual Game Rules</a></li>
-<li><a href="rules_alternate.html">Alternate Names</a></li>
+<li> <a href="glossary.html">Glossary</a>
+<li> <a href="general_rules.html">General Rules</a>
+<li> <a href="rules.html">Individual Game Rules</a>
+<li> <a href="rules_alternate.html">Alternate Names</a>
 </ul>
+
 <!-- <p> <a href="news.html">What's new ?</a> -->
-<p><a href="license.html">PySol license terms</a></p>
-<hr />
-<p>Visit the official <a href=
-"http://pysolfc.sourceforge.net/">PySolFC Home Page</a>. <!--
+<p> <a href="license.html">PySol license terms</a>
+<p>
+<hr>
+
+<p> Visit the official <a href="http://pysolfc.sourceforge.net/">PySolFC Home
+Page</a>.
+<!--
 <p>
 Copyright (C) 1998-2003 by <a href="mailto:markus@oberhumer.com">Markus
 F.X.J. Oberhumer</a>.<br>
 Copyright (C) 2003 by Mt. Hood Playing Card Co.<br>
 Copyright (C) 2005 by <a href="mailto:skomoroh@gmail.com">Skomoroh</a>.<br>
 All Rights Reserved.
---></p>
-<p>PySol is distributed under the terms of the <a href=
-"license.html">GNU General Public License</a>.</p>
-</body>
-</html>
+-->
+
+<p>
+PySol is distributed under the terms of the
+<a href="license.html">GNU General Public License</a>.

--- a/html-src/install.html
+++ b/html-src/install.html
@@ -1,45 +1,47 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Installation</h1>
-<p>There is no need to compile anything since the whole program is
-just a Python script. Just run it, and that's all.</p>
-<p>PySol requires Python 2.3 and Tcl/Tk 8.4 or better. Both
-packages are freely available for Unix, Windows and Macintosh
-platforms.</p>
-<p>PySol is free <i>Open Source</i> software distributed under the
-terms of the <a href="license.html">GNU GPL</a>.</p>
+<p>
+There is no need to compile anything since the whole program is just
+a Python script. Just run it, and that's all.
+<p>
+PySol requires Python 2.3 and Tcl/Tk 8.4 or better. Both packages are
+freely available for Unix, Windows and Macintosh platforms.
+<p>
+PySol is free <i>Open Source</i> software distributed under the terms of the
+<a href="license.html">GNU GPL</a>.
+
+
 <h2>Windows 95/98/ME/NT/2000</h2>
-PySol now ships as a completely self-contained setup file, so
-there's no need to install anything else.
-<p>If you want to modify the PySol source code or write your own
-Python programs you can get the development system from <a href=
-"http://www.python.org/download/download_windows.html">http://www.python.org/download/download_windows.html</a></p>
+
+PySol now ships as a completely self-contained setup file, so there's
+no need to install anything else.
+<p>
+If you want to modify the PySol source code or write your own
+Python programs you can get the development system from
+<a href="http://www.python.org/download/download_windows.html">http://www.python.org/download/download_windows.html</a>
+
+
 <h2>Unix</h2>
-There are good chances that your system already ships with Python
-and Tcl/Tk.<br />
-Otherwise visit <a href=
-"http://www.python.org/download/">http://www.python.org/download/</a>
+
+There are good chances that your system already ships with Python and Tcl/Tk.<br>
+Otherwise visit
+<a href="http://www.python.org/download/">http://www.python.org/download/</a>
 for full source code.
-<p>Also, installable packages exist for all major Linux
-distributions, FreeBSD and HPUX.</p>
+<p>
+Also, installable packages exist for all major Linux distributions,
+FreeBSD and HPUX.
+
+
 <h2>Macintosh</h2>
-Self installing exectuables for Python and Tcl/Tk are available
-from<br />
-<a href=
-"http://www.python.org/download/download_mac.html">http://www.python.org/download/download_mac.html</a>
-<p>As I don't have access to a Mac I'd appreciate any detailed
-feedback on installation and look &amp; feel. "Porting" from X11 to
-Windows only required some minor changes in the default font
-settings, so I hope the situation on Macs is similar.</p>
-<p>[ I have been told that PySol works fine on a Mac - just drop
-"pysol.py" on the Python interpreter and that's it. But for some
-reason you must assign a large amount of memory to the Python
-interpreter. ]</p>
-</body>
-</html>
+
+Self installing exectuables for Python and Tcl/Tk are available from<br>
+<a href="http://www.python.org/download/download_mac.html">http://www.python.org/download/download_mac.html</a>
+<p>
+As I don't have access to a Mac I'd appreciate any detailed feedback on
+installation and look & feel. "Porting" from X11 to Windows only required some
+minor changes in the default font settings, so I hope the situation on Macs is
+similar.
+<p>
+[ I have been told that PySol works fine on a Mac - just drop "pysol.py"
+  on the Python interpreter and that's it. But for some reason you must
+  assign a large amount of memory to the Python interpreter. ]
+

--- a/html-src/intro.html
+++ b/html-src/intro.html
@@ -1,43 +1,34 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Introduction</h1>
-<p>"Why yet another solitaire game ?" you may ask. The answer is
-simple...</p>
+<p>
+"Why yet another solitaire game ?" you may ask.
+The answer is simple...
+
 <h3>PySol highlights</h3>
 <ul>
-<li>currently supports more than 1000 distinct solitaire games</li>
-<li>based upon an extensible solitaire engine</li>
-<li>lots of classic games like Forty Thieves, FreeCell, Klondike
-and Spider</li>
-<li>special games like Ganjifa, Hanafuda, Poker and Tarock type
-games</li>
-<li>modern look and feel</li>
-<li>multiple cardsets and backgrounds</li>
-<li>background table tiles</li>
-<li>unlimited undo &amp; redo</li>
-<li>persistent bookmarks</li>
-<li>load &amp; save games</li>
-<li>player statistics</li>
-<li>a hint system</li>
-<li>demo games</li>
-<li>a solitaire wizard</li>
-<li>support for user written plug-ins</li>
-<li>sound samples and background music</li>
-<li>integrated HTML help browser</li>
-<li>lots of documentation</li>
-<li>portable across Unix/X11, Windows 95/98/NT/2000/XP and Mac
-OSX</li>
-<li>written in 100% pure Python</li>
-<li>distributed under the terms of the GNU General Public
-License</li>
-<li><i>Commercial Quality Freeware</i></li>
+<li> currently supports more than 1000 distinct solitaire games
+<li> based upon an extensible solitaire engine
+<li> lots of classic games like Forty Thieves, FreeCell, Klondike and Spider
+<li> special games like Ganjifa, Hanafuda, Poker and Tarock type games
+<li> modern look and feel
+<li> multiple cardsets and backgrounds
+<li> background table tiles
+<li> unlimited undo &amp; redo
+<li> persistent bookmarks
+<li> load &amp; save games
+<li> player statistics
+<li> a hint system
+<li> demo games
+<li> a solitaire wizard
+<li> support for user written plug-ins
+<li> sound samples and background music
+<li> integrated HTML help browser
+<li> lots of documentation
+<li> portable across Unix/X11, Windows 95/98/NT/2000/XP and Mac OSX
+<li> written in 100% pure Python
+<li> distributed under the terms of the GNU General Public License
+<li> <i>Commercial Quality Freeware</i>
 </ul>
+
 <!--
 <h3>Legal terms</h3>
 <p>
@@ -47,5 +38,3 @@ All Rights Reserved.
 PySol is distributed under the terms of the
 <a href="license.html">GNU General Public License</a>.
 -->
-</body>
-</html>

--- a/html-src/license.html
+++ b/html-src/license.html
@@ -1,505 +1,657 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
-<p align="center"><b>GNU GENERAL PUBLIC LICENSE</b><br />
-Version 3, 29 June 2007</p>
-<p>Copyright (C) 2007 <a href="http://fsf.org/">Free Software
-Foundation, Inc.</a></p>
-<p>Everyone is permitted to copy and distribute verbatim copies of
-this license document, but changing it is not allowed.</p>
-<p align="center"><b>TERMS AND CONDITIONS</b></p>
-<p>0. Definitions.</p>
-<p>"This License" refers to version 3 of the GNU General Public
-License.</p>
-<p>"Copyright" also means copyright-like laws that apply to other
-kinds of works, such as semiconductor masks.</p>
-<p>"The Program" refers to any copyrightable work licensed under
-this License. Each licensee is addressed as "you". "Licensees" and
-"recipients" may be individuals or organizations.</p>
-<p>To "modify" a work means to copy from or adapt all or part of
-the work in a fashion requiring copyright permission, other than
-the making of an exact copy. The resulting work is called a
-"modified version" of the earlier work or a work "based on" the
-earlier work.</p>
-<p>A "covered work" means either the unmodified Program or a work
-based on the Program.</p>
-<p>To "propagate" a work means to do anything with it that, without
+<p align="center">
+                    <b>GNU GENERAL PUBLIC LICENSE</b><br>
+                       Version 3, 29 June 2007
+
+<p>
+ Copyright (C) 2007 <a href="http://fsf.org/">Free Software Foundation, Inc.</a>
+<p>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+<p align="center">
+                       <b>TERMS AND CONDITIONS</b>
+
+<p>
+  0. Definitions.
+
+<p>
+  "This License" refers to version 3 of the GNU General Public License.
+
+<p>
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+<p>
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+<p>
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+<p>
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+<p>
+  To "propagate" a work means to do anything with it that, without
 permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on
-a computer or modifying a private copy. Propagation includes
-copying, distribution (with or without modification), making
-available to the public, and in some countries other activities as
-well.</p>
-<p>To "convey" a work means any kind of propagation that enables
-other parties to make or receive copies. Mere interaction with a
-user through a computer network, with no transfer of a copy, is not
-conveying.</p>
-<p>An interactive user interface displays "Appropriate Legal
-Notices" to the extent that it includes a convenient and
-prominently visible feature that (1) displays an appropriate
-copyright notice, and (2) tells the user that there is no warranty
-for the work (except to the extent that warranties are provided),
-that licensees may convey the work under this License, and how to
-view a copy of this License. If the interface presents a list of
-user commands or options, such as a menu, a prominent item in the
-list meets this criterion.</p>
-<p>1. Source Code.</p>
-<p>The "source code" for a work means the preferred form of the
-work for making modifications to it. "Object code" means any
-non-source form of a work.</p>
-<p>A "Standard Interface" means an interface that either is an
-official standard defined by a recognized standards body, or, in
-the case of interfaces specified for a particular programming
-language, one that is widely used among developers working in that
-language.</p>
-<p>The "System Libraries" of an executable work include anything,
-other than the work as a whole, that (a) is included in the normal
-form of packaging a Major Component, but which is not part of that
-Major Component, and (b) serves only to enable use of the work with
-that Major Component, or to implement a Standard Interface for
-which an implementation is available to the public in source code
-form. A "Major Component", in this context, means a major essential
-component (kernel, window system, and so on) of the specific
-operating system (if any) on which the executable work runs, or a
-compiler used to produce the work, or an object code interpreter
-used to run it.</p>
-<p>The "Corresponding Source" for a work in object code form means
-all the source code needed to generate, install, and (for an
-executable work) run the object code and to modify the work,
-including scripts to control those activities. However, it does not
-include the work's System Libraries, or general-purpose tools or
-generally available free programs which are used unmodified in
-performing those activities but which are not part of the work. For
-example, Corresponding Source includes interface definition files
-associated with source files for the work, and the source code for
-shared libraries and dynamically linked subprograms that the work
-is specifically designed to require, such as by intimate data
-communication or control flow between those subprograms and other
-parts of the work.</p>
-<p>The Corresponding Source need not include anything that users
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+<p>
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+<p>
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+<p>
+  1. Source Code.
+
+<p>
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+<p>
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+<p>
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+<p>
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+<p>
+  The Corresponding Source need not include anything that users
 can regenerate automatically from other parts of the Corresponding
-Source.</p>
-<p>The Corresponding Source for a work in source code form is that
-same work.</p>
-<p>2. Basic Permissions.</p>
-<p>All rights granted under this License are granted for the term
-of copyright on the Program, and are irrevocable provided the
-stated conditions are met. This License explicitly affirms your
-unlimited permission to run the unmodified Program. The output from
-running a covered work is covered by this License only if the
-output, given its content, constitutes a covered work. This License
-acknowledges your rights of fair use or other equivalent, as
-provided by copyright law.</p>
-<p>You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise
-remains in force. You may convey covered works to others for the
-sole purpose of having them make modifications exclusively for you,
-or provide you with facilities for running those works, provided
-that you comply with the terms of this License in conveying all
-material for which you do not control copyright. Those thus making
-or running the covered works for you must do so exclusively on your
-behalf, under your direction and control, on terms that prohibit
-them from making any copies of your copyrighted material outside
-their relationship with you.</p>
-<p>Conveying under any other circumstances is permitted solely
-under the conditions stated below. Sublicensing is not allowed;
-section 10 makes it unnecessary.</p>
-<p>3. Protecting Users' Legal Rights From Anti-Circumvention
-Law.</p>
-<p>No covered work shall be deemed part of an effective
-technological measure under any applicable law fulfilling
-obligations under article 11 of the WIPO copyright treaty adopted
-on 20 December 1996, or similar laws prohibiting or restricting
-circumvention of such measures.</p>
-<p>When you convey a covered work, you waive any legal power to
-forbid circumvention of technological measures to the extent such
-circumvention is effected by exercising rights under this License
-with respect to the covered work, and you disclaim any intention to
-limit operation or modification of the work as a means of
-enforcing, against the work's users, your or third parties' legal
-rights to forbid circumvention of technological measures.</p>
-<p>4. Conveying Verbatim Copies.</p>
-<p>You may convey verbatim copies of the Program's source code as
-you receive it, in any medium, provided that you conspicuously and
+Source.
+
+<p>
+  The Corresponding Source for a work in source code form is that
+same work.
+
+<p>
+  2. Basic Permissions.
+
+<p>
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+<p>
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+<p>
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+<p>
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+<p>
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+<p>
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+<p>
+  4. Conveying Verbatim Copies.
+
+<p>
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
 appropriately publish on each copy an appropriate copyright notice;
 keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the
-code; keep intact all notices of the absence of any warranty; and
-give all recipients a copy of this License along with the
-Program.</p>
-<p>You may charge any price or no price for each copy that you
-convey, and you may offer support or warranty protection for a
-fee.</p>
-<p>5. Conveying Modified Source Versions.</p>
-<p>You may convey a work based on the Program, or the modifications
-to produce it from the Program, in the form of source code under
-the terms of section 4, provided that you also meet all of these
-conditions:</p>
-<p>a) The work must carry prominent notices stating that you
-modified it, and giving a relevant date.</p>
-<p>b) The work must carry prominent notices stating that it is
-released under this License and any conditions added under section
-7. This requirement modifies the requirement in section 4 to "keep
-intact all notices".</p>
-<p>c) You must license the entire work, as a whole, under this
-License to anyone who comes into possession of a copy. This License
-will therefore apply, along with any applicable section 7
-additional terms, to the whole of the work, and all its parts,
-regardless of how they are packaged. This License gives no
-permission to license the work in any other way, but it does not
-invalidate such permission if you have separately received it.</p>
-<p>d) If the work has interactive user interfaces, each must
-display Appropriate Legal Notices; however, if the Program has
-interactive interfaces that do not display Appropriate Legal
-Notices, your work need not make them do so.</p>
-<p>A compilation of a covered work with other separate and
-independent works, which are not by their nature extensions of the
-covered work, and which are not combined with it such as to form a
-larger program, in or on a volume of a storage or distribution
-medium, is called an "aggregate" if the compilation and its
-resulting copyright are not used to limit the access or legal
-rights of the compilation's users beyond what the individual works
-permit. Inclusion of a covered work in an aggregate does not cause
-this License to apply to the other parts of the aggregate.</p>
-<p>6. Conveying Non-Source Forms.</p>
-<p>You may convey a covered work in object code form under the
-terms of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this
-License, in one of these ways:</p>
-<p>a) Convey the object code in, or embodied in, a physical product
-(including a physical distribution medium), accompanied by the
-Corresponding Source fixed on a durable physical medium customarily
-used for software interchange.</p>
-<p>b) Convey the object code in, or embodied in, a physical product
-(including a physical distribution medium), accompanied by a
-written offer, valid for at least three years and valid for as long
-as you offer spare parts or customer support for that product
-model, to give anyone who possesses the object code either (1) a
-copy of the Corresponding Source for all the software in the
-product that is covered by this License, on a durable physical
-medium customarily used for software interchange, for a price no
-more than your reasonable cost of physically performing this
-conveying of source, or (2) access to copy the Corresponding Source
-from a network server at no charge.</p>
-<p>c) Convey individual copies of the object code with a copy of
-the written offer to provide the Corresponding Source. This
-alternative is allowed only occasionally and noncommercially, and
-only if you received the object code with such an offer, in accord
-with subsection 6b.</p>
-<p>d) Convey the object code by offering access from a designated
-place (gratis or for a charge), and offer equivalent access to the
-Corresponding Source in the same way through the same place at no
-further charge. You need not require recipients to copy the
-Corresponding Source along with the object code. If the place to
-copy the object code is a network server, the Corresponding Source
-may be on a different server (operated by you or a third party)
-that supports equivalent copying facilities, provided you maintain
-clear directions next to the object code saying where to find the
-Corresponding Source. Regardless of what server hosts the
-Corresponding Source, you remain obligated to ensure that it is
-available for as long as needed to satisfy these requirements.</p>
-<p>e) Convey the object code using peer-to-peer transmission,
-provided you inform other peers where the object code and
-Corresponding Source of the work are being offered to the general
-public at no charge under subsection 6d.</p>
-<p>A separable portion of the object code, whose source code is
-excluded from the Corresponding Source as a System Library, need
-not be included in conveying the object code work.</p>
-<p>A "User Product" is either (1) a "consumer product", which means
-any tangible personal property which is normally used for personal,
-family, or household purposes, or (2) anything designed or sold for
-incorporation into a dwelling. In determining whether a product is
-a consumer product, doubtful cases shall be resolved in favor of
-coverage. For a particular product received by a particular user,
-"normally used" refers to a typical or common use of that class of
-product, regardless of the status of the particular user or of the
-way in which the particular user actually uses, or expects or is
-expected to use, the product. A product is a consumer product
-regardless of whether the product has substantial commercial,
-industrial or non-consumer uses, unless such uses represent the
-only significant mode of use of the product.</p>
-<p>"Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to
-install and execute modified versions of a covered work in that
-User Product from a modified version of its Corresponding Source.
-The information must suffice to ensure that the continued
-functioning of the modified object code is in no case prevented or
-interfered with solely because modification has been made.</p>
-<p>If you convey an object code work under this section in, or
-with, or specifically for use in, a User Product, and the conveying
-occurs as part of a transaction in which the right of possession
-and use of the User Product is transferred to the recipient in
-perpetuity or for a fixed term (regardless of how the transaction
-is characterized), the Corresponding Source conveyed under this
-section must be accompanied by the Installation Information. But
-this requirement does not apply if neither you nor any third party
-retains the ability to install modified object code on the User
-Product (for example, the work has been installed in ROM).</p>
-<p>The requirement to provide Installation Information does not
-include a requirement to continue to provide support service,
-warranty, or updates for a work that has been modified or installed
-by the recipient, or for the User Product in which it has been
-modified or installed. Access to a network may be denied when the
-modification itself materially and adversely affects the operation
-of the network or violates the rules and protocols for
-communication across the network.</p>
-<p>Corresponding Source conveyed, and Installation Information
-provided, in accord with this section must be in a format that is
-publicly documented (and with an implementation available to the
-public in source code form), and must require no special password
-or key for unpacking, reading or copying.</p>
-<p>7. Additional Terms.</p>
-<p>"Additional permissions" are terms that supplement the terms of
-this License by making exceptions from one or more of its
-conditions. Additional permissions that are applicable to the
-entire Program shall be treated as though they were included in
-this License, to the extent that they are valid under applicable
-law. If additional permissions apply only to part of the Program,
-that part may be used separately under those permissions, but the
-entire Program remains governed by this License without regard to
-the additional permissions.</p>
-<p>When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part
-of it. (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.) You may place
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+<p>
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+<p>
+  5. Conveying Modified Source Versions.
+
+<p>
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+<p>
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+<p>
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+<p>
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+<p>
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+<p>
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+<p>
+  6. Conveying Non-Source Forms.
+
+<p>
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+<p>
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+<p>
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+<p>
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+<p>
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+<p>
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+<p>
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+<p>
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+<p>
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+<p>
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+<p>
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+<p>
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+<p>
+  7. Additional Terms.
+
+<p>
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+<p>
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
 additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright
-permission.</p>
-<p>Notwithstanding any other provision of this License, for
-material you add to a covered work, you may (if authorized by the
-copyright holders of that material) supplement the terms of this
-License with terms:</p>
-<p>a) Disclaiming warranty or limiting liability differently from
-the terms of sections 15 and 16 of this License; or</p>
-<p>b) Requiring preservation of specified reasonable legal notices
-or author attributions in that material or in the Appropriate Legal
-Notices displayed by works containing it; or</p>
-<p>c) Prohibiting misrepresentation of the origin of that material,
-or requiring that modified versions of such material be marked in
-reasonable ways as different from the original version; or</p>
-<p>d) Limiting the use for publicity purposes of names of licensors
-or authors of the material; or</p>
-<p>e) Declining to grant rights under trademark law for use of some
-trade names, trademarks, or service marks; or</p>
-<p>f) Requiring indemnification of licensors and authors of that
-material by anyone who conveys the material (or modified versions
-of it) with contractual assumptions of liability to the recipient,
-for any liability that these contractual assumptions directly
-impose on those licensors and authors.</p>
-<p>All other non-permissive additional terms are considered
-"further restrictions" within the meaning of section 10. If the
-Program as you received it, or any part of it, contains a notice
-stating that it is governed by this License along with a term that
-is a further restriction, you may remove that term. If a license
-document contains a further restriction but permits relicensing or
-conveying under this License, you may add to a covered work
-material governed by the terms of that license document, provided
-that the further restriction does not survive such relicensing or
-conveying.</p>
-<p>If you add terms to a covered work in accord with this section,
-you must place, in the relevant source files, a statement of the
+for which you have or can give appropriate copyright permission.
+
+<p>
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+<p>
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+<p>
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+<p>
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+<p>
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+<p>
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+<p>
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+<p>
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+<p>
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
 additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.</p>
-<p>Additional terms, permissive or non-permissive, may be stated in
-the form of a separately written license, or stated as exceptions;
-the above requirements apply either way.</p>
-<p>8. Termination.</p>
-<p>You may not propagate or modify a covered work except as
-expressly provided under this License. Any attempt otherwise to
-propagate or modify it is void, and will automatically terminate
-your rights under this License (including any patent licenses
-granted under the third paragraph of section 11).</p>
-<p>However, if you cease all violation of this License, then your
+where to find the applicable terms.
+
+<p>
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+<p>
+  8. Termination.
+
+<p>
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+<p>
+  However, if you cease all violation of this License, then your
 license from a particular copyright holder is reinstated (a)
 provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the
-copyright holder fails to notify you of the violation by some
-reasonable means prior to 60 days after the cessation.</p>
-<p>Moreover, your license from a particular copyright holder is
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+<p>
+  Moreover, your license from a particular copyright holder is
 reinstated permanently if the copyright holder notifies you of the
 violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from
-that copyright holder, and you cure the violation prior to 30 days
-after your receipt of the notice.</p>
-<p>Termination of your rights under this section does not terminate
-the licenses of parties who have received copies or rights from you
-under this License. If your rights have been terminated and not
-permanently reinstated, you do not qualify to receive new licenses
-for the same material under section 10.</p>
-<p>9. Acceptance Not Required for Having Copies.</p>
-<p>You are not required to accept this License in order to receive
-or run a copy of the Program. Ancillary propagation of a covered
-work occurring solely as a consequence of using peer-to-peer
-transmission to receive a copy likewise does not require
-acceptance. However, nothing other than this License grants you
-permission to propagate or modify any covered work. These actions
-infringe copyright if you do not accept this License. Therefore, by
-modifying or propagating a covered work, you indicate your
-acceptance of this License to do so.</p>
-<p>10. Automatic Licensing of Downstream Recipients.</p>
-<p>Each time you convey a covered work, the recipient automatically
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+<p>
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+<p>
+  9. Acceptance Not Required for Having Copies.
+
+<p>
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+<p>
+  10. Automatic Licensing of Downstream Recipients.
+
+<p>
+  Each time you convey a covered work, the recipient automatically
 receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License. You are not
-responsible for enforcing compliance by third parties with this
-License.</p>
-<p>An "entity transaction" is a transaction transferring control of
-an organization, or substantially all assets of one, or subdividing
-an organization, or merging organizations. If propagation of a
-covered work results from an entity transaction, each party to that
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+<p>
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
 transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or
-could give under the previous paragraph, plus a right to possession
-of the Corresponding Source of the work from the predecessor in
-interest, if the predecessor has it or can get it with reasonable
-efforts.</p>
-<p>You may not impose any further restrictions on the exercise of
-the rights granted or affirmed under this License. For example, you
-may not impose a license fee, royalty, or other charge for exercise
-of rights granted under this License, and you may not initiate
-litigation (including a cross-claim or counterclaim in a lawsuit)
-alleging that any patent claim is infringed by making, using,
-selling, offering for sale, or importing the Program or any portion
-of it.</p>
-<p>11. Patents.</p>
-<p>A "contributor" is a copyright holder who authorizes use under
-this License of the Program or a work on which the Program is
-based. The work thus licensed is called the contributor's
-"contributor version".</p>
-<p>A contributor's "essential patent claims" are all patent claims
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+<p>
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+<p>
+  11. Patents.
+
+<p>
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+<p>
+  A contributor's "essential patent claims" are all patent claims
 owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner,
-permitted by this License, of making, using, or selling its
-contributor version, but do not include claims that would be
-infringed only as a consequence of further modification of the
-contributor version. For purposes of this definition, "control"
-includes the right to grant patent sublicenses in a manner
-consistent with the requirements of this License.</p>
-<p>Each contributor grants you a non-exclusive, worldwide,
-royalty-free patent license under the contributor's essential
-patent claims, to make, use, sell, offer for sale, import and
-otherwise run, modify and propagate the contents of its contributor
-version.</p>
-<p>In the following three paragraphs, a "patent license" is any
-express agreement or commitment, however denominated, not to
-enforce a patent (such as an express permission to practice a
-patent or covenant not to sue for patent infringement). To "grant"
-such a patent license to a party means to make such an agreement or
-commitment not to enforce a patent against the party.</p>
-<p>If you convey a covered work, knowingly relying on a patent
-license, and the Corresponding Source of the work is not available
-for anyone to copy, free of charge and under the terms of this
-License, through a publicly available network server or other
-readily accessible means, then you must either (1) cause the
-Corresponding Source to be so available, or (2) arrange to deprive
-yourself of the benefit of the patent license for this particular
-work, or (3) arrange, in a manner consistent with the requirements
-of this License, to extend the patent license to downstream
-recipients. "Knowingly relying" means you have actual knowledge
-that, but for the patent license, your conveying the covered work
-in a country, or your recipient's use of the covered work in a
-country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.</p>
-<p>If, pursuant to or in connection with a single transaction or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+<p>
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+<p>
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+<p>
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+<p>
+  If, pursuant to or in connection with a single transaction or
 arrangement, you convey, or propagate by procuring conveyance of, a
 covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate,
-modify or convey a specific copy of the covered work, then the
-patent license you grant is automatically extended to all
-recipients of the covered work and works based on it.</p>
-<p>A patent license is "discriminatory" if it does not include
-within the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that
-are specifically granted under this License. You may not convey a
-covered work if you are a party to an arrangement with a third
-party that is in the business of distributing software, under which
-you make payment to the third party based on the extent of your
-activity of conveying the work, and under which the third party
-grants, to any of the parties who would receive the covered work
-from you, a discriminatory patent license (a) in connection with
-copies of the covered work conveyed by you (or copies made from
-those copies), or (b) primarily for and in connection with specific
-products or compilations that contain the covered work, unless you
-entered into that arrangement, or that patent license was granted,
-prior to 28 March 2007.</p>
-<p>Nothing in this License shall be construed as excluding or
-limiting any implied license or other defenses to infringement that
-may otherwise be available to you under applicable patent law.</p>
-<p>12. No Surrender of Others' Freedom.</p>
-<p>If conditions are imposed on you (whether by court order,
-agreement or otherwise) that contradict the conditions of this
-License, they do not excuse you from the conditions of this
-License. If you cannot convey a covered work so as to satisfy
-simultaneously your obligations under this License and any other
-pertinent obligations, then as a consequence you may not convey it
-at all. For example, if you agree to terms that obligate you to
-collect a royalty for further conveying from those to whom you
-convey the Program, the only way you could satisfy both those terms
-and this License would be to refrain entirely from conveying the
-Program.</p>
-<p>13. Use with the GNU Affero General Public License.</p>
-<p>Notwithstanding any other provision of this License, you have
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+<p>
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+<p>
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+<p>
+  12. No Surrender of Others' Freedom.
+
+<p>
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+<p>
+  13. Use with the GNU Affero General Public License.
+
+<p>
+  Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a
-single combined work, and to convey the resulting work. The terms
-of this License will continue to apply to the part which is the
-covered work, but the special requirements of the GNU Affero
-General Public License, section 13, concerning interaction through
-a network will apply to the combination as such.</p>
-<p>14. Revised Versions of this License.</p>
-<p>The Free Software Foundation may publish revised and/or new
-versions of the GNU General Public License from time to time. Such
-new versions will be similar in spirit to the present version, but
-may differ in detail to address new problems or concerns.</p>
-<p>Each version is given a distinguishing version number. If the
-Program specifies that a certain numbered version of the GNU
-General Public License "or any later version" applies to it, you
-have the option of following the terms and conditions either of
-that numbered version or of any later version published by the Free
-Software Foundation. If the Program does not specify a version
-number of the GNU General Public License, you may choose any
-version ever published by the Free Software Foundation.</p>
-<p>If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that
-proxy's public statement of acceptance of a version permanently
-authorizes you to choose that version for the Program.</p>
-<p>Later license versions may give you additional or different
-permissions. However, no additional obligations are imposed on any
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+<p>
+  14. Revised Versions of this License.
+
+<p>
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+<p>
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+<p>
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+<p>
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
 author or copyright holder as a result of your choosing to follow a
-later version.</p>
-<p>15. Disclaimer of Warranty.</p>
-<p>THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE
-COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS"
-WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE
-RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.
-SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL
-NECESSARY SERVICING, REPAIR OR CORRECTION.</p>
-<p>16. Limitation of Liability.</p>
-<p>IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
-WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES
-AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
-DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
-CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE
-THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA
-BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF
-THE POSSIBILITY OF SUCH DAMAGES.</p>
-<p>17. Interpretation of Sections 15 and 16.</p>
-<p>If the disclaimer of warranty and limitation of liability
-provided above cannot be given local legal effect according to
-their terms, reviewing courts shall apply local law that most
-closely approximates an absolute waiver of all civil liability in
-connection with the Program, unless a warranty or assumption of
-liability accompanies a copy of the Program in return for a
-fee.</p>
-<p align="center"><b>END OF TERMS AND CONDITIONS</b></p>
-</body>
-</html>
+later version.
+
+<p>
+  15. Disclaimer of Warranty.
+
+<p>
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+<p>
+  16. Limitation of Liability.
+
+<p>
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+<p>
+  17. Interpretation of Sections 15 and 16.
+
+<p>
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+<p align="center">
+                     <b>END OF TERMS AND CONDITIONS</b>

--- a/html-src/news.html
+++ b/html-src/news.html
@@ -1,11 +1,3 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <pre>
 ==================================================================
 User visible changes for PySol - a solitaire game collection
@@ -227,5 +219,3 @@ Changes in 1.00 (10 Sep 1998, 4 games)
   * first public release
 
 </pre>
-</body>
-</html>

--- a/html-src/rules.html
+++ b/html-src/rules.html
@@ -1,18 +1,10 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>PySol - Game Rules</h1>
-<hr />
+<hr>
+
 <h2>Basic Concepts</h2>
 <ul>
-<li><a href="glossary.html">Glossary</a></li>
-<li><a href="general_rules.html">General Rules</a></li>
+<li> <a href="glossary.html">Glossary</a>
+<li> <a href="general_rules.html">General Rules</a>
 </ul>
 <h2>Game Rules</h2>
-</body>
-</html>
+<ul>

--- a/html-src/rules/10x8.html
+++ b/html-src/rules/10x8.html
@@ -1,25 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>10 x 8</h1>
 Klondike type. Two decks. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="8x8.html">8 x 8</a> with ten rows and <a href=
-"../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="8x8.html">8 x 8</a>
+with ten rows and
+<a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like 8 x 8. The rows build down in rank in alternate
-color. The Wizards will play in their proper rank position on the
-tableau as the alternate of either red or black. Any card or
-sequence may be played on an empty row. Cards are dealt from the
-talon one at a time. Cards may be played from the foundations.
+Game play is like 8 x 8.  The rows build down in rank in alternate
+color.  The Wizards will play in their proper rank position on the
+tableau as the alternate of either red or black.  Any card or sequence
+may be played on an empty row.  Cards are dealt from the talon one at
+a time.  Cards may be played from the foundations.
 <h3>Strategy</h3>
 Try to open a row to the canvas.
-</body>
-</html>

--- a/html-src/rules/8x8.html
+++ b/html-src/rules/8x8.html
@@ -1,26 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>8 x 8</h1>
-<p>Klondike type. 2 decks. Unlimited redeals.</p>
+<p>
+Klondike type. 2 decks. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>As the name implies, the eight playing piles in the tableau all
-start with eight cards face-up.</p>
-<p>Piles build down by alternate color, and an empty space can be
-filled with any card or sequence.</p>
-<p>When you click on the talon, one card is turned over onto the
-waste pile. There is no limit to the number of times you go through
-the talon.</p>
-<p>You are also permitted to move cards back out of the
-foundation.</p>
+<p>
+As the name implies, the eight playing
+piles in the tableau all start with eight cards face-up.
+<p>
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence.
+<p>
+When you click on the talon, one card is turned over onto the waste pile.
+There is no limit to the number of times you go through the talon.
+<p>
+You are also permitted to move cards back out of the foundation.
+
 <h3>Strategy</h3>
-<p>Try to go for an empty space.</p>
-</body>
-</html>
+<p>
+Try to go for an empty space.

--- a/html-src/rules/abacus.html
+++ b/html-src/rules/abacus.html
@@ -1,35 +1,38 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Abacus</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick Description</h3>
-<p>A combination of <a href="yukon.html">Yukon type</a> and
-<a href="calculation.html">Calculation type</a> game elements.</p>
+<p>
+A combination of
+<a href="yukon.html">Yukon type</a>
+and
+<a href="calculation.html">Calculation type</a>
+game elements.
+
 <h3>Rules</h3>
-<p>The four Foundations build up by suit the following way: The
-first pile from Ace, by one. The second pile from Two, by two. The
-third pile from Three, by three. The fourth pile from Four, by
-four.</p>
-<pre>
+<p>
+The four Foundations build up by suit the following way:
+The first pile from Ace, by one. The second pile from Two, by two.
+The third pile from Three, by three. The fourth pile from Four, by four.
+<pRE>
 Club:     A 2 3 4 5 6 7 8 9 T J Q K
 Spade:    2 4 6 8 T Q A 3 5 7 9 J K
 Heart:    3 6 9 Q 2 5 8 J A 4 7 T K
 Diamond:  4 8 Q 3 7 J 2 6 T A 5 9 K
-</pre>
-<p>Cards in Tableau are built down by suit, the ranks going the
-opposite way as the foundations: Club down by one, Spade down by
-two, Heart down by three and Diamond down by four.</p>
-<p>Groups of cards can be moved regardless of sequence, and an
-empty space can be filled with any card or sequence.</p>
-<p>When no more moves are possible, click on the Talon. One card
-will be added to each of the playing piles.</p>
-</body>
-</html>
+</pRE>
+<p>
+Cards in Tableau are built down by suit, the ranks going
+the opposite way as the foundations:
+Club down by one, Spade down by two, Heart down by three and
+Diamond down by four.
+<p>
+Groups of cards can be moved regardless of sequence,
+and an empty space can be filled with any card or sequence.
+<p>
+When no more moves are possible, click on the Talon. One card will be
+added to each of the playing piles.

--- a/html-src/rules/acesup.html
+++ b/html-src/rules/acesup.html
@@ -1,28 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Aces Up</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards except the four Aces to the single
-foundation.</p>
+<p>
+Move all cards except the four Aces to the single foundation.
+
 <h3>Rules</h3>
-<p>Any top card that is of lower rank and of the same suit of
-another top card may be dropped to the foundation. Aces rank
-high.</p>
-<p>There is no building on the tableau, except that an empty pile
-may be filled with any card.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles.</p>
+<p>
+Any top card that is of lower rank and of the same suit of another
+top card may be dropped to the foundation. Aces rank high.
+<p>
+There is no building on the tableau, except that an empty pile
+may be filled with any card.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each of the playing piles.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
+<p>
+<i>Autodrop</i> is disabled for this game.
+
 <h3>History</h3>
-<p>This simple game is known by many names, such as <i>Aces
-High</i>, <i>Drivel</i> and <i>Idiot's Delight</i>.</p>
-</body>
-</html>
+<p>
+This simple game is known by many names, such as
+<i>Aces High</i>, <i>Drivel</i> and <i>Idiot's Delight</i>.

--- a/html-src/rules/acesup5.html
+++ b/html-src/rules/acesup5.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Ace Up 5</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards except the four Aces to the single
-foundation.</p>
+<p>
+Move all cards except the four Aces to the single foundation.
+
 <h3>Quick Description</h3>
-<p>Like <a href="acesup.html">Aces Up</a>, but five piles.</p>
+<p>
+Like <a href="acesup.html">Aces Up</a>,
+but five piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/agnessorel.html
+++ b/html-src/rules/agnessorel.html
@@ -1,26 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Agnes Sorel</h1>
-<p>Gypsy type. 1 deck. No redeal.</p>
+<p>
+Gypsy type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards in the Tableau are built down by same color. Groups of
-cards in sequence and same color can be moved as a unit.</p>
-<p>Each deal flips one card from the Stock to each pile of the
-Tableau. There are no redeals.</p>
-<p>Foundations are built up in suit in sequence, wrapping from King
-to Ace when necessary. Cards in Foundations are still in play.
-Double clicking on a card in the Tableau will move it to the
-appropriate Foundation pile if such a move is possible.</p>
+<p>
+Cards in the Tableau are built down by same color. Groups of cards in sequence
+and same color can be moved as a unit.
+<p>
+Each deal flips one card from the Stock to each pile of the Tableau. There are
+no redeals.
+<p>
+Foundations are built up in suit in sequence, wrapping from King to Ace when
+necessary. Cards in Foundations are still in play. Double clicking on a card
+in the Tableau will move it to the appropriate Foundation pile if such a move
+is possible.
+
 <h3>Strategy</h3>
-<p>Try to build down in suit whenever possible. Try to score as
-many points as you can as this game is very hard to win.</p>
-</body>
-</html>
+<p>
+Try to build down in suit whenever possible. Try to score as many points as
+you can as this game is very hard to win.

--- a/html-src/rules/akbarsconquest.html
+++ b/html-src/rules/akbarsconquest.html
@@ -1,36 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Akbar's Conquest</h1>
 Braid type. Two decks. Two redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
 <h3>Quick description</h3>
-Similar to <a href="braid.html">Braid</a> played with two Mughal
-<a href="../ganjifa.html">Ganjifa</a> decks.
+Similar to <a href="braid.html">Braid</a>
+played with two Mughal
+<a href="../ganjifa.html">Ganjifa</a>
+decks.
+
 <h3>Rules</h3>
-Game play is like Braid. In this variation there are two Braid
-stacks that each have their own set of Braid reserve stacks. The
-game lay out starts with the sixteen foundations in the outer most
-columns. The next two columns inwards are the eight Braid reserves.
-Then there are two columns with four general reserves each. The
-inner most two columns are the two Braid stacks. Each Braid starts
-with sixteen cards. When one of the Braid reserves becomes open the
-card at the top of the corresponding Braid will be moved there.
-When all the cards from one of the Braids are removed a card from
-the other Braid will be used.
-<p>The game is named after the reputed inventor of a twelve suited
-Ganjifa deck of singular splendor. It was engraved on ivory and
-hand painted by court artisans. No cards from this pack are known
-to still exist.</p>
+Game play is like Braid.  In this variation there are two Braid
+stacks that each have their own set of Braid reserve stacks.  The
+game lay out starts with the sixteen foundations in the outer most columns.
+The next two columns inwards are the eight Braid reserves.  Then there
+are two columns with four general reserves each.  The inner most two
+columns are the two Braid stacks.  Each Braid starts with sixteen cards.
+When one of the Braid reserves becomes open the card at the top of the
+corresponding Braid will be moved there.  When all the cards from one
+of the Braids are removed a card from the other Braid will be used.
+<p>
+The game is named after the reputed inventor of a twelve suited Ganjifa
+deck of singular splendor.  It was engraved on ivory and hand painted
+by court artisans.  No cards from this pack are known to still exist.
 <h3>Strategy</h3>
-Build sequences on the rows that will play when the correct card
-turns over from the talon. This game type requires careful strategy
-to win.
-</body>
-</html>
+Build sequences on the rows that will play when the correct card turns
+over from the talon.  This game type requires careful strategy to win.

--- a/html-src/rules/akbarstriumph.html
+++ b/html-src/rules/akbarstriumph.html
@@ -1,36 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Akbar's Triumph</h1>
 Braid type. One deck. Two redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
 <h3>Quick description</h3>
-Similar to <a href="braid.html">Braid</a> played with a single
-Mughal <a href="../ganjifa.html">Ganjifa</a> deck.
+Similar to <a href="braid.html">Braid</a>
+played with a single Mughal
+<a href="../ganjifa.html">Ganjifa</a>
+deck.
+
 <h3>Rules</h3>
-Game play is like Braid. In this variation there are two Braid
-stacks that each have their own set of Braid reserve stacks. The
-game lay out starts with the eight foundations in the outer most
-columns. The next two columns inwards are the eight Braid reserves.
-Then there are two columns with four general reserves each. The
-inner most two columns are the two Braid stacks. Each Braid starts
-with twelve cards. When one of the Braid reserves becomes open the
-card at the top of the corresponding Braid will be moved there.
-When all the cards from one of the Braids are removed a card from
-the other Braid will be used.
-<p>The game is named after the reputed inventor of a twelve suited
-Ganjifa deck of singular splendor. It was engraved on ivory and
-hand painted by court artisans. No cards from this pack are known
-to still exist.</p>
+Game play is like Braid.  In this variation there are two Braid
+stacks that each have their own set of Braid reserve stacks.  The
+game lay out starts with the eight foundations in the outer most columns.
+The next two columns inwards are the eight Braid reserves.  Then there
+are two columns with four general reserves each.  The inner most two
+columns are the two Braid stacks.  Each Braid starts with twelve cards.
+When one of the Braid reserves becomes open the card at the top of the
+corresponding Braid will be moved there.  When all the cards from one
+of the Braids are removed a card from the other Braid will be used.
+<p>
+The game is named after the reputed inventor of a twelve suited Ganjifa
+deck of singular splendor.  It was engraved on ivory and hand painted
+by court artisans.  No cards from this pack are known to still exist.
 <h3>Strategy</h3>
-Build sequences on the rows that will play when the correct card
-turns over from the talon. This game type requires careful strategy
-to win.
-</body>
-</html>
+Build sequences on the rows that will play when the correct card turns
+over from the talon.  This game type requires careful strategy to win.

--- a/html-src/rules/alaska.html
+++ b/html-src/rules/alaska.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Alaska</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="yukon.html">Yukon</a>, but the rows build <b>up or
-down</b> in suit.</p>
+<p>
+Like <a href="yukon.html">Yukon</a>,
+but the rows build <b>up or down</b> in suit.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/allinarow.html
+++ b/html-src/rules/allinarow.html
@@ -1,26 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>All in a Row</h1>
-<p>Fan game type. 1 deck. No redeal.</p>
+<p>
+Fan game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the bottom in a single row.</p>
+<p>
+Move all cards to the bottom in a single row.
+
 <h3>Rules</h3>
-<p>The row builds up or down by rank ignoring color and suit,
-wrapping around from King to Ace and from Ace to King.</p>
-<p>There is no building on the tableau piles, and spaces are not
-filled. Only top cards from reach pile can be moved.</p>
-<p>The first card the bottom row can be arbitrarily selected from
-the top of any pile.</p>
+<p>
+The row builds up or down by rank ignoring color and suit, wrapping
+around from King to Ace and from Ace to King.
+<p>
+There is no building on the tableau piles, and spaces
+are not filled. Only top cards from reach pile can be moved.
+<p>
+The first card the bottom row can be arbitrarily selected from the
+top of any pile.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
+<p>
+<i>Autodrop</i> is disabled for this game.
+
 <h3>Strategy</h3>
-<p>Plan carefully - one wrong move and you may never be able to
-untangle the mess.</p>
-</body>
-</html>
+<p>
+Plan carefully - one wrong move and you may never
+be able to untangle the mess.

--- a/html-src/rules/americantoad.html
+++ b/html-src/rules/americantoad.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>American Toad</h1>
-<p>Canfield type. 2 decks. 1 redeal.</p>
+<p>
+Canfield type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="doublecanfield.html">Double Canfield</a>, but the
-8 piles build down in suit, cards are dealt singly, the reserve is
-face-up, and only one redeal.</p>
+<p>
+Like <a href="doublecanfield.html">Double Canfield</a>,
+but the 8 piles build down in suit, cards are dealt singly,
+the reserve is face-up, and only one redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/appachanswaterfall.html
+++ b/html-src/rules/appachanswaterfall.html
@@ -1,35 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Appachan's Waterfall</h1>
 Dashavatara Ganjifa game type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundation.
+
 <h3>Quick description</h3>
-Build complete suits in descending rank order on the tableau then
-move them to the single foundation in ascending rank and suit
-order. Refer to the general <a href="../ganjifa.html">Ganjifa</a>
+Build complete suits in descending rank order on the tableau then move
+them to the single foundation in ascending rank and suit order.  Refer
+to the general <a href="../ganjifa.html">Ganjifa</a>
 description for the suit order used.
+
 <h3>Rules</h3>
-Cards will play on the tableau in descending rank order without
-regard to suit. They can only be moved to the single foundation
-when a complete suit of twelve cards is finished and only in
-ascending suit order. The suit of the Fish Incarnation is first,
-the Tortoise next etc. When a suit is ready to be moved to the
-foundation, press (a)uto or play with auto drop enabled and all
-twelve cards will move there in order. Four cards are dealt to each
-of the ten rows when the game begins. Press (d)eal or click the
-talon to deal the next round of one card to each row. The reserve
-stacks to either side of the foundation will take one card each.
-Cards on the reserves may only be played to the rows.
+Cards will play on the tableau in descending rank order without regard
+to suit.  They can only be moved to the single foundation when a complete
+suit of twelve cards is finished and only in ascending suit order.  The
+suit of the Fish Incarnation is first, the Tortoise next etc.  When a
+suit is ready to be moved to the foundation, press (a)uto or play with
+auto drop enabled and all twelve cards will move there in order.  Four
+cards are dealt to each of the ten rows when the game begins.  Press
+(d)eal or click the talon to deal the next round of one card to each
+row.  The reserve stacks to either side of the foundation will take one
+card each.  Cards on the reserves may only be played to the rows.
 <h3>Strategy</h3>
-Make every play possible before dealing the next round. While the
-cards will play in rank order only, it's helpful to also work on
-playing them by suit.
-</body>
-</html>
+Make every play possible before dealing the next round.  While the cards
+will play in rank order only, it's helpful to also work on playing them by
+suit.

--- a/html-src/rules/ashrafi.html
+++ b/html-src/rules/ashrafi.html
@@ -1,27 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Ashrafi</h1>
 Mughal Ganjifa type. One deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="freecell.html">Free Cell</a>. The rows
-build down by rank only, no more than twelve to a row.
+Play is similar to
+<a href="freecell.html">Free Cell</a>.
+The rows build down by rank only, no more than twelve to a row.
+
 <h3>Rules</h3>
-The cards on the tableau build down by rank regardless of suit. No
-more than twelve cards may be placed in one row. The four reserve
-stacks below the foundations will hold one card each. The
-foundations build up in rank by suit starting with the Ace. Only
-the Mirs (Kings) may be played on empty rows.
+The cards on the tableau build down by rank regardless of suit.  No more
+than twelve cards may be placed in one row.  The four reserve stacks
+below the foundations will hold one card each.  The foundations build
+up in rank by suit starting with the Ace.  Only the Mirs (Kings) may
+be played on empty rows.
+
 <h3>Strategy</h3>
-Move the tableau cards with the objective of releasing the Aces
-first. Keep the reserve stacks open as much as possible. Build
-piles on the Mirs so they can be moved to open rows.
-</body>
-</html>
+Move the tableau cards with the objective of releasing the Aces first.
+Keep the reserve stacks open as much as possible.  Build piles on
+the Mirs so they can be moved to open rows.

--- a/html-src/rules/ashtadikapala.html
+++ b/html-src/rules/ashtadikapala.html
@@ -1,38 +1,36 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Ashta Dikapala</h1>
-<p>One Moghul Ganjifa deck. No redeal.</p>
+<p>
+One Moghul Ganjifa deck. No redeal.
+
 <h3>Object</h3>
-<p>Arrange the Eight Guardians in order.</p>
+<p>
+Arrange the Eight Guardians in order.
+
 <h3>Rules</h3>
-<p>Play is similar to <a href="picturegallery.html">Picture
-Gallery</a>. The layout consists of three rows of playing piles, a
-row for newly dealt cards and three free cells that will hold one
-card each.</p>
-<p>The cards must be arranged in the top three rows as follows:</p>
+<p>
+Play is similar to <a href="picturegallery.html">Picture Gallery</a>.
+The layout consists of three rows of playing piles, a row for newly
+dealt cards and three free cells that will hold one card each.
+<p>
+The cards must be arranged in the top three rows as follows:
 <ul>
-<li>The top row must start with a three and build by suit in
-increments of three,</li>
-<li>the second row must with a two,</li>
-<li>and the third row must start with an Ace.</li>
+<li>The top row must start with a three and build by suit in increments of three,
+<li>the second row must with a two,
+<li>and the third row must start with an Ace.
 </ul>
-<p>If you clear a space at the bottom it will be automatically
-filled with a card from the talon. But if the talon is gone and you
-clear a space at the bottom, then you can fill it with any card.
-You may move any card to the free cells from the tableau on top or
-the rows below, but only as long as there are cards left in the
-talon. When the talon is empty, you may only move cards from, not
-to the free cells. When no further moves are possible, click on the
-talon for a fresh row of cards at the bottom.</p>
-<p>You win when all of the suits are arranged in order.</p>
+<p>
+If you clear a space at the bottom it will be automatically filled
+with a card from the talon. But if the talon is gone and you clear a space
+at the bottom, then you can fill it with any card.  You may move any card
+to the free cells from the tableau on top or the rows below, but only as
+long as there are cards left in the talon.  When the talon is empty, you
+may only move cards from, not to the free cells.
+When no further moves are possible, click on the talon for a fresh row
+of cards at the bottom.
+<p>
+You win when all of the suits are arranged in order.
+
 <h3>Strategy</h3>
-<p>Because of the many piles involved the Picture Gallery requires
-some concentration, but it is not too hard to win.</p>
-</body>
-</html>
+<p>
+Because of the many piles involved the Picture Gallery requires some
+concentration, but it is not too hard to win.

--- a/html-src/rules/ashwapati.html
+++ b/html-src/rules/ashwapati.html
@@ -1,29 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Ashwapati</h1>
 Mughal Ganjifa type. One deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank in the same suit.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank in the same suit.
+
 <h3>Rules</h3>
-The cards on the tableau build down by ranks of the same suit. The
-foundations build up in rank by suit starting with the Ace. Any
-card or movable pile may be played on an empty row. Cards are dealt
-from the talon one at a time. There is no limit on the number of
-redeals. Cards may be played from the foundations.
-<p>This game is one of a series of games that have names ending in
-"pati" which transliterates as "lord of". Ashwapati means "Lord of
-Horses". The names are the names of the suits in a twelve suit
-Ganjifa deck.</p>
+The cards on the tableau build down by ranks of the same suit.  The
+foundations build up in rank by suit starting with the Ace.  Any
+card or movable pile may be played on an empty row.  Cards are dealt
+from the talon one at a time.  There is no limit on the number of
+redeals.  Cards may be played from the foundations.
+<p>
+This game is one of a series of games that have names ending in "pati"
+which transliterates as "lord of".  Ashwapati means "Lord of Horses".
+The names are the names of the suits in a twelve suit Ganjifa deck.
+
 <h3>Strategy</h3>
 Move cards off of the deepest stacks first.
-</body>
-</html>

--- a/html-src/rules/auldlangsyne.html
+++ b/html-src/rules/auldlangsyne.html
@@ -1,23 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Auld Lang Syne</h1>
-<p>Numerica type. 1 deck. No redeal.</p>
+<p>
+Numerica type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations build up by rank ignoring suit. At game start
-the four Aces are dealt here.</p>
-<p>There is no building on the tableau piles - cards can only be
-moved to the foundations, and spaces are not filled.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles.</p>
+<p>
+The foundations build up by rank ignoring suit.
+At game start the four Aces are dealt here.
+<p>
+There is no building on the tableau piles - cards can only be
+moved to the foundations, and spaces are not filled.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each of the playing piles.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/babyspiderette.html
+++ b/html-src/rules/babyspiderette.html
@@ -1,21 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Baby Spiderette</h1>
-<p>Spider type. 1 deck. No redeal.</p>
+<p>
+Spider type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="spiderette.html">Spiderette</a>, but somewhat
-easier as groups of cards can be moved if they <i>build down by
-rank</i>.</p>
+<p>
+Just like <a href="spiderette.html">Spiderette</a>,
+but somewhat easier as groups of cards can be moved
+if they <i>build down by rank</i>.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/badseven.html
+++ b/html-src/rules/badseven.html
@@ -1,17 +1,13 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
-<h1>Bad Seven (Die böse Sieben)</h1>
-<p>Two-Deck game type. 2 stripped decks. 1 redeal.</p>
+<h1>Bad Seven (Die b&ouml;se Sieben)</h1>
+<p>
+Two-Deck game type. 2 stripped decks. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>This game is played with two stripped decks.</p>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+This game is played with two stripped decks.
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/bakersdozen.html
+++ b/html-src/rules/bakersdozen.html
@@ -1,19 +1,15 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Baker's Dozen</h1>
-<p>Baker's Dozen type. 1 deck. No redeal.</p>
+<p>
+Baker's Dozen type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The piles build down by rank regardless of suit. Only one card
-can be moved at a time.</p>
-<p>Empty piles cannot be filled - therefore all Kings are placed at
-the bottom of a pile during the initial dealing.</p>
-</body>
-</html>
+<p>
+The piles build down by rank regardless of suit.
+Only one card can be moved at a time.
+<p>
+Empty piles cannot be filled - therefore all Kings are placed
+at the bottom of a pile during the initial dealing.

--- a/html-src/rules/bakersgame.html
+++ b/html-src/rules/bakersgame.html
@@ -1,32 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Baker's Game</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="freecell.html">FreeCell</a>, but the piles build
-down by suit.</p>
+<p>
+Like <a href="freecell.html">FreeCell</a>,
+but the piles build down by suit.
+
 <h3>Rules</h3>
-<p>All cards are dealt at the start of the game. To compensate for
-this there are 4 free cells which can hold any - and just one -
-card.</p>
-<p>Cards may only be moved onto cards of the same suit.</p>
-<p>The number of cards you can move as a sequence is restricted by
+<p>
+All cards are dealt at the start of the game. To compensate for this
+there are 4 free cells which can hold any - and just one - card.
+<p>
+Cards may only be moved onto cards of the same suit.
+<p>
+The number of cards you can move as a sequence is restricted by
 the number of free cells - the number of free cells required is the
-same as if you would make an equivalent sequence of moves with
-single cards. (As a shortcut, the computer also considers the
-number of free piles so that you can move even more cards as one
-single sequence.)</p>
+same as if you would make an equivalent sequence of moves with single cards.
+(As a shortcut, the computer also considers the number of free piles so
+that you can move even more cards as one single sequence.)
+
 <h3>History</h3>
-<p><i>Baker's Game</i> is named after the mathematician C.L. Baker
+<p>
+<i>Baker's Game</i> is named after the mathematician C.L. Baker
 and was first published in Martin Gardner's June 1968
-<i>Mathematical Games</i> column in <i>Scientific American</i>.</p>
-</body>
-</html>
+<i>Mathematical Games</i> column in <i>Scientific American</i>.

--- a/html-src/rules/balarama.html
+++ b/html-src/rules/balarama.html
@@ -1,28 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Balarama</h1>
 Dashavatara Ganjifa type. One deck. No redeal.
 <h3>Object</h3>
 Move all cards to the foundations.
 <h3>Quick description</h3>
-The cards build down by rank in alternate colors on the tableau, no
-more than twelve to a row. Any card or sequence may be played on an
-empty row.
+The cards build down by rank in alternate colors on the tableau, no more
+than twelve to a row.  Any card or sequence may be played on an empty row.
 <h3>Rules</h3>
-All cards are dealt to the sixteen rows when the games begins.
-Cards on the tableau build down in rank in alternating colors. See
-the general <a href="../ganjifa.html">Ganjifa</a> card rules for
-information on that. The foundations build up by suit. Any card or
-sequence may be played on an empty row. The four reserve stacks
-hold one card each.
+All cards are dealt to the sixteen rows when the games begins.  Cards
+on the tableau build down in rank in alternating colors.  See the general
+<a href="../ganjifa.html">Ganjifa</a>
+card rules for information on that.   The foundations build up by suit.
+Any card or sequence may be played on an empty row.  The four reserve
+stacks hold one card each.
 <h3>Strategy</h3>
-An empty row is more useful than the reserve stacks. Try for an
-empty row.
-</body>
-</html>
+An empty row is more useful than the reserve stacks.  Try for an empty row.

--- a/html-src/rules/batsford.html
+++ b/html-src/rules/batsford.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Batsford</h1>
-<p>Klondike type. 2 decks. No redeal.</p>
+<p>
+Klondike type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="doubleklondike.html">Double Klondike</a>, but 10
-piles, no redeal, and an extra reserve that can hold up to 3
-Kings.</p>
+<p>
+Like <a href="doubleklondike.html">Double Klondike</a>,
+but 10 piles, no redeal, and an extra reserve that can
+hold up to 3 Kings.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/beleagueredcastle.html
+++ b/html-src/rules/beleagueredcastle.html
@@ -1,21 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Beleaguered Castle</h1>
-<p>Beleaguered Castle type. 1 deck. No redeal.</p>
+<p>
+Beleaguered Castle type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>At game start the four Aces are dealt to the foundations.</p>
-<p>The eight piles build down by rank regardless of suit. Only one
-card can be moved at a time and empty piles can be filled with any
-single card.</p>
+<p>
+At game start the four Aces are dealt to the foundations.
+<p>
+The eight piles build down by rank regardless of suit.
+Only one card can be moved at a time and
+empty piles can be filled with any single card.
+
 <h3>Strategy</h3>
-<p>Build evenly on to foundations. Try to get an empty pile.</p>
-</body>
-</html>
+<p>
+Build evenly on to foundations. Try to get an empty pile.

--- a/html-src/rules/betsyross.html
+++ b/html-src/rules/betsyross.html
@@ -1,35 +1,35 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Betsy Ross</h1>
-<p>One-Deck game type. 1 deck. 2 redeals.</p>
+<p>
+One-Deck game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="calculation.html">Calculation</a>, but using a
-waste with 2 redeals instead of row stacks.</p>
+<p>
+Like <a href="calculation.html">Calculation</a>,
+but using a waste with 2 redeals instead of row stacks.
+
 <h3>Rules</h3>
-<p>The four foundations at the top are out of play.</p>
-<p>The four foundations below build regardless of suit the
-following way: The first pile from Two, by one. The second pile
-from Four, by two. The third pile from Six, by three. The fourth
-pile from Eight, by four.</p>
-<pre>
+<p>
+The four foundations at the top are out of play.
+<p>
+The four foundations below build regardless of suit the following way:
+The first pile from Two, by one. The second pile from Four, by two.
+The third pile from Six, by three. The fourth pile from Eight, by four.
+<pRE>
 1:  2 3 4 5 6 7 8 9 T J Q K
 2:  4 6 8 T Q A 3 5 7 9 J K
 3:  6 9 Q 2 5 8 J A 4 7 T K
 4:  8 Q 3 7 J 2 6 T A 5 9 K
-</pre>
-<p>When you click on the talon, one card is turned over onto the
-waste pile. There are 2 redeals.</p>
+</pRE>
+<p>
+When you click on the talon, one card is turned over onto the waste pile.
+There are 2 redeals.
+
 <h3>History</h3>
-<p>This game is known by many names, such as <i>Fairest</i>,
-<i>Four Kings</i>, <i>Musical Patience</i>, <i>Quadruple
-Alliance</i> and <i>Plus Belle</i>.</p>
-</body>
-</html>
+<p>
+This game is known by many names, such as
+<i>Fairest</i>, <i>Four Kings</i>, <i>Musical Patience</i>,
+<i>Quadruple Alliance</i> and <i>Plus Belle</i>.

--- a/html-src/rules/bigbraid.html
+++ b/html-src/rules/bigbraid.html
@@ -1,18 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Big Braid</h1>
-<p>Napoleon type. 3 decks. 2 redeals.</p>
+<p>
+Napoleon type. 3 decks. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="braid.html">Braid</a>, but with three decks.</p>
+<p>
+Like <a href="braid.html">Braid</a>,
+but with three decks.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/bigdivorce.html
+++ b/html-src/rules/bigdivorce.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Big Divorce</h1>
-<p>Spider type. 3 decks. No redeal.</p>
+<p>
+Spider type. 3 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="groundsforadivorce.html">Grounds for a
-Divorce</a>, but with three decks and 13 playing piles.</p>
+<p>
+Like <a href="groundsforadivorce.html">Grounds for a Divorce</a>,
+but with three decks and 13 playing piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/bigeasy.html
+++ b/html-src/rules/bigeasy.html
@@ -1,29 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Big Easy</h1>
 Hanafuda type. 2 decks. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-This is a double deck version of <a href="littleeasy.html">Little
-Easy</a>. The rows build down by rank in the same suit. The
-foundations build with cards of the same rank in suit order. Only
-first rank cards may be played on an empty row.
+This is a double deck version of
+<a href="littleeasy.html">Little Easy</a>.
+The rows build down by rank in the same suit.  The foundations
+build with cards of the same rank in suit order.  Only first rank
+cards may be played on an empty row.
+
 <h3>Rules</h3>
-The rules are the same as in <a href="littleeasy.html">Little
-Easy</a>.
+The rules are the same as in
+<a href="littleeasy.html">Little Easy</a>.
+
 <h3>Strategy</h3>
-Disable auto drop and build on the rows until all cards are face
-up. These games may be easy by name and easy to play but they're
-not easy to win.
+Disable auto drop and build on the rows until all cards are face up.
+These games may be easy by name and easy to play but they're not easy
+to win.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/bigharp.html
+++ b/html-src/rules/bigharp.html
@@ -1,28 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
-<h1>Big Harp (Die große Harfe)</h1>
-<p>Klondike type. 2 decks. No redeal.</p>
+<h1>Big Harp (Die gro&szlig;e Harfe)</h1>
+<p>
+Klondike type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="doubleklondike.html">Double Klondike</a>, but ten
-piles, anything on an empty space, and no redeal.</p>
+<p>
+Like <a href="doubleklondike.html">Double Klondike</a>,
+but ten piles, anything on an empty space, and no redeal.
+
 <h3>Rules</h3>
-<p>Piles build down by alternate color, and an empty space can be
-filled with any card or sequence.</p>
-<p>Cards from the talon are turned over to the waste pile, one at a
-time. You can move the top card to the playing piles or the
-foundations. There is no redeal.</p>
-<p>You are also permitted to move cards back out of the
-foundations.</p>
+<p>
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence.
+<p>
+Cards from the talon are turned over to the waste pile, one at a time.
+You can move the top card to the playing piles or the foundations.
+There is no redeal.
+<p>
+You are also permitted to move cards back out of the foundations.
+
 <h3>History</h3>
-<p><i>Small Harp</i> and <i>Big Harp</i> are the German ways of
-playing <i>Klondike</i> and <i>Double Klondike</i>.</p>
-</body>
-</html>
+<p>
+<i>Small Harp</i> and <i>Big Harp</i> are the German ways of playing
+<i>Klondike</i> and <i>Double Klondike</i>.

--- a/html-src/rules/bigspider.html
+++ b/html-src/rules/bigspider.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Big Spider</h1>
-<p>Spider type. 3 decks. No redeal.</p>
+<p>
+Spider type. 3 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="spider.html">Spider</a>, but with three decks and
-13 playing piles.</p>
+<p>
+Like <a href="spider.html">Spider</a>,
+but with three decks and 13 playing piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/bigsumo.html
+++ b/html-src/rules/bigsumo.html
@@ -1,30 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Big Sumo</h1>
 Hanafuda type. 2 decks. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="freecell.html">Free Cell</a>. Cards
-build from first to fourth rank on the tableau by suit and from
-fourth to first on the foundations. Only first rank cards may be
-played on an empty row.
+Play is similar to
+<a href="freecell.html">Free Cell</a>.
+Cards build from first to fourth rank on the tableau by suit and
+from fourth to first on the foundations.  Only first rank cards
+may be played on an empty row.
+
 <h3>Rules</h3>
-This is a two deck version of <a href="sumo.html">Sumo</a>. Cards
-build down in rank on the rows and up in rank on the foundations.
-Third and fourth rank (trash) cards are not interchangeable. Only a
-first rank card or correctly ordered pile may be played on an empty
-row.
+This is a two deck version of
+<a href="sumo.html">Sumo</a>.
+Cards build down in rank on the rows and up in rank on the foundations.
+Third and fourth rank (trash) cards are not interchangeable.  Only a first
+rank card or correctly ordered pile may be played on an empty row.
+
 <h3>Strategy</h3>
 Don't play cards on the reserves unless they can be removed.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/bitsnbytes.html
+++ b/html-src/rules/bitsnbytes.html
@@ -1,36 +1,40 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Bits n Bytes</h1>
-<p>Hex A Deck type. 1 deck. One redeal.</p>
+<p>
+Hex A Deck type. 1 deck. One redeal.
+
 <h3>Object</h3>
-<p>Fill all row stacks.</p>
+<p>
+Fill all row stacks.
+
 <h3>Quick description</h3>
-<p>Fill Byte stacks by matching the goal card's byte value, fill
-bit stacks by matching the corresponding bit value.</p>
+<p>
+Fill Byte stacks by matching the goal card's byte value, fill bit
+stacks by matching the corresponding bit value.
+
 <h3>Rules</h3>
-<p>When play begins the four left most columns are filled with four
-goal cards of different ranks, one from each suit. The next two
-columns to the right are the byte stacks. They can be filled with
-cards of the same rank as the goal card in that row. The four right
-most columns are the bit stacks. They can be filled with cards of
-the same suit as the goal card in the respective row if their least
-significant bit matches the corresponding bit on the goal card.</p>
-<p>Cards from the talon are turned over to the waste pile, two at a
-time. There is only one redeal.</p>
-<p>The only function of the Wizards in this game is to block the
-waste stack at the worst possible time.</p>
+<p>
+When play begins the four left most columns are filled with four
+goal cards of different ranks, one from each suit.  The next two
+columns to the right are the byte stacks.  They can be filled
+with cards of the same rank as the goal card in that row.  The
+four right most columns are the bit stacks.  They can be filled
+with cards of the same suit as the goal card in the respective
+row if their least significant bit matches the corresponding
+bit on the goal card.
+<p>
+Cards from the talon are turned over to the waste pile, two at a
+time.  There is only one redeal.
+<p>
+The only function of the Wizards in this game is to block the
+waste stack at the worst possible time.
+
 <h3>Strategy</h3>
-<p>Since there are only four cards of any one rank, it's important
-to fill the byte columns first.</p>
+<p>
+Since there are only four cards of any one rank, it's important
+to fill the byte columns first.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/blackhole.html
+++ b/html-src/rules/blackhole.html
@@ -1,25 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Black Hole</h1>
-<p>Fan game type. 1 deck. No redeal.</p>
+<p>
+Fan game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the single foundation.</p>
+<p>
+Move all cards to the single foundation.
+
 <h3>Rules</h3>
-<p>The foundation (the <i>Black Hole</i>) builds up or down by rank
-ignoring color and suit, wrapping around from King to Ace and from
-Ace to King.</p>
-<p>There is no building on the tableau piles, and spaces are not
-filled. Only the top card can be moved.</p>
+<p>
+The foundation (the <i>Black Hole</i>) builds up or down by rank
+ignoring color and suit, wrapping around from King to Ace
+and from Ace to King.
+<p>
+There is no building on the tableau piles, and spaces
+are not filled.
+Only the top card can be moved.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
+<p>
+<i>Autodrop</i> is disabled for this game.
+
 <h3>Strategy</h3>
-<p>Plan carefully - one wrong move and you may never be able to
-untangle the mess.</p>
-</body>
-</html>
+<p>
+Plan carefully - one wrong move and you may never
+be able to untangle the mess.

--- a/html-src/rules/blackwidow.html
+++ b/html-src/rules/blackwidow.html
@@ -1,21 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Black Widow</h1>
-<p>Spider type. 2 decks. No redeal.</p>
+<p>
+Spider type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="spider.html">Spider</a>, but somewhat easier
-as groups of cards can be moved if they <i>build down by
-rank</i>.</p>
+<p>
+Just like <a href="spider.html">Spider</a>,
+but somewhat easier as groups of cards can be moved
+if they <i>build down by rank</i>.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/blindalleys.html
+++ b/html-src/rules/blindalleys.html
@@ -1,25 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Blind Alleys</h1>
-<p>Klondike type. 1 deck. 1 redeal.</p>
+<p>
+Klondike type. 1 deck. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but 6 piles, anything
-on an empty space, and one redeal.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but 6 piles, anything on an empty space, and one redeal.
+
 <h3>Rules</h3>
-<p>Piles build down by alternate color, and an empty space can be
-filled with any card or sequence.</p>
-<p>Cards from the talon are turned over to the waste pile, one at a
-time. You can move the top card to the playing piles or the
-foundations. There is one redeal.</p>
-<p>You are also permitted to move cards back out of the
-foundations.</p>
-</body>
-</html>
+<p>
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence.
+<p>
+Cards from the talon are turned over to the waste pile, one at a time.
+You can move the top card to the playing piles or the foundations.
+There is one redeal.
+<p>
+You are also permitted to move cards back out of the foundations.

--- a/html-src/rules/blondesandbrunettes.html
+++ b/html-src/rules/blondesandbrunettes.html
@@ -1,16 +1,11 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Blondes and Brunettes</h1>
-<p>Terrace type. 2 decks. No redeal.</p>
+<p>
+Terrace type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/bluemoon.html
+++ b/html-src/rules/bluemoon.html
@@ -1,33 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Blue Moon</h1>
-<p>Montana type. 1 deck. 2 redeals.</p>
+<p>
+Montana type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in ascending sequence by
-suit from Ace to King.</p>
+<p>
+Group all the cards in sets of 13 cards in ascending sequence
+by suit from Ace to King.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="montana.html">Montana</a>, but the Aces are
-moved to the left.<br />
-Gameplay is completely equivalent.</p>
+<p>
+Just like <a href="montana.html">Montana</a>,
+but the Aces are moved to the left.
+<br>Gameplay is completely equivalent.
+
 <h3>Rules</h3>
-<p>This 52-card solitaire starts with the entire deck shuffled and
-dealt out in four rows. The aces are then moved to the left end of
-the layout, making 4 initial free spaces. You may move to a space
-only the card that matches the left neighbor in suit, and is one
-greater in rank. Kings are high, so no cards may be placed to their
-right (they create dead spaces).</p>
-<p>When no moves can be made, cards still out of sequence are
-reshuffled and dealt face up after the ends of the partial
-sequences, leaving a card space after each sequence, so that each
-row looks like a partial sequence followed by a space, followed by
-enough cards to make a row of 14.</p>
+<p>
+This 52-card solitaire starts with the entire deck shuffled and dealt
+out in four rows.  The aces are then moved to the left end of the layout,
+making 4 initial free spaces.  You may move to a space only the card that
+matches the left neighbor in suit, and is one greater in rank.  Kings are
+high, so no cards may be placed to their right (they create dead spaces).
+<p>
+When no moves can be made,  cards still out of sequence are  reshuffled
+and dealt face up after the ends of the partial sequences, leaving a card
+space after each sequence, so that each row looks like a partial sequence
+followed by a space, followed by enough cards to make a row of 14.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/braid.html
+++ b/html-src/rules/braid.html
@@ -1,44 +1,44 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Braid (Der Zopf)</h1>
-<p>Napoleon type. 2 decks. 2 redeals.</p>
+<p>
+Napoleon type. 2 decks. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>This game is somewhat harder and requires thoughtful
-strategy.</p>
-<p>The layout consist of a Braid of 20 cards, two groups of four
-helper fields, four braid fields (each showing a picture of a
-braid), the waste pile, and the eight foundations. The first card
-automatically dealt to a Foundation sets the beginning value for
-all foundations, and an indicator displays the value of that
-card.</p>
-<p>You choose whether the sequences on the foundations will be
-ascending or descending, and your choice is displayed in an
-indicator. The choice is made when you place the first card on a
-foundation which is not the already-determined base card. It must
-follow suit and must have a numerical value of either one more or
-one less than the base card. Ace is considered one higher than
-King, and at the same time one less than Two.</p>
-<p>You may place cards on the foundation from anywhere on the
-table, including the end of the Braid. The eight helper fields can
-be filled from the waste pile but not from the Braid or the braid
-fields. When you move a card from a braid field to the foundation,
-that field is automatically filled with the last card on the Braid
-itself.</p>
-<p>In going through the talon, you are limited to three rounds, and
-an indicator reports on that status.</p>
+<p>
+This game is somewhat harder and requires thoughtful strategy.
+<p>
+The layout consist of a Braid of 20 cards, two groups of four helper
+fields, four braid fields (each showing a picture of a braid), the waste
+pile, and the eight foundations.  The first card automatically dealt to a
+Foundation sets the beginning value for all foundations, and an indicator
+displays the value of that card.
+<p>
+You choose whether the sequences on the foundations will be ascending
+or descending, and your choice is displayed in an indicator.  The choice is
+made when you place the first card on a foundation which is not the
+already-determined base card.
+It must follow suit and must have a numerical value
+of either one more or one less than the base card.  Ace is considered one
+higher than King, and at the same time one less than Two.
+<p>
+You may place cards on the foundation from anywhere on the table,
+including the end of the Braid.  The eight helper fields can be filled from
+the waste pile but not from the Braid or the braid fields.  When you move
+a card from a braid field to the foundation, that field is automatically
+filled with the last card on the Braid itself.
+<p>
+In going through the talon, you are limited to three rounds, and an
+indicator reports on that status.
+
 <h3>Strategy</h3>
-<p>You can use the helper fields to temporarily store cards you
-expect to use soon, and you can leave them open until the right
-card comes up from the Talon.</p>
+<p>
+You can use the helper fields to temporarily store cards you expect to
+use soon, and you can leave them open until the right card comes up from the
+Talon.
+
 <h3>History</h3>
-<p>This is a solitaire variant of German origin.</p>
-</body>
-</html>
+<p>
+This is a solitaire variant of German origin.

--- a/html-src/rules/bridgetsgame.html
+++ b/html-src/rules/bridgetsgame.html
@@ -1,42 +1,39 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Bridget's Game</h1>
 Hex A Deck game type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with sixteen
-rows, one redeal and <a href="../hexadeck.html">Hex A Deck</a>
+Similar to <a href="larasgame.html">Lara's Game</a>
+with sixteen rows, one redeal and
+<a href="../hexadeck.html">Hex A Deck</a>
 variations.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to seventeen piles instead
-of fourteen and if a dealt card is of rank eleven or over one card
-is dealt to the talon. Otherwise the dealing rules are the same.
-<p>Play is the same as Lara's Game with two exceptions. The first
-exception is that there is one redeal. When the talon is empty
-after the first round the cards are gathered up from the tableau
-and dealt to the rows without being shuffled using the same dealing
-rules as in the first round.</p>
-<p>The other exception is the extra reserve stack just to the right
-of the rows and the top foundations. This reserve stack has the
-potential to save a game that would otherwise be lost. The way it
-works is this. When empty it will accept any Wizard card, but only
-from a foundation. Once a Wizard has been played on it, it will
-accept one card only from any row stack. Once played on the stack,
-cards can only be remove from it to a foundation.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to seventeen piles instead of fourteen
+and if a dealt card is of rank eleven or over one card is dealt to
+the talon.  Otherwise the dealing rules are the same.
+<p>
+Play is the same as Lara's Game with two exceptions.  The first exception
+is that there is one redeal.  When the talon is empty after the first
+round the cards are gathered up from the tableau and dealt to the rows
+without being shuffled using the same dealing rules as in the first round.
+<p>
+The other exception is the extra reserve stack just to the right of the
+rows and the top foundations.  This reserve stack has the potential to
+save a game that would otherwise be lost.  The way it works is this.
+When empty it will accept any Wizard card, but only from a foundation.
+Once a Wizard has been played on it, it will accept one card only from
+any row stack.  Once played on the stack, cards can only be remove from
+it to a foundation.
+
 <h3>Strategy</h3>
-Don't play on the extra reserve stack unless you are sure the top
-card will play to a foundation soon.
+Don't play on the extra reserve stack unless you are sure the
+top card will play to a foundation soon.
+
 <h3>Notes</h3>
 This game is dedicated to the memory of Bridget Bishop, hanged as a
 witch on June 10, 1692 in Salem Massachusetts, U. S. A. and to the
 nineteen other victims of that notorious witch hunt.
-</body>
-</html>

--- a/html-src/rules/bridgetsgamedoubled.html
+++ b/html-src/rules/bridgetsgamedoubled.html
@@ -1,45 +1,41 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Bridget's Game</h1>
 Hex A Deck game type. 4 decks. 2 redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with sixteen
-rows, one redeal and <a href="../hexadeck.html">Hex A Deck</a>
-variations. This is the same as <a href=
-"bridgetsgame.html">Bridget's Game</a> with four decks and two
-redeals.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with sixteen rows, one redeal and
+<a href="../hexadeck.html">Hex A Deck</a>
+variations.  This is the same as
+<a href="bridgetsgame.html">Bridget's Game</a>
+with four decks and two redeals.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to seventeen piles instead
-of fourteen and if a dealt card is of rank eleven or over one card
-is dealt to the talon. Otherwise the dealing rules are the same.
-<p>Play is the same as Lara's Game with two exceptions. The first
-exception is that there is one redeal. When the talon is empty
-after the first round the cards are gathered up from the tableau
-and dealt to the rows without being shuffled using the same dealing
-rules as in the first round.</p>
-<p>The other exception is the extra reserve stack just to the right
-of the rows and the top foundations. This reserve stack has the
-potential to save a game that would otherwise be lost. The way it
-works is this. When empty it will accept any Wizard card, but only
-from a foundation. Once a Wizard has been played on it, it will
-accept any two cards from any of the row stacks. Once played on the
-stack, cards can only be removed by playing them to a
-foundation.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to seventeen piles instead of fourteen
+and if a dealt card is of rank eleven or over one card is dealt to
+the talon.  Otherwise the dealing rules are the same.
+<p>
+Play is the same as Lara's Game with two exceptions.  The first exception
+is that there is one redeal.  When the talon is empty after the first
+round the cards are gathered up from the tableau and dealt to the rows
+without being shuffled using the same dealing rules as in the first round.
+<p>
+The other exception is the extra reserve stack just to the right of the
+rows and the top foundations.  This reserve stack has the potential to
+save a game that would otherwise be lost.  The way it works is this.
+When empty it will accept any Wizard card, but only from a foundation.
+Once a Wizard has been played on it, it will accept any two cards from
+any of the row stacks.  Once played on the stack, cards can only be removed
+by playing them to a foundation.
+
 <h3>Strategy</h3>
-Don't play on the extra reserve stack unless you are sure the top
-card will play to a foundation soon.
+Don't play on the extra reserve stack unless you are sure the
+top card will play to a foundation soon.
+
 <h3>Notes</h3>
 This game is dedicated to the memory of Bridget Bishop, hanged as a
 witch on June 10, 1692 in Salem Massachusetts, U. S. A. and to the
 nineteen other victims of that notorious witch hunt.
-</body>
-</html>

--- a/html-src/rules/bristol.html
+++ b/html-src/rules/bristol.html
@@ -1,18 +1,14 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Bristol</h1>
-<p>Fan game type. 1 deck. No redeal.</p>
+<p>
+Fan game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-<p>Empty piles cannot be filled - therefore all Kings are placed at
-the bottom of a pile during the initial dealing.</p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>
+<p>
+Empty piles cannot be filled - therefore all Kings are placed
+at the bottom of a pile during the initial dealing.

--- a/html-src/rules/brunswick.html
+++ b/html-src/rules/brunswick.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Brunswick</h1>
-<p>Yukon type. 2 decks. No redeal.</p>
+<p>
+Yukon type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="lexingtonharp.html">Lexington Harp</a>, but
-deal all cards face-up.<br />
-Very easy.</p>
+<p>
+Just like <a href="lexingtonharp.html">Lexington Harp</a>,
+but deal all cards face-up.
+<br>Very easy.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/busyaces.html
+++ b/html-src/rules/busyaces.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Busy Aces</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but with 12
-piles.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but with 12 piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/calculation.html
+++ b/html-src/rules/calculation.html
@@ -1,28 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Calculation</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The four foundations build regardless of suit the following way:
+<p>
+The four foundations build regardless of suit the following way:
 The first pile from Ace, by one. The second pile from Two, by two.
-The third pile from Three, by three. The fourth pile from Four, by
-four.</p>
-<pre>
+The third pile from Three, by three. The fourth pile from Four, by four.
+<pRE>
 1:  A 2 3 4 5 6 7 8 9 T J Q K
 2:  2 4 6 8 T Q A 3 5 7 9 J K
 3:  3 6 9 Q 2 5 8 J A 4 7 T K
 4:  4 8 Q 3 7 J 2 6 T A 5 9 K
-</pre>
+</pRE>
 Once on a stack, a card can only be moved onto a foundation.
+
 <h3>Notes</h3>
-<p>The auto-solver is completely clueless.</p>
-</body>
-</html>
+<p>
+The auto-solver is completely clueless.

--- a/html-src/rules/camelot.html
+++ b/html-src/rules/camelot.html
@@ -1,45 +1,53 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Camelot</h1>
+
 <h3>Object</h3>
-<p>Remove all cards but picture cards (Jacks, Queens, and Kings).
-You have won if your Tableau looks like this --<br />
-<img src="../images/camelot-goal.gif" alt=
-"The Winning Tableau." /></p>
-<p>-- and your Stock and Waste are empty. The suits do not
-matter.</p>
+
+<p>
+Remove all cards but picture cards (Jacks, Queens, and Kings).  You have
+won if your Tableau looks like this -- <br>
+
+<img src="../images/camelot-goal.gif" alt="The Winning Tableau.">
+
+<p>
+-- and your Stock and Waste are empty. The suits do not matter.
+
 <h3>Rules</h3>
-<p>There are two phases to this game. Alternate between the two
-phases until game is lost or won. Start with Phase One until
-Tableau is completely filled. At that point, move to Phase Two.
-Please note that you cannot begin Phase Two unless Tableau is
-completely filled. At any point, you can return to Phase One, but
-remember that you cannot go back to Phase Two unless the tableau is
-once again filled. An exception to this rule is if the stock and
-waste are empty.</p>
-<p>Phase One -- Click on the Stock to move a card into the empty
-Waste pile. If card is a:</p>
+
+<p>
+There are two phases to this game.  Alternate between the two phases
+until game is lost or won.  Start with Phase One until Tableau is
+completely filled.  At that point, move to Phase Two.  Please note that
+you cannot begin Phase Two unless Tableau is completely filled.  At any
+point, you can return to Phase One, but remember that you cannot go back
+to Phase Two unless the tableau is once again filled.  An exception to
+this rule is if the stock and waste are empty.
+
+<p>
+Phase One -- Click on the Stock to move a card into the empty Waste pile.  If
+card is a:
 <ul type="disc">
-<li>King: Place in one of the empty four corner spaces.</li>
-<li>Queen: Place in one of the empty middle two spaces of the top
-or bottom row.</li>
-<li>Jack: Place in any of the empty middle two spaces of the
-leftmost or rightmost column.</li>
-<li>Any other card: Place in any empty space.</li>
+<li>
+King: Place in one of the empty four corner spaces.
+</li>
+<li>
+Queen: Place in one of the empty middle two spaces of the top or bottom row.
+</li>
+<li>
+Jack: Place in any of the empty middle two spaces of the leftmost or rightmost
+column.
+</li>
+<li>
+Any other card:  Place in any empty space.
+</li>
 </ul>
-<p>Phase Two -- Remove 10's singly by clicking on them. Remove
-pairs that add up to 10 by dragging one card on top of its
-pair.</p>
+
+<p>
+Phase Two -- Remove 10's singly by clicking on them.  Remove pairs that
+add up to 10 by dragging one card on top of its pair.
+
 <h3>Strategy</h3>
-<p>It is always safest in the middle. During Phase One of play,
-deal in the middle before going to the edges. If you see a possible
-pair, place that card on the edge so as to free more edge spaces
-during Phase Two of play.</p>
-</body>
-</html>
+<p>
+It is always safest in the middle.  During Phase One of play, deal in
+the middle before going to the edges.  If you see a possible pair, place
+that card on the edge so as to free more edge spaces during Phase Two of
+play.

--- a/html-src/rules/canfield.html
+++ b/html-src/rules/canfield.html
@@ -1,44 +1,44 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Canfield</h1>
-<p>Canfield type. 1 deck. Unlimited redeals.</p>
+<p>
+Canfield type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Canfield is played with one deck. The object is to build all
-four of the foundations at the top right from the rank of the first
-card dealt into there (varies from game to game), all in the same
-suit.</p>
-<p>The tableau consists of four piles, starting with one card each.
-The cards can be stacked according to the following rules</p>
+<p>
+Canfield is played with one deck. The object is to build all four
+of the foundations at the top right from the rank of the first card
+dealt into there (varies from game to game), all in the same suit.
+<p>
+The tableau consists of four piles, starting with one card each.  The
+cards can be stacked according to the following rules
 <ul>
-<li>Red cards may be only played on black cards, and black only on
-red.</li>
-<li>Only the next smaller card may be played, so that the stacks
-are in descending sequence except when the previous card is an Ace,
-in which only the King may be played.</li>
-<li>You may not move parts of a sequence except the top card.</li>
-<li>Empty spaces in the tableau will be filled automatically from
-the reserve (the pile below the talon) until it is exhausted. When
-the reserve is exhausted, the empty spaces can be filled with any
-card.</li>
+<li> Red cards may be only played on black cards, and black only on
+  red.
+<li> Only the next smaller card may be played, so that the stacks
+  are in descending sequence except when the previous card is an Ace,
+  in which only the King may be played.
+<li> You may not move parts of a sequence except the top card.
+<li> Empty spaces in the tableau will be filled automatically from
+  the reserve (the pile below the talon) until it is exhausted.  When
+  the reserve is exhausted, the empty spaces can be filled with any
+  card.
 </ul>
-<p>When there are no more possible moves, click on the talon. Three
-cards will be moved from the talon to the waste pile directly to
-its right.</p>
+<p>
+When there are no more possible moves, click on the talon.  Three
+cards will be moved from the talon to the waste pile directly to its
+right.
+
 <h3>Notes</h3>
-<p>The auto-solver is hopeless. Don't believe the hints. They tend
-to be right but it doesn't figure everything out (there may be
-valid moves that it won't guess).</p>
+<p>
+The auto-solver is hopeless.  Don't believe the hints.  They tend to
+be right but it doesn't figure everything out (there may be valid
+moves that it won't guess).
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:drew_csillag@geocities.com">Drew Csillag</a> and is part of
-the official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:drew_csillag@geocities.com">Drew Csillag</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/carlton.html
+++ b/html-src/rules/carlton.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Carlton</h1>
-<p>Yukon type. 2 decks. No redeal.</p>
+<p>
+Yukon type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="milliganharp.html">Milligan Harp</a>, but
-deal all cards face-up.</p>
+<p>
+Just like <a href="milliganharp.html">Milligan Harp</a>,
+but deal all cards face-up.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/carpet.html
+++ b/html-src/rules/carpet.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Carpet</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The four foundations are built up in suit from Ace to King.</p>
-<p>The 20 reserve piles can hold any single card.</p>
-<p>When you click on the talon, one card is turned over onto the
-waste pile. There is no redeal.</p>
-</body>
-</html>
+<p>
+The four foundations are built up in suit from Ace to King.
+<p>
+The 20 reserve piles can hold any single card.
+<p>
+When you click on the talon, one card is turned over onto the waste pile.
+There is no redeal.

--- a/html-src/rules/casinoklondike.html
+++ b/html-src/rules/casinoklondike.html
@@ -1,24 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Casino Klondike</h1>
-<p>Klondike type. 1 deck. 2 redeals.</p>
+<p>
+Klondike type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="klondike.html">Klondike</a>, but only two
-redeals.</p>
+<p>
+Just like <a href="klondike.html">Klondike</a>,
+but only two redeals.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>Notes</h3>
-<p>There is a simple casino scoring system here - you debit $52 for
-each game and for every card you bear off, you get $5 credit. Your
-balance is reset whenever you select a different game. Loaded games
-and manually entered game numbers don't count.</p>
-</body>
-</html>
+<p>
+There is a simple casino scoring system here - you debit $52 for each game
+and for every card you bear off, you get $5 credit.
+Your balance is reset whenever you select a different game.
+Loaded games and manually entered game numbers don't count.

--- a/html-src/rules/castlesinspain.html
+++ b/html-src/rules/castlesinspain.html
@@ -1,17 +1,13 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Castles in Spain</h1>
-<p>Baker's Dozen type. 1 deck. No redeal.</p>
+<p>
+Baker's Dozen type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The piles build down by alternate color. Only one card can be
-moved at a time, and empty piles can be filled with any card.</p>
-</body>
-</html>
+<p>
+The piles build down by alternate color.
+Only one card can be moved at a time, and empty piles
+can be filled with any card.

--- a/html-src/rules/catstail.html
+++ b/html-src/rules/catstail.html
@@ -1,25 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Cat's Tail (Der Katzenschwanz)</h1>
-<p>FreeCell type. 2 decks. No redeal.</p>
+<p>
+FreeCell type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, but the number of cards you
-can move as a sequence is not restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+but the number of cards you can move as a sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-King starting a new pile. To compensate for this there are 8 free
-cells which can hold any - and just one - card.</p>
-<p>Piles build down by alternate color, and an empty space cannot
-be filled.</p>
+<p>
+All cards are dealt to 9 piles at the start of the game, each King
+starting a new pile.
+To compensate for this there are 8 free cells which can hold any
+- and just one - card.
+<p>
+Piles build down by alternate color, and an empty space cannot be filled.
+
 <h3>History</h3>
-<p>This is a solitaire variant of German origin.</p>
-</body>
-</html>
+<p>
+This is a solitaire variant of German origin.

--- a/html-src/rules/cavalier.html
+++ b/html-src/rules/cavalier.html
@@ -1,28 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Cavalier</h1>
 Tarock type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-This is a <a href="bakersdozen.html">Baker's Dozen</a> type game
-played with the 78 card Tarock deck. Piles build down in rank in
-alternate colors. The Trumps can play as either color.
+This is a
+<a href="bakersdozen.html">Baker's Dozen</a>
+type game played with the 78 card Tarock deck.  Piles build down
+in rank in alternate colors.  The Trumps can play as either color.
+
 <h3>Rules</h3>
 Rows build down in rank by alternate color with the Trumps playing
-as either color. A pile may be moved to another location but only a
-single card may be played on an empty row. Cards may be played from
-the foundations.
+as either color.  A pile may be moved to another location but only
+a single card may be played on an empty row.  Cards may be played
+from the foundations.
+
 <h3>Strategy</h3>
 Use the Trumps to open spots for suit cards.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/chameleon.html
+++ b/html-src/rules/chameleon.html
@@ -1,21 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Chameleon</h1>
-<p>Canfield type. 1 deck. No redeal.</p>
+<p>
+Canfield type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="canfield.html">Canfield</a>, but the three piles
-build down by rank, cards are dealt singly, and no redeal.</p>
+<p>
+Like <a href="canfield.html">Canfield</a>,
+but the three piles build down by rank,
+cards are dealt singly, and no redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>History</h3>
-<p>This game is also known under names such as <i>Kansas</i>.</p>
-</body>
-</html>
+<p>
+This game is also known under names such as
+<i>Kansas</i>.

--- a/html-src/rules/cherrybomb.html
+++ b/html-src/rules/cherrybomb.html
@@ -1,31 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Cherry Bomb</h1>
 Hanafuda type. 2 decks. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-This is a double deck version of <a href="firecracker.html">Fire
-Cracker</a>. The rows build down in rank in the same suit. The
-foundations build with cards of the same rank in suit order.
+This is a double deck version of
+<a href="firecracker.html">Fire Cracker</a>.
+The rows build down in rank in the same suit.  The foundations
+build with cards of the same rank in suit order.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build in ascending suit order from Pine to Phoenix by
-rank. The third and fourth rank (trash) cards are interchangeable
-on the tableau. Cards may not be played from the foundations. Any
-card or correctly ordered pile may be played on an empty row.
+The rows build from first rank to fourth rank by suit.  The foundations
+build in ascending suit order from Pine to Phoenix by rank.  The third
+and fourth rank (trash) cards are interchangeable on the tableau.  Cards
+may not be played from the foundations.  Any card or correctly ordered
+pile may be played on an empty row.
+
 <h3>Strategy</h3>
-Build sequences on the tableau. Since the trash cards are
-interchangeable it's possible to build a valid sequence that has
-more than four cards in a two deck game.
+Build sequences on the tableau.  Since the trash cards are interchangeable
+it's possible to build a valid sequence that has more than four cards in
+a two deck game.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/chessboard.html
+++ b/html-src/rules/chessboard.html
@@ -1,22 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Chessboard</h1>
-<p>Beleaguered Castle type. 1 deck. No redeal.</p>
+<p>
+Beleaguered Castle type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations build up in suit, wrapping around from King to
-Ace. The first card moved to the foundations determines the base
-rank.</p>
-<p>The ten piles build <b>up or down</b> in suit, wrapping around
-from King to Ace and from Ace to King.</p>
-<p>Only one card can be moved at a time and empty piles can be
-filled with any single card.</p>
-</body>
-</html>
+<p>
+The foundations build up in suit, wrapping around from King to Ace.
+The first card moved to the foundations determines the base rank.
+<p>
+The ten piles build <b>up or down</b> in suit, wrapping around from
+King to Ace and from Ace to King.
+<p>
+Only one card can be moved at a time and
+empty piles can be filled with any single card.

--- a/html-src/rules/chinesediscipline.html
+++ b/html-src/rules/chinesediscipline.html
@@ -1,26 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Chinese Discipline</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="yukon.html">Yukon</a>, but don't deal all cards at
-game start.</p>
+<p>
+Like <a href="yukon.html">Yukon</a>,
+but don't deal all cards at game start.
+
 <h3>Rules</h3>
-<p>Cards in Tableau are built down by alternate color. Groups of
-cards can be moved regardless of sequence. An empty pile in the
-Tableau can be filled with a King or a group of cards with a King
-on the bottom.</p>
-<p>Foundations are built up in suit from Ace to King. Cards in
-Foundations are no longer in play.</p>
-<p>When no more moves are possible, click on the Talon. Three more
-cards will be dealt.</p>
-</body>
-</html>
+<p>
+Cards in Tableau are built down by alternate color.
+Groups of cards can be moved regardless of sequence.
+An empty pile in the Tableau can be filled with a King or a group
+of cards with a King on the bottom.
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in Foundations are no longer in play.
+<p>
+When no more moves are possible, click on the Talon.
+Three more cards will be dealt.

--- a/html-src/rules/chinesesolitaire.html
+++ b/html-src/rules/chinesesolitaire.html
@@ -1,21 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Chinese Solitaire</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="chinesediscipline.html">Chinese
-Discipline</a>, but anything on an empty space.</p>
+<p>
+Just like <a href="chinesediscipline.html">Chinese Discipline</a>,
+but anything on an empty space.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-<p>When no more moves are possible, click on the Talon. Three more
-cards will be dealt.</p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>
+<p>
+When no more moves are possible, click on the Talon.
+Three more cards will be dealt.

--- a/html-src/rules/citadel.html
+++ b/html-src/rules/citadel.html
@@ -1,20 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Citadel</h1>
-<p>Beleaguered Castle type. 1 deck. No redeal.</p>
+<p>
+Beleaguered Castle type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="beleagueredcastle.html">Beleaguered
-Castle</a>, but matching cards are moved to the foundations during
-initial dealing.</p>
+<p>
+Just like <a href="beleagueredcastle.html">Beleaguered Castle</a>,
+but matching cards are moved to the foundations during initial dealing.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/cluitjarslair.html
+++ b/html-src/rules/cluitjarslair.html
@@ -1,29 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Cluitjar's Lair</h1>
 Klondike type. One deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="klondike.html">Klondike</a> with <a href=
-"../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="klondike.html">Klondike</a>
+with <a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like Klondike. The rows build down in rank in
-alternate color. Any card or sequence may be played on an empty
-row. The Wizards will play in their proper rank position on the
-tableau regardless of color. While two or more Wizards will play on
-top of each other, the stack must still be of alternating colors to
-be a movable sequence. Cards are dealt from the talon one at a
-time. There is no redeal. Cards may be played from the foundations.
+Game play is like Klondike.  The rows build down in rank in alternate
+color.  Any card or sequence may be played on an empty row.  The Wizards
+will play in their proper rank position on the tableau regardless of
+color.  While two or more Wizards will play on top of each other, the stack
+must still be of alternating colors to be a movable sequence.  Cards are
+dealt from the talon one at a time.  There is no redeal.  Cards may be
+played from the foundations.
 <h3>Strategy</h3>
-The Wizards will not play to their foundation until all the suit
-cards are on theirs. That can make the end game a bit of a puzzle.
-Use an empty row to move them out of the way.
-</body>
-</html>
+The Wizards will not play to their foundation until all the suit cards
+are on theirs.  That can make the end game a bit of a puzzle.  Use an
+empty row to move them out of the way.

--- a/html-src/rules/cockroach.html
+++ b/html-src/rules/cockroach.html
@@ -1,17 +1,13 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Cockroach</h1>
-<p>Tarock type. 1 deck. No redeal.</p>
+<p>
+Tarock type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Play is identical to <a href="grasshopper.html">Grasshopper</a>
-except there is no redeal.</p>
-</body>
-</html>
+<p>
+Play is identical to
+<a href="grasshopper.html">Grasshopper</a>
+except there is no redeal.

--- a/html-src/rules/concentration.html
+++ b/html-src/rules/concentration.html
@@ -1,26 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Concentration</h1>
-<p>Memory game type. 1 deck. No redeal.</p>
+<p>
+Memory game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Flip all pairs of matching cards and get a score of 50 points or
-more.</p>
+<p>
+Flip all pairs of matching cards and get a score of 50 points or more.
+
 <h3>Rules</h3>
-<p>At game start 52 cards are dealt to the tableau piles.</p>
-<p>Flip any 2 cards that match in rank.</p>
-<p>Any pair that matches will gain you 5 points, while a pair that
-doesn't match will cost you 1 point.</p>
-<p>You win if your final score reaches 50 points.</p>
+<p>
+At game start 52 cards are dealt to the tableau piles.
+<p>
+Flip any 2 cards that match in rank.
+<p>
+Any pair that matches will gain you 5 points, while a pair that
+doesn't match will cost you 1 point.
+<p>
+You win if your final score reaches 50 points.
+
 <h3>Notes</h3>
-<p>To get awarded for a perfect game you must reach the maximum
-score of 130 points. You can reach this by restarting the game.</p>
-<p><i>Undo</i>, <i>Bookmarks</i>, <i>Autodrop</i> and
-<i>Quickplay</i> are disabled for this game.</p>
-</body>
-</html>
+<p>
+To get awarded for a perfect game you must reach the maximum score of
+130 points. You can reach this by restarting the game.
+<p>
+<i>Undo</i>, <i>Bookmarks</i>, <i>Autodrop</i> and <i>Quickplay</i>
+are disabled for this game.

--- a/html-src/rules/congress.html
+++ b/html-src/rules/congress.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Congress</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the 8
-piles build down by rank ignoring suit, and empty piles are
-automatically filled from the waste or talon,</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the 8 piles build down by rank ignoring suit,
+and empty piles are automatically filled from the waste or talon,
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/convolution.html
+++ b/html-src/rules/convolution.html
@@ -1,23 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Convolution</h1>
-<p>FreeCell type. Two Hex A Decks. No redeal.</p>
+<p>
+FreeCell type.  Two Hex A Decks.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, with the Hex A Deck
-Variations and the number of cards you can move as a sequence is
-not restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+with the Hex A Deck Variations and the number of cards you can move as a
+sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-King or "Ten" (hexadecimal) starting a new pile. Rows build down in
-rank regardless of color and empty rows cannot be filled. The
-Wizards play as any color.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each King or "Ten"
+(hexadecimal) starting a new pile.  Rows build down in rank regardless of
+color and empty rows cannot be filled.  The Wizards play as any color.

--- a/html-src/rules/corkscrew.html
+++ b/html-src/rules/corkscrew.html
@@ -1,23 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Corkscrew</h1>
-<p>FreeCell type. Two Tarock Decks. No redeal.</p>
+<p>
+FreeCell type.  Two Tarock Decks.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, using two 78 card Tarock
-decks and the number of cards you can move as a sequence is not
-restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+using two 78 card Tarock decks and the number of cards you can move as a
+sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-King or Skiz starting a new pile. Rows build down in rank
-regardless of suit. Empty rows cannot be filled. The eight free
-cells will hold one card each.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each King or Skiz
+starting a new pile.  Rows build down in rank regardless of suit.
+Empty rows cannot be filled. The eight free cells will hold one card each.

--- a/html-src/rules/corona.html
+++ b/html-src/rules/corona.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Corona</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but empty
-piles are automatically filled from the waste or talon.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but empty piles are automatically filled from the waste or talon.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/courtyard.html
+++ b/html-src/rules/courtyard.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Courtyard</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but with 12
-piles, sequences can be moved, and empty piles are automatically
-filled from the waste or talon.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but with 12 piles, sequences can be moved,
+and empty piles are automatically filled from the waste or talon.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/cruel.html
+++ b/html-src/rules/cruel.html
@@ -1,20 +1,15 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Cruel</h1>
-<p>Baker's Dozen type. 1 deck. Unlimited redeals.</p>
+<p>
+Baker's Dozen type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The piles build down by suit. Only one card can be moved at a
-time, and empty spaces cannot be filled.</p>
-<p>When no more moves are possible click on the talon for a redeal.
-The cards are not re-shuffled, but re-dealt in packs of 4
-cards.</p>
-</body>
-</html>
+<p>
+The piles build down by suit.
+Only one card can be moved at a time, and empty spaces cannot be filled.
+<p>
+When no more moves are possible click on the talon for a redeal.
+The cards are not re-shuffled, but re-dealt in packs of 4 cards.

--- a/html-src/rules/daddylonglegs.html
+++ b/html-src/rules/daddylonglegs.html
@@ -1,35 +1,14 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Daddy Longlegs</h1>
 <p>Spider type. 1 deck. No redeal.</p>
 <h3>Object</h3>
-<p>Group all the cards into four sets of 13 cards by suit in
-ascending sequence from Ace to King.</p>
+<p>Group all the cards into four sets of 13 cards by suit in ascending sequence from Ace to King.</p>
 <h3>Rules</h3>
-<p>Cards are dealt four at a time, one card into each of four
-piles. A card can be moved onto the end of another pile, if it is
-the same suit and follows in sequence. The rest of the pile moves
-with the card. Only an Ace (with the rest of its pile) can move to
-an empty space.</p>
-<p>At any time, you can deal more cards by clicking on the talon.
-One card will be added to each of the playing piles.</p>
+<p>Cards are dealt four at a time, one card into each of four piles.  A card can be moved onto the end of another pile, if it is the same suit and follows in sequence.  The rest of the pile moves with the card.  Only an Ace (with the rest of its pile) can move to an empty space.</p>
+<p>At any time, you can deal more cards by clicking on the talon. One card will be added to each of the playing piles.</p>
 <h3>History</h3>
-<p>I created Daddy Longlegs in the early 1980's to amuse myself
-with a different solitaire variant. Over the years, I have
-implemented this game many times under the name of "Deal Four" as
-an exercise when learning new programming languages.</p>
-<p>I learned of pysol in 2006 and almost immediately realized that
-it is a perfect platform for Daddy Longlegs. Thank you, Markus
-Oberhumer!</p>
+<p>I created Daddy Longlegs in the early 1980's to amuse myself with a different solitaire variant.  Over the years, I have implemented this game many times under the name of "Deal Four" as an exercise when learning new programming languages.</p>
+<p>I learned of pysol in 2006 and almost immediately realized that it is a perfect platform for Daddy Longlegs.  Thank you, Markus Oberhumer!</p>
 <h3>Author</h3>
 <p>Jim Sizelove</p>
 <p>sizelji@comcast.net</p>
 <p>March 8, 2007</p>
-</body>
-</html>

--- a/html-src/rules/danda.html
+++ b/html-src/rules/danda.html
@@ -1,24 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Danda</h1>
-<p>FreeCell type. One Moghul Ganjifa Deck. No redeal.</p>
+<p>
+FreeCell type.  One Moghul Ganjifa Deck.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, using the eight suit Moghul
-Ganjifa deck and the number of cards you can move as a sequence is
-not restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+using the eight suit Moghul Ganjifa deck and the number of cards you can move
+as a sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-Raja or King starting a new pile. Rows build down in rank by
-alternate force suits. Refer to the general <a href=
-"ganjifa.html">Ganjifa</a> page. Empty rows cannot be filled. The
-eight free cells will hold one card each.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each Raja or King
+starting a new pile.  Rows build down in rank by alternate force suits.
+Refer to the general <a href="ganjifa.html">Ganjifa</a> page.
+Empty rows cannot be filled. The eight free cells will hold one card each.

--- a/html-src/rules/dashavatara.html
+++ b/html-src/rules/dashavatara.html
@@ -1,38 +1,36 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Dashavatara</h1>
-<p>One Dashavatara Ganjifa deck. No redeal.</p>
+<p>
+One Dashavatara Ganjifa deck. No redeal.
+
 <h3>Object</h3>
-<p>Arrange the Ten Avatars in order.</p>
+<p>
+Arrange the Ten Avatars in order.
+
 <h3>Rules</h3>
-<p>Play is similar to <a href="picturegallery.html">Picture
-Gallery</a>. The layout consists of three rows of playing piles, a
-row for newly dealt cards and three free cells that will hold one
-card each.</p>
-<p>The cards must be arranged in the top three rows as follows:</p>
+<p>
+Play is similar to <a href="picturegallery.html">Picture Gallery</a>.
+The layout consists of three rows of playing piles, a row for newly
+dealt cards and three free cells that will hold one card each.
+<p>
+The cards must be arranged in the top three rows as follows:
 <ul>
-<li>The top row must start with a three and build by suit in
-increments of three,</li>
-<li>the second row must with a two,</li>
-<li>and the third row must start with an Ace.</li>
+<li>The top row must start with a three and build by suit in increments of three,
+<li>the second row must with a two,
+<li>and the third row must start with an Ace.
 </ul>
-<p>If you clear a space at the bottom it will be automatically
-filled with a card from the talon. But if the talon is gone and you
-clear a space at the bottom, then you can fill it with any card.
-You may move any card to the free cells from the tableau on top or
-the rows below, but only as long as there are cards left in the
-talon. When the talon is empty, you may only move cards from, not
-to the free cells. When no further moves are possible, click on the
-talon for a fresh row of cards at the bottom.</p>
-<p>You win when all of the suits are arranged in order.</p>
+<p>
+If you clear a space at the bottom it will be automatically filled
+with a card from the talon. But if the talon is gone and you clear a space
+at the bottom, then you can fill it with any card.  You may move any card
+to the free cells from the tableau on top or the rows below, but only as
+long as there are cards left in the talon.  When the talon is empty, you
+may only move cards from, not to the free cells.
+When no further moves are possible, click on the talon for a fresh row
+of cards at the bottom.
+<p>
+You win when all of the suits are arranged in order.
+
 <h3>Strategy</h3>
-<p>Because of the many piles involved the Picture Gallery requires
-some concentration, but it is not too hard to win.</p>
-</body>
-</html>
+<p>
+Because of the many piles involved the Picture Gallery requires some
+concentration, but it is not too hard to win.

--- a/html-src/rules/dashavataracircles.html
+++ b/html-src/rules/dashavataracircles.html
@@ -1,27 +1,14 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Dashavatara Circles</h1>
 Dashavatara Ganjifa type. One deck. No redeal.
 <h3>Object</h3>
 Move all cards to the foundations.
 <h3>Quick description</h3>
-The cards build down by rank and by suit on the tableau. Any card
-may be played on an empty row. Only one card may be moved at a
-time.
+The cards build down by rank and by suit on the tableau.  Any card may be
+played on an empty row.  Only one card may be moved at a time.
 <h3>Rules</h3>
-All cards are dealt to the thirty two rows when the games begins.
-Cards on the tableau build down by suit in descending rank order.
-The foundations build up by suit. Any card may be played on an
-empty row. The reserve stacks hold one card each. Only one card at
-a time may be moved.
+All cards are dealt to the thirty two rows when the games begins.  Cards
+on the tableau build down by suit in descending rank order.  The foundations
+build up by suit.  Any card may be played on an empty row. The reserve stacks
+hold one card each. Only one card at a time may be moved.
 <h3>Strategy</h3>
-Try to keep a reserve stack open. Play higher ranked cards on empty
-rows.
-</body>
-</html>
+Try to keep a reserve stack open.  Play higher ranked cards on empty rows.

--- a/html-src/rules/deadkinggolf.html
+++ b/html-src/rules/deadkinggolf.html
@@ -1,21 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Dead King Golf</h1>
-<p>Golf type. 1 deck. No redeal.</p>
+<p>
+Golf type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the waste stack.</p>
+<p>
+Move all cards to the waste stack.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="golf.html">Golf</a>, but <em>nothing</em> may
-be placed on a King.</p>
+<p>
+Just like <a href="golf.html">Golf</a>,
+but <em>nothing</em> may be placed on a King.
+
 <h3>Rules</h3>
 <i>[To be written]</i>
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/derfreienapoleon.html
+++ b/html-src/rules/derfreienapoleon.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Der freie Napoleon</h1>
-<p>Napoleon type. 1 deck. No redeal.</p>
+<p>
+Napoleon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="derkleinenapoleon.html">Der kleine
-Napoleon</a>, only with a different screen layout.<br />
-Gameplay is completely equivalent.</p>
+<p>
+Just like <a href="derkleinenapoleon.html">Der kleine Napoleon</a>,
+only with a different screen layout.
+<br>Gameplay is completely equivalent.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/derkleinenapoleon.html
+++ b/html-src/rules/derkleinenapoleon.html
@@ -1,42 +1,46 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Der kleine Napoleon</h1>
-<p>Napoleon type. 1 deck. No redeal.</p>
+<p>
+Napoleon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>This game is somewhat harder and requires thoughtful
-strategy.</p>
-<p>The layout consist of 4 foundations in the middle, 8 row stacks
-(4 on each of the left and right side), 2 reserve stacks (one on
-each of the left and right side), and a free cell in the
-middle.</p>
-<p>The row stacks and reserve stacks grow from the middle and are
-laid out open, but only the outer card is in play.</p>
-<p>The foundations build either up or down in suit, depending on
-the first card you play there. They wrap around from King to Ace
-and Ace to King.</p>
-<p>The 8 row stacks build both up and down in suit, also wrapping
-around. Only a single card can be moved, and free rows can be
-filled with any single card.</p>
-<p>There is no building on the 2 reserve stacks. Cards can only be
-moved to other stacks from there.</p>
-<p>Finally there is one extra free cell that can hold any single
-card. But to move a card back from the free cell at least one of
-the two "blocking" reserve stacks must have been cleared.</p>
+<p>
+This game is somewhat harder and requires thoughtful strategy.
+<p>
+The layout consist of 4 foundations in the middle,
+8 row stacks (4 on each of the left and right side),
+2 reserve stacks (one on each of the left and right side),
+and a free cell in the middle.
+<p>
+The row stacks and reserve stacks grow from the middle and are laid out
+open, but only the outer card is in play.
+<p>
+The foundations build either up or down in suit, depending on the
+first card you play there.
+They wrap around from King to Ace and Ace to King.
+<p>
+The 8 row stacks build both up and down in suit, also wrapping around.
+Only a single card can be moved, and free rows can be filled with
+any single card.
+<p>
+There is no building on the 2 reserve stacks. Cards can only be moved
+to other stacks from there.
+<p>
+Finally there is one extra free cell that can hold any single card.
+But to move a card back from the free cell at least one of the
+two "blocking" reserve stacks must have been cleared.
+
 <h3>Notes</h3>
-<p>Try <a href="derfreienapoleon.html">Der freie Napoleon</a> if
-you have troubles understanding the rules - it is the exactly same
-game in a different layout.</p>
+<p>
+Try <a href="derfreienapoleon.html">Der freie Napoleon</a> if
+you have troubles understanding the rules - it is the exactly
+same game in a different layout.
+
 <h3>Strategy</h3>
-<p>Decide carefully if you build the foundations up or down.</p>
-<p>Getting a free row stack should be one of your highest
-priorities.</p>
-</body>
-</html>
+<p>
+Decide carefully if you build the foundations up or down.
+<p>
+Getting a free row stack should be one of your highest priorities.

--- a/html-src/rules/deuces.html
+++ b/html-src/rules/deuces.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Deuces</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the
-foundations build up from Two to Ace.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the foundations build up from Two to Ace.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/dhanpati.html
+++ b/html-src/rules/dhanpati.html
@@ -1,31 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Dhanpati</h1>
 Mughal Ganjifa type. One deck. One redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank regardless of suit.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank regardless of suit.
+
 <h3>Rules</h3>
-The cards on the tableau build down by rank. The foundations build
-up in rank by suit starting with the Ace. Only the Mirs (Kings) may
-be played on an empty row. Cards are dealt from the talon three at
-a time. There is only one redeal. Cards may not be played from the
+The cards on the tableau build down by rank.  The foundations build
+up in rank by suit starting with the Ace.  Only the Mirs (Kings) may
+be played on an empty row.  Cards are dealt from the talon three at
+a time.  There is only one redeal.  Cards may not be played from the
 foundations.
-<p>This game is one of a series of games that have names ending in
-"pati" which transliterates as "lord of". Dhanpati means "Lord of
-Treasure". The names are the names of the suits in a twelve suit
-Ganjifa deck.</p>
+<p>
+This game is one of a series of games that have names ending in "pati"
+which transliterates as "lord of".  Dhanpati means "Lord of Treasure".
+The names are the names of the suits in a twelve suit Ganjifa deck.
+
 <h3>Strategy</h3>
-Move cards back and forth on the rows to make every play possible
-on the first pass through the talon. Don't let the waste stack get
-too deep on the second pass.
-</body>
-</html>
+Move cards back and forth on the rows to make every play possible on
+the first pass through the talon.  Don't let the waste stack get too
+deep on the second pass.

--- a/html-src/rules/diamondmine.html
+++ b/html-src/rules/diamondmine.html
@@ -1,27 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Diamond Mine</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Remove all diamonds to the foundation and have all the other
-cards in suit and sequence with Aces being low in the Tableau.</p>
+<p>
+Remove all diamonds to the foundation and have all the other cards in suit and
+sequence with Aces being low in the Tableau.
+
 <h3>Rules</h3>
-<p>Cards (other than diamonds) can be built down in sequence
-regardless of suit. Builds of cards can be moved as a unit. Empty
-slots can be filled by any card (except for diamonds) or build of
-cards.</p>
-<p>Diamonds cannot be moved except to be place on to the
-Foundation. The diamond Foundation must be built up in sequence but
-can start from any number you want.</p>
+<p>
+Cards (other than diamonds) can be built down in sequence regardless of suit.
+Builds of cards can be moved as a unit. Empty slots can be filled by any card
+(except for diamonds) or build of cards.
+<p>
+Diamonds cannot be moved except to be place on to the Foundation. The diamond
+Foundation must be built up in sequence but can start from any number you
+want.
+
 <h3>Strategy</h3>
-<p>Mining for diamonds is hard work. Keep in mind that not all
-diamonds are worth the same. Don't forget to clean up after
-yourself and put the other suits in order.</p>
-</body>
-</html>
+<p>
+Mining for diamonds is hard work. Keep in mind that not all diamonds are worth
+the same. Don't forget to clean up after yourself and put the other suits in
+order.

--- a/html-src/rules/diekoenigsbergerin.html
+++ b/html-src/rules/diekoenigsbergerin.html
@@ -1,21 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
-<h1>Die Königsbergerin</h1>
-<p>Gypsy type. 2 decks. No redeal.</p>
+<h1>Die K&ouml;nigsbergerin</h1>
+<p>
+Gypsy type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="gypsy.html">Gypsy</a>, but Aces go off during
-dealing, and cards in the foundations are no longer in play.</p>
+<p>
+Like <a href="gypsy.html">Gypsy</a>,
+but Aces go off during dealing, and cards in the foundations
+are no longer in play.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-<p>You are <em>not</em> permitted to move cards back out of the
-foundations.</p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>
+<p>
+You are <em>not</em> permitted to move cards back out of the foundations.

--- a/html-src/rules/diplomat.html
+++ b/html-src/rules/diplomat.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Diplomat</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the 8
-piles build down by rank ignoring suit.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the 8 piles build down by rank ignoring suit.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/dojoujisgame.html
+++ b/html-src/rules/dojoujisgame.html
@@ -1,28 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Dojoujis's Game</h1>
 Hanafuda game type. 2 decks. No redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with two
-Hanafuda decks.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with two Hanafuda decks.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The difference
-is the use of two Hanafuda decks instead of two 52 card standard
-decks When a first rank card is dealt to the rows two cards are
-dealt to the talon. There are twelve first rank cards in a Hanafuda
-deck. There are 8 rows in this Lara's game version. Cards are dealt
-to all eight rows based on their rank and which deck they are from.
-The decks are shuffled together on the talon.
-<p>The foundations take two complete rounds of a suit. After the
-last card of the first round is played to a foundation the first
-card of the second round will play.</p>
-</body>
-</html>
+Refer to the description of the deal in Lara's Game.  The difference
+is the use of two Hanafuda decks instead of two 52 card standard decks
+When a first rank card is dealt to the rows two cards are dealt to the talon.
+There are twelve first rank cards in a Hanafuda deck.  There are 8 rows
+in this Lara's game version.  Cards are dealt to all eight rows based on
+their rank and which deck they are from.  The decks are shuffled together
+on the talon.
+<p>
+The foundations take two complete rounds of a suit.  After the last card
+of the first round is played to a foundation the first card of the second
+round will play.

--- a/html-src/rules/dojoujisgamedoubled.html
+++ b/html-src/rules/dojoujisgamedoubled.html
@@ -1,28 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Dojoujis's Game</h1>
 Hanafuda game type. 4 decks. No redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with four
-Hanafuda decks.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with four Hanafuda decks.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The difference
-is the use of four Hanafuda decks instead of two 52 card standard
-decks When a first rank card is dealt to the rows two cards are
-dealt to the talon. There are twelve first rank cards in a Hanafuda
-deck. There are 16 rows in this Lara's game version. Cards are
-dealt to all sixteen rows based on their rank and which deck they
-are from. The four decks are shuffled together on the talon.
-<p>The foundations take four complete rounds of a suit. After the
-last card of the first round is played to a foundation the first
-card of the second round will play.</p>
-</body>
-</html>
+Refer to the description of the deal in Lara's Game.  The difference
+is the use of four Hanafuda decks instead of two 52 card standard decks
+When a first rank card is dealt to the rows two cards are dealt to the talon.
+There are twelve first rank cards in a Hanafuda deck.  There are 16 rows
+in this Lara's game version.  Cards are dealt to all sixteen rows based on
+their rank and which deck they are from.  The four decks are shuffled together
+on the talon.
+<p>
+The foundations take four complete rounds of a suit.  After the last card
+of the first round is played to a foundation the first card of the second
+round will play.

--- a/html-src/rules/doublebisley.html
+++ b/html-src/rules/doublebisley.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Bisley</h1>
-<p>Two-Deck game type. 2 decks. No redeal.</p>
+<p>
+Two-Deck game type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="bisley.html">Bisley</a>, but two decks and twenty
-four playing piles.</p>
+<p>
+Like <a href="bisley.html">Bisley</a>,
+but two decks and twenty four playing piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/doublecanfield.html
+++ b/html-src/rules/doublecanfield.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Canfield</h1>
-<p>Canfield type. 2 decks. Unlimited redeals.</p>
+<p>
+Canfield type. 2 decks. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="canfield.html">Canfield</a>, but with two decks
-and five playing piles.</p>
+<p>
+Like <a href="canfield.html">Canfield</a>,
+but with two decks and five playing piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/doublecockroach.html
+++ b/html-src/rules/doublecockroach.html
@@ -1,19 +1,15 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Cockroach</h1>
-<p>Tarock type. 2 decks. No redeal.</p>
+<p>
+Tarock type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Play is identical to <a href="grasshopper.html">Grasshopper</a>
-except there are two Trumps only row stacks, and nine row stacks
-and there is no redeal. Twenty-eight cards are dealt to the reserve
-at the start of the game.</p>
-</body>
-</html>
+<p>
+Play is identical to
+<a href="grasshopper.html">Grasshopper</a>
+except there are two Trumps only row stacks, and nine row stacks and
+there is no redeal.  Twenty-eight cards are dealt to the reserve at
+the start of the game.

--- a/html-src/rules/doubledrawbridge.html
+++ b/html-src/rules/doubledrawbridge.html
@@ -1,26 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Drawbridge</h1>
 Klondike type. Two decks. One redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-This is the two deck version of <a href=
-"drawbridge.html">Drawbridge</a>.
+This is the two deck version of
+<a href="drawbridge.html">Drawbridge</a>.
 <h3>Rules</h3>
-Game play is like Klondike. The rows build down in rank in
-alternate color. Any card or sequence may be played on an empty
-row. The Wizards will play in their proper rank position on the
-tableau as the alternate of either red or black. Cards are dealt
-from the talon one at a time. Cards may be played from the
-foundations.
+Game play is like Klondike.  The rows build down in rank in alternate
+color.  Any card or sequence may be played on an empty row.  The Wizards
+will play in their proper rank position on the tableau as the alternate of
+either red or black.  Cards are dealt from the talon one at a time.  Cards
+may be played from the foundations.
 <h3>Strategy</h3>
 Play cards back off of the foundations to uncover face down cards.
-</body>
-</html>

--- a/html-src/rules/doublegrasshopper.html
+++ b/html-src/rules/doublegrasshopper.html
@@ -1,36 +1,34 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Grasshopper</h1>
-<p>Tarock type. 2 deck. 1 redeal.</p>
+<p>
+Tarock type. 2 deck. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The tableau consists of one reserve stack, two Trumps only row
-stacks, and nine row stacks. Twenty-eight cards are dealt to the
-reserve stack and one card each to the row stacks. When a row stack
-is emptied it must be filled from the reserve stack first. When the
-reserve stack is empty any card can be played on an empty row
-stack. The Trumps only stacks are left empty and can be played on
-at will. The row stacks build down in rank by alternate colors. The
-Trumps can be played as either color. The Trumps only row stacks
-also build down in rank. They will accept a stack of cards that
-contains suit cards as long as the bottom card is a Trump. The
-foundations build up in rank by suit.</p>
+<p>
+The tableau consists of one reserve stack, two Trumps only row stacks,
+and nine row stacks.  Twenty-eight cards are dealt to the reserve
+stack and one card each to the row stacks.  When a row stack is emptied
+it must be filled from the reserve stack first.  When the reserve stack
+is empty any card can be played on an empty row stack.  The Trumps only
+stacks are left empty and can be played on at will.  The row stacks
+build down in rank by alternate colors.  The Trumps can be played as
+either color.  The Trumps only row stacks also build down in rank.  They
+will accept a stack of cards that contains suit cards as long as the
+bottom card is a Trump.  The foundations build up in rank by suit.
+
 <h3>Strategy</h3>
-<p>With skillful play and a bit of luck it's possible to sweep this
-one without needing the redeal. The first priority is to empty the
-reserve stack. Once that's done try to keep one or more row stacks
-open. Play high rank cards on the rows and build down on them. The
-same goes for the Trumps only rows.</p>
+<p>
+With skillful play and a bit of luck it's possible to sweep this one
+without needing the redeal.  The first priority is to empty the reserve
+stack.  Once that's done try to keep one or more row stacks open.  Play
+high rank cards on the rows and build down on them.  The same goes for
+the Trumps only rows.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/doubleklondike.html
+++ b/html-src/rules/doubleklondike.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Klondike</h1>
-<p>Klondike type. 2 decks. Unlimited redeals.</p>
+<p>
+Klondike type. 2 decks. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but with two decks
-and nine playing piles.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but with two decks and nine playing piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/doubleklondikebythrees.html
+++ b/html-src/rules/doubleklondikebythrees.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Klondike by Threes</h1>
-<p>Klondike type. 2 decks. Unlimited redeals.</p>
+<p>
+Klondike type. 2 decks. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="doubleklondike.html">Double Klondike</a>, but deal
-three cards.</p>
+<p>
+Like <a href="doubleklondike.html">Double Klondike</a>,
+but deal three cards.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/doublerail.html
+++ b/html-src/rules/doublerail.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Rail</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the 5
-piles build down by rank ignoring suit, and sequences can be
-moved.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the 5 piles build down by rank ignoring suit,
+and sequences can be moved.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/doublesamuri.html
+++ b/html-src/rules/doublesamuri.html
@@ -1,21 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Samuri</h1>
-<p>Hanafuda type. 2 decks. No redeal.</p>
+<p>
+Hanafuda type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-This is <a href="samuri.html">Samuri</a> played with two decks.
+This is
+<a href="samuri.html">Samuri</a>
+played with two decks.
+
 <h3>Strategy</h3>
 Try not to let the waste stack get too deep.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/doublets.html
+++ b/html-src/rules/doublets.html
@@ -1,25 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Doublets</h1>
-<p>One-Deck game type. 1 deck. 2 redeals.</p>
+<p>
+One-Deck game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards except the four Kings to the single
-foundation.</p>
+<p>
+Move all cards except the four Kings to the single foundation.
+
 <h3>Rules</h3>
-<p>The base rank for the foundation is determined at game start,
-and it builds up by doubling the rank ignoring suit:</p>
-<p>A, 2, 4, 8, 3, 6, Q, J, 9, 5, 10, 7, A, repeat...</p>
-<p>The 7 reserve piles are automatically filled from the waste or
-talon.</p>
-<p>Kings are blocking, therefore all Kings in the first 8 cards are
-put at the bottom of the talon during game start.</p>
+<p>
+The base rank for the foundation is determined at game start,
+and it builds up by doubling the rank ignoring suit:
+<p>
+A, 2, 4, 8, 3, 6, Q, J, 9, 5, 10, 7, A, repeat...
+<p>
+The 7 reserve piles are automatically filled from the waste or talon.
+<p>
+Kings are blocking, therefore all Kings in the first 8 cards
+are put at the bottom of the talon during game start.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/doubleyourfun.html
+++ b/html-src/rules/doubleyourfun.html
@@ -1,30 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Your Fun</h1>
 Hanafuda type. 2 decks. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="freecell.html">Free Cell</a>. The rows
-build down by rank in the same suit. The foundations build with
-cards of the same rank in suit order.
+Play is similar to
+<a href="freecell.html">Free Cell</a>.
+The rows build down by rank in the same suit.  The foundations
+build with cards of the same rank in suit order.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build in ascending suit order from Pine to Phoenix by
-rank. The third and fourth rank (trash) cards are not
-interchangeable on the tableau. Cards may not be played from the
-foundations. Only first rank cards or correctly ordered piles may
-be played on an empty row.
+The rows build from first rank to fourth rank by suit.  The foundations
+build in ascending suit order from Pine to Phoenix by rank.  The third
+and fourth rank (trash) cards are not interchangeable on the tableau.
+Cards may not be played from the foundations.  Only first rank cards
+or correctly ordered piles may be played on an empty row.
+
 <h3>Strategy</h3>
 Use the reserve stacks to release the fourth rank cards first.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/dover.html
+++ b/html-src/rules/dover.html
@@ -1,18 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Dover</h1>
-<p>Fan type. 2 decks. No redeals.</p>
+<p>
+Fan type. 2 decks. No redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="bristol.html">Bristol</a>, but with two decks.</p>
+<p>
+Like <a href="bristol.html">Bristol</a>,
+but with two decks.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/drawbridge.html
+++ b/html-src/rules/drawbridge.html
@@ -1,26 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Drawbridge</h1>
 Klondike type. One deck. One redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="klondike.html">Klondike</a> with <a href=
-"../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="klondike.html">Klondike</a>
+with <a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like Klondike. The rows build down in rank in
-alternate color. Any card or sequence may be played on an empty
-row. The Wizards will play in their proper rank position on the
-tableau as the alternate of either red or black. Cards are dealt
-from the talon one at a time. Cards may be played from the
-foundations.
+Game play is like Klondike.  The rows build down in rank in alternate
+color.  Any card or sequence may be played on an empty row.  The Wizards
+will play in their proper rank position on the tableau as the alternate of
+either red or black.  Cards are dealt from the talon one at a time.  Cards
+may be played from the foundations.
 <h3>Strategy</h3>
 Play cards back off of the foundations to uncover face down cards.
-</body>
-</html>

--- a/html-src/rules/eaglewing.html
+++ b/html-src/rules/eaglewing.html
@@ -1,16 +1,11 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Eagle Wing</h1>
-<p>Canfield type. 1 deck. 2 redeals.</p>
+<p>
+Canfield type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/eastcliff.html
+++ b/html-src/rules/eastcliff.html
@@ -1,25 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Eastcliff</h1>
-<p>Klondike type. 1 deck. No redeal.</p>
+<p>
+Klondike type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but anything on an
-empty space, and no redeal.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but anything on an empty space, and no redeal.
+
 <h3>Rules</h3>
-<p>Piles build down by alternate color, and an empty space can be
-filled with any card or sequence.</p>
-<p>Cards from the talon are turned over to the waste pile, one at a
-time. You can move the top card to the playing piles or the
-foundations. There is no redeal.</p>
-<p>You are also permitted to move cards back out of the
-foundations.</p>
-</body>
-</html>
+<p>
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence.
+<p>
+Cards from the talon are turned over to the waste pile, one at a time.
+You can move the top card to the playing piles or the foundations.
+There is no redeal.
+<p>
+You are also permitted to move cards back out of the foundations.

--- a/html-src/rules/easthaven.html
+++ b/html-src/rules/easthaven.html
@@ -1,25 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Easthaven</h1>
-<p>Klondike type. 1 deck. No redeal.</p>
+<p>
+Klondike type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but anything on an
-empty space, and no redeal.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but anything on an empty space, and no redeal.
+
 <h3>Rules</h3>
-<p>Piles build down by alternate color, and an empty space can be
-filled with any card or sequence.</p>
-<p>Cards from the Talon are turned over to the Waste pile, one at a
-time. You can move the top card to the playing piles or the
-Foundations. There is no redeal.</p>
-<p>You are also permitted to move cards back out of the
-Foundations.</p>
-</body>
-</html>
+<p>
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence.
+<p>
+Cards from the Talon are turned over to the Waste pile, one at a time.
+You can move the top card to the playing piles or the Foundations.
+There is no redeal.
+<p>
+You are also permitted to move cards back out of the Foundations.

--- a/html-src/rules/easysupreme.html
+++ b/html-src/rules/easysupreme.html
@@ -1,29 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Easy Supreme</h1>
 Hanafuda type. 4 decks. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-This is a four deck version of <a href="littleeasy.html">Little
-Easy</a>. The rows build down by rank in the same suit. The
-foundations build with cards of the same rank in suit order. Only
-first rank cards may be played on an empty row.
+This is a four deck version of
+<a href="littleeasy.html">Little Easy</a>.
+The rows build down by rank in the same suit.  The foundations
+build with cards of the same rank in suit order.  Only first
+rank cards may be played on an empty row.
+
 <h3>Rules</h3>
-The rules are the same as in <a href="littleeasy.html">Little
-Easy</a>.
+The rules are the same as in
+<a href="littleeasy.html">Little Easy</a>.
+
 <h3>Strategy</h3>
-Disable auto drop and build on the rows until all cards are face
-up. These games may be easy by name and easy to play but they're
-not easy to win.
+Disable auto drop and build on the rows until all cards are face up.
+These games may be easy by name and easy to play but they're not easy
+to win.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/easyxone.html
+++ b/html-src/rules/easyxone.html
@@ -1,30 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Easy x One</h1>
 Hanafuda type. 1 deck. One redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-This is a variation of <a href="littleeasy.html">Little Easy</a>.
-The rows build down by rank in the same suit. The foundations build
-with cards of the same rank in suit order. Only first rank cards
-may be played on an empty row.
+This is a variation of
+<a href="littleeasy.html">Little Easy</a>.
+The rows build down by rank in the same suit.  The foundations
+build with cards of the same rank in suit order.  Only first
+rank cards may be played on an empty row.
+
 <h3>Rules</h3>
-The rules are the same as in <a href="littleeasy.html">Little
-Easy</a> except that the cards deal from the talon one at a time
-and there is only one redeal.
+The rules are the same as in
+<a href="littleeasy.html">Little Easy</a>
+except that the cards deal from the talon one at a time and there
+is only one redeal.
+
 <h3>Strategy</h3>
-Disable auto drop and build on the rows until all cards are face
-up. These games may be easy by name and easy to play but they're
-not easy to win.
+Disable auto drop and build on the rows until all cards are face up.
+These games may be easy by name and easy to play but they're not easy
+to win.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/eiffeltower.html
+++ b/html-src/rules/eiffeltower.html
@@ -1,25 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Eiffel Tower</h1>
-<p>Pairing game type. 2 decks. No redeal.</p>
+<p>
+Pairing game type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the tableau piles.</p>
+<p>
+Move all cards to the tableau piles.
+
 <h3>Rules</h3>
-<p>This is a very simple game, which takes its name from the shape
-of the layout. The object is to use up all the cards from the
-talon, placing them on the Tower. You can only put a card on top of
-another card when the numerical values of the two cards adds up to
-14. King is worth 13, Queen is worth 12 and Jack is worth 11. You
-do not have to follow suit.</p>
-<p>You win when the talon is all gone. There is no redeal.</p>
+<p>
+This is a very simple game, which takes its name from the shape of the
+layout. The object is to use up all the cards from the talon, placing them
+on the Tower. You can only put a card on top of another card when the
+numerical values of the two cards adds up to 14. King is worth 13, Queen is
+worth 12 and Jack is worth 11. You do not have to follow suit.
+<p>
+You win when the talon is all gone. There is no redeal.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> and <i>Quickplay</i> are disabled for this
-game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> and <i>Quickplay</i> are disabled for this game.

--- a/html-src/rules/eightlegions.html
+++ b/html-src/rules/eightlegions.html
@@ -1,29 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Eight legions</h1>
 Mughal Ganjifa type. One deck. No redeal.
+
 <h3>Object</h3>
 Arrange all cards in suit and rank order on the tableau.
+
 <h3>Quick description</h3>
-The cards build down by rank only on the tableau. The ten reserve
-stacks hold one card each. The game is won when all cards are on
-the tableau in suit and rank order.
+The cards build down by rank only on the tableau.  The ten reserve
+stacks hold one card each.  The game is won when all cards are on the
+tableau in suit and rank order.
+
 <h3>Rules</h3>
-The game begins with five cards on each of the twelve rows and the
-ten reserve stacks empty. Cards are dealt from the talon twelve at
-a time, one to each row. Rows can be built with cards of any suit
-in descending rank. Only Mirs can be played on an empty row. All
-twelve suits must be in descending rank order for the game to be
-won.
+The game begins with five cards on each of the twelve rows and the ten
+reserve stacks empty.  Cards are dealt from the talon twelve at a time, one
+to each row.  Rows can be built with cards of any suit in descending rank.
+Only Mirs can be played on an empty row.  All twelve suits must be in
+descending rank order for the game to be won.
+
 <h3>Strategy</h3>
-Make as many plays as possible without filling too many reserves
-before taking another deal. Put a priority on getting the Mirs and
-Wazirs in place.
-</body>
-</html>
+Make as many plays as possible without filling too many reserves before taking
+another deal.  Put a priority on getting the Mirs and Wazirs in place.

--- a/html-src/rules/eightoff.html
+++ b/html-src/rules/eightoff.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Eight Off</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="kingonlybakersgame.html">King Only Baker's
-Game</a>, but with 8 free cells.</p>
+<p>
+Like <a href="kingonlybakersgame.html">King Only Baker's Game</a>,
+but with 8 free cells.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/eighttimeseight.html
+++ b/html-src/rules/eighttimeseight.html
@@ -1,19 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Eight Times Eight (Achtmal Acht)</h1>
-<p>Klondike type. 2 decks. 2 redeals.</p>
+<p>
+Klondike type. 2 decks. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>This is a variant of <a href="8x8.html">8 x 8</a> with only two
-redeals. Experienced players probably will prefer this.</p>
+<p>
+This is a variant of <a href="8x8.html">8 x 8</a>
+with only two redeals.
+Experienced players probably will prefer this.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/elevator.html
+++ b/html-src/rules/elevator.html
@@ -1,21 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Elevator</h1>
-<p>Golf type. 1 deck. No redeal.</p>
+<p>
+Golf type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="relaxedgolf.html">Relaxed Golf</a>, only with
-a <a href="pyramid.html">Pyramid</a> like layout.</p>
+<p>
+Just like <a href="relaxedgolf.html">Relaxed Golf</a>,
+only with a <a href="pyramid.html">Pyramid</a>
+like layout.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/eularia.html
+++ b/html-src/rules/eularia.html
@@ -1,26 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Eularia</h1>
 Hanafuda type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="paulownia.html">Eularia</a>. The rows
-build down in rank by same suit. The foundations build up in rank
-by suit.
+Play is similar to
+<a href="paulownia.html">Eularia</a>.
+The rows build down in rank by same suit.  The foundations
+build up in rank by suit.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build from fourth to first. The third and fourth rank
-(trash) cards are not interchangeable on the tableau. Cards may not
-be played from the foundations. Any card or correctly ordered pile
-may be played on an empty row.
+The rows build from first rank to fourth rank by suit.  The foundations
+build from fourth to first.  The third and fourth rank (trash) cards are
+not interchangeable on the tableau.  Cards may not be played from the
+foundations.  Any card or correctly ordered pile may be played on an
+empty row.
+
 <h3>Strategy</h3>
 Uncover the deepest row stacks first.
-</body>
-</html>

--- a/html-src/rules/excuse.html
+++ b/html-src/rules/excuse.html
@@ -1,28 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Excuse</h1>
-<p>Tarock type. 1 deck. No redeal.</p>
+<p>
+Tarock type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Rows build down in rank regardless of suit. Only one card can be
-moved at a time. Foundations build up in rank by suit. An empty row
-stack cannot be filled. For this reason the Kings and the highest
-Trump are dealt to the bottoms of the rows. Cards can be played
-from the foundations.</p>
+<p>
+Rows build down in rank regardless of suit.  Only one card can
+be moved at a time.  Foundations build up in rank by suit.  An
+empty row stack cannot be filled.  For this reason the Kings and
+the highest Trump are dealt to the bottoms of the rows.  Cards
+can be played from the foundations.
+
 <h3>Strategy</h3>
-<p>Uncover low rank cards before building on higher rank cards on
-top of them. Use cards already on the foundations to assist in
-moving rows.</p>
+<p>
+Uncover low rank cards before building on higher rank cards on
+top of them.  Use cards already on the foundations to assist in
+moving rows.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/fallingstar.html
+++ b/html-src/rules/fallingstar.html
@@ -1,19 +1,15 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Falling Star</h1>
-<p>Terrace type. 2 decks. No redeal.</p>
+<p>
+Terrace type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Much like <a href="blondesandbrunettes.html">Blondes and
-Brunettes</a>.</p>
+<p>
+Much like <a href="blondesandbrunettes.html">Blondes and Brunettes</a>.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/fan.html
+++ b/html-src/rules/fan.html
@@ -1,19 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Fan</h1>
-<p>Fan game type. 1 deck. No redeal.</p>
+<p>
+Fan game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The 18 piles build down by suit. Only one card can be moved at a
-time, and empty piles can be filled with a King only.</p>
+<p>
+The 18 piles build down by suit.
+Only one card can be moved at a time, and
+empty piles can be filled with a King only.
+
 <h3>Strategy</h3>
-<p>Build evenly on to foundations.</p>
-</body>
-</html>
+<p>
+Build evenly on to foundations.

--- a/html-src/rules/fastness.html
+++ b/html-src/rules/fastness.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Fastness</h1>
-<p>Beleaguered Castle type. 1 deck. No redeal.</p>
+<p>
+Beleaguered Castle type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="streetsandalleys.html">Streets and Alleys</a>, but
-with two free cells.</p>
+<p>
+Like <a href="streetsandalleys.html">Streets and Alleys</a>,
+but with two free cells.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/fatimehsgame.html
+++ b/html-src/rules/fatimehsgame.html
@@ -1,26 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Fatimeh's Game</h1>
 Mughal Ganjifa game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with twelve
-rows and two redeals.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with twelve rows and two redeals.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to thirteen piles instead
-of fourteen and if a dealt card is of rank Pradhan or over one card
-is dealt to the talon. Otherwise the dealing rules are the same.
-<p>Play is the same as Lara's Game except that there are two
-redeals. When the talon is empty after each round the cards are
-gathered up from the tableau and dealt to the rows without being
-shuffled using the same dealing rules as in the first round.</p>
-</body>
-</html>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to thirteen piles instead of fourteen
+and if a dealt card is of rank Pradhan or over one card is dealt to the
+talon.  Otherwise the dealing rules are the same.
+<p>
+Play is the same as Lara's Game except that there are two redeals.  When
+the talon is empty after each round the cards are gathered up from the
+tableau and dealt to the rows without being shuffled using the same
+dealing rules as in the first round.

--- a/html-src/rules/fatimehsgamerelaxed.html
+++ b/html-src/rules/fatimehsgamerelaxed.html
@@ -1,31 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relaxed Fatimeh's Game</h1>
 Mughal Ganjifa game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with twelve
-rows, two redeals and a reserve stack which will hold two cards.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with twelve rows, two redeals and a reserve stack
+which will hold two cards.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to thirteen piles instead
-of fourteen and if a dealt card is of rank Pradhan or over one card
-is dealt to the talon. Otherwise the dealing rules are the same.
-<p>Play is the same as Lara's Game except that there are two
-redeals. When the talon is empty after each round the cards are
-gathered up from the tableau and dealt to the rows without being
-shuffled using the same dealing rules as in the first round.</p>
-<p>The reserve stack will take any two cards from the rows.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to thirteen piles instead of fourteen
+and if a dealt card is of rank Pradhan or over one card is dealt to the
+talon.  Otherwise the dealing rules are the same.
+<p>
+Play is the same as Lara's Game except that there are two redeals.  When
+the talon is empty after each round the cards are gathered up from the
+tableau and dealt to the rows without being shuffled using the same
+dealing rules as in the first round.
+
+<p>
+The reserve stack will take any two cards from the rows.
+
 <h3>Strategy</h3>
-Use the reserve stack to allow buried cards to play. The best times
-to use it are just before a redeal. Once played to the reserve a
+Use the reserve stack to allow buried cards to play.  The best times
+to use it are just before a redeal.  Once played to the reserve a
 card may only be played from it to a foundation.
-</body>
-</html>

--- a/html-src/rules/fifteenplus.html
+++ b/html-src/rules/fifteenplus.html
@@ -1,27 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Fifteen Plus</h1>
-<p>Tarock type. 1 deck. No redeal.</p>
+<p>
+Tarock type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Rows build down in rank in alternating color. The Trumps can
-play as either color. Only one card can be moved at a time.
-Foundations build up in rank by suit. Any card can be played on an
-empty row. Cards can be played from the foundations.</p>
+<p>
+Rows build down in rank in alternating color.  The Trumps can
+play as either color.  Only one card can be moved at a time.
+Foundations build up in rank by suit.  Any card can be played
+on an empty row.  Cards can be played from the foundations.
+
 <h3>Strategy</h3>
-<p>Uncover low rank cards before building on higher rank cards on
-top of them. Use cards already on the foundations to assist in
-moving rows.</p>
+<p>
+Uncover low rank cards before building on higher rank cards on
+top of them.  Use cards already on the foundations to assist in
+moving rows.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/firecracker.html
+++ b/html-src/rules/firecracker.html
@@ -1,29 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Fire Cracker</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-The rows build down in rank in the same suit. The foundations build
-with cards of the same rank in suit order. Any card may be played
-on an empty row.
+The rows build down in rank in the same suit.  The foundations
+build with cards of the same rank in suit order.  Any card may
+be played on an empty row.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build in ascending suit order from Pine to Phoenix by
-rank. The third and fourth rank (trash) cards are interchangeable
-on the tableau. Cards may not be played from the foundations. Any
-card or correctly ordered pile may be played on an empty row.
+The rows build from first rank to fourth rank by suit.  The foundations
+build in ascending suit order from Pine to Phoenix by rank.  The third
+and fourth rank (trash) cards are interchangeable on the tableau.
+Cards may not be played from the foundations.  Any card or correctly
+ordered pile may be played on an empty row.
+
 <h3>Strategy</h3>
 Build sequences on the tableau.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/fiveaces.html
+++ b/html-src/rules/fiveaces.html
@@ -1,29 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Five Aces</h1>
 Tarock type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-This is a <a href="bakersdozen.html">Baker's Dozen</a> type game
-played with the 78 card Tarock deck. Piles build down in rank in
-alternate colors. The Trumps can play as either color. The five
-Aces are dealt to the foundations at the start of the game.
+This is a
+<a href="bakersdozen.html">Baker's Dozen</a>
+type game played with the 78 card Tarock deck.  Piles build down
+in rank in alternate colors.  The Trumps can play as either color.
+The five Aces are dealt to the foundations at the start of the game.
+
 <h3>Rules</h3>
 Rows build down in rank by alternate color with the Trumps playing
-as either color. A pile may be moved to another location but only a
-single card may be played on an empty row. Cards may be played from
-the foundations.
+as either color.  A pile may be moved to another location but only
+a single card may be played on an empty row.  Cards may be played
+from the foundations.
+
 <h3>Strategy</h3>
 Use the Trumps to open spots for suit cards.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/flowerarrangement.html
+++ b/html-src/rules/flowerarrangement.html
@@ -1,36 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Flower Arrangement</h1>
-<p>Two-Deck game type. Two Hanafuda decks. No redeal.</p>
+<p>
+Two-Deck game type. Two Hanafuda decks. No redeal.
+
 <h3>Object</h3>
-<p>Arrange the Flower Cards in suit order.</p>
+<p>
+Arrange the Flower Cards in suit order.
+
 <h3>Rules</h3>
-<p>The layout consists of three rows of playing piles and a row for
-newly dealt cards.</p>
-<p>The cards must be arranged from forth rank to first in the top
-three rows as follows:</p>
+<p>
+The layout consists of three rows of playing piles and a row for newly
+dealt cards.
+<p>
+The cards must be arranged from forth rank to first in the top three
+rows as follows:
 <ul>
-<li>The first row will only accept the first four suits, Pine,
-Plum, Cherry and Wisteria</li>
-<li>the second row will accept the second four, Iris, Peony, Bush
-Clover and Eularia</li>
-<li>and the third row will accept the last four, Chrysanthemum,
-Maple, Willow and Paulownia.</li>
+<li>The first row will only accept the first four suits, Pine, Plum, Cherry and Wisteria
+<li>the second row will accept the second four, Iris, Peony, Bush Clover and Eularia
+<li>and the third row will accept the last four, Chrysanthemum, Maple, Willow and Paulownia.
 </ul>
-<p>If you clear a space at the bottom it will be automatically
-filled with a card from the talon. But if the talon is gone and you
-clear a space at the bottom, then you can fill it with any card.
-When no further moves are possible, click on the talon for a fresh
-row of cards at the bottom.</p>
-<p>You win when all of the suits are arranged in order.</p>
+<p>
+If you clear a space at the bottom it will be automatically filled
+with a card from the talon. But if the talon is gone and you clear a space
+at the bottom, then you can fill it with any card.
+When no further moves are possible, click on the talon for a fresh row
+of cards at the bottom.
+<p>
+You win when all of the suits are arranged in order.
+
 <h3>Strategy</h3>
-<p>Because of the many piles involved the Picture Gallery requires
-some concentration, but it is not too hard to win.</p>
-</body>
-</html>
+<p>
+Because of the many piles involved the Picture Gallery requires some
+concentration, but it is not too hard to win.

--- a/html-src/rules/flowerclock.html
+++ b/html-src/rules/flowerclock.html
@@ -1,35 +1,38 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Flower Clock</h1>
-<p>Hanafuda type. 1 deck. No redeal.</p>
+<p>
+Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>This one is for people who want a mindless distraction. It's a
-good way to learn the suits and ranks of the flower cards. The
-foundations build from fourth rank to first, by suits. Any fourth
-rank card can be played on any open foundation stack, but a game
-doesn't count as a win unless the suits are in their proper order.
-That means Pine is at 1 o'clock, Plum at 2 o'clock etc. Once a card
-is played on a foundation stack it can't be taken off except by
-undoing the move. There can be no more than eight cards in a
-row.</p>
-<p>The cards in the tableau build from first rank to fourth,
-without regard to suit. The third and fourth rank cards are
-interchangeable. Any card can be played on the canvas.</p>
-<p>This is <a href="grandfathersclock.html">Grandfather's Clock</a>
-with flower cards.</p>
+<p>
+This one is for people who want a mindless distraction.  It's a good
+way to learn the suits and ranks of the flower cards.  The foundations
+build from fourth rank to first, by suits.  Any fourth rank card can be
+played on any open foundation stack, but a game doesn't count as a win
+unless the suits are in their proper order.  That means Pine is at 1
+o'clock, Plum at 2 o'clock etc.  Once a card is played on a foundation stack
+it can't be taken off except by undoing the move.  There can be no
+more than eight cards in a row.
+
+<p>
+The cards in the tableau build from first rank to fourth, without regard
+to suit.  The third and fourth rank cards are interchangeable.  Any card
+can be played on the canvas.
+
+<p>
+This is
+<a href="grandfathersclock.html">Grandfather's Clock</a>
+with flower cards.
+
 <h3>Strategy</h3>
-<p>Hint: try to keep a row open to the canvas.</p>
+<p>
+Hint: try to keep a row open to the canvas.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/forecell.html
+++ b/html-src/rules/forecell.html
@@ -1,25 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>ForeCell</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="freecell.html">FreeCell</a>, but the reserves are
-filled at game start, and only Kings on empty spaces.</p>
+<p>
+Like <a href="freecell.html">FreeCell</a>,
+but the reserves are filled at game start, and only Kings on empty spaces.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>History</h3>
-<p>According to the <a href=
-"http://www.solitairelaboratory.com/fcfaq.html">FreeCell FAQ</a>
-this is the first known game which bears an extremely close
-resemblance to FreeCell. It was invented in Sweden and dates back
-at least to 1945.</p>
-</body>
-</html>
+<p>
+According to the
+<a href="http://www.solitairelaboratory.com/fcfaq.html">FreeCell FAQ</a>
+this is the first known game which bears an extremely close resemblance
+to FreeCell. It was invented in Sweden and dates back at least to 1945.

--- a/html-src/rules/fortress.html
+++ b/html-src/rules/fortress.html
@@ -1,21 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Fortress</h1>
-<p>Beleaguered Castle type. 1 deck. No redeal.</p>
+<p>
+Beleaguered Castle type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The ten piles build <b>up or down</b> by suit. Only one card can
-be moved at a time and empty piles can be filled with any single
-card.</p>
+<p>
+The ten piles build <b>up or down</b> by suit.
+Only one card can be moved at a time and
+empty piles can be filled with any single card.
+
 <h3>Similar Games</h3>
-<p>This is a very hard game - try <a href=
-"chessboard.html">Chessboard</a> for a more enjoyful variant.</p>
-</body>
-</html>
+<p>
+This is a very hard game - try
+<a href="chessboard.html">Chessboard</a>
+for a more enjoyful variant.

--- a/html-src/rules/fortyandeight.html
+++ b/html-src/rules/fortyandeight.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Forty and Eight</h1>
-<p>Forty Thieves type. 2 decks. 1 redeal.</p>
+<p>
+Forty Thieves type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but with
-eight piles and one redeal.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but with eight piles and one redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/fortythieves.html
+++ b/html-src/rules/fortythieves.html
@@ -1,25 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Forty Thieves</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Forty cards are dealt to 10 piles. These piles are built down in
-suit. Only the top card of a pile is available for playing, and
-spaces can be filled by any card.</p>
-<p>Cards from the talon are turned over to the waste pile, one at a
-time. You can move the leftmost card to the playing piles or the
-foundations. There is no redeal.</p>
+<p>
+Forty cards are dealt to 10 piles. These piles are built down in suit.
+Only the top card of a pile is available for playing, and
+spaces can be filled by any card.
+<p>
+Cards from the talon are turned over to the waste pile, one at a time.
+You can move the leftmost card to the playing piles or the foundations.
+There is no redeal.
+
 <h3>History</h3>
-<p>This is a classic solitaire game that probably dates back to the
-nineteenth century. It is known by many names, such as <i>Napoleon
-at St.Helena</i>, <i>Big Forty</i> and <i>Le Cadran</i>.</p>
-</body>
-</html>
+<p>
+This is a classic solitaire game that probably dates back to the
+nineteenth century. It is known by many names, such as
+<i>Napoleon at St.Helena</i>, <i>Big Forty</i> and <i>Le Cadran</i>.

--- a/html-src/rules/fourteen.html
+++ b/html-src/rules/fourteen.html
@@ -1,23 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Fourteen</h1>
-<p>Pairing game type. 1 deck. No redeal.</p>
+<p>
+Pairing game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Discard all pairs of cards that add up to fourteen in rank.</p>
+<p>
+Discard all pairs of cards that add up to fourteen in rank.
+
 <h3>Rules</h3>
-<p>The object is to use up all the cards from the tableau by
-discarding pairs of cards that add up to fourteen in rank.</p>
-<p>Aces are worth one and Jacks, Queens, and Kings are worth 11,
-12, and 13, respectively.</p>
-<p>There is no other playing on the piles. You win when the tableau
-piles are all gone.</p>
+<p>
+The object is to use up all the cards from the tableau by
+discarding pairs of cards that add up to fourteen in rank.
+<p>
+Aces are worth one and Jacks, Queens, and Kings are worth
+11, 12, and 13, respectively.
+<p>
+There is no other playing on the piles.
+You win when the tableau piles are all gone.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/freecell.html
+++ b/html-src/rules/freecell.html
@@ -1,33 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>FreeCell</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>FreeCell is played with one deck. All cards are dealt at the
-start of the game. To compensate for this there are 4 free cells
-which can hold any - and just one - card.</p>
-<p>Piles build down by alternate color, and an empty space can be
-filled with any card or sequence.</p>
-<p>The number of cards you can move as a sequence is restricted by
+<p>
+FreeCell is played with one deck. All cards are dealt at the start of the
+game. To compensate for this there are 4 free cells which can hold
+any - and just one - card.
+<p>
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence.
+<p>
+The number of cards you can move as a sequence is restricted by
 the number of free cells - the number of free cells required is the
-same as if you would make an equivalent sequence of moves with
-single cards. (As a shortcut, the computer also considers the
-number of free piles so that you can move even more cards as one
-single sequence.)</p>
+same as if you would make an equivalent sequence of moves with single cards.
+(As a shortcut, the computer also considers the number of free piles so
+that you can move even more cards as one single sequence.)
+
 <h3>Notes</h3>
-<p>Game numbers in the range 1 to 32000 are compatible to the ones
-in the <a href=
-"http://www.solitairelaboratory.com/fcfaq.html">FreeCell FAQ</a>.
-Visit this page to find out a lot of interesting information about
-FreeCell its variants.</p>
-<p>More than 99.9% of all FreeCell games are solvable.</p>
-</body>
-</html>
+<p>
+Game numbers in the range 1 to 32000 are compatible to the ones in the
+<a href="http://www.solitairelaboratory.com/fcfaq.html">FreeCell FAQ</a>.
+Visit this page to find out a lot of interesting information
+about FreeCell its variants.
+<p>
+More than 99.9% of all FreeCell games are solvable.

--- a/html-src/rules/freefan.html
+++ b/html-src/rules/freefan.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Free Fan</h1>
-<p>Fan game type. 1 deck. No redeal.</p>
+<p>
+Fan game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fan.html">Fan</a>, but with two extra free
-cells.</p>
+<p>
+Like <a href="fan.html">Fan</a>,
+but with two extra free cells.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/freenapoleon.html
+++ b/html-src/rules/freenapoleon.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Free Napoleon</h1>
-<p>Napoleon type. 1 deck. No redeal.</p>
+<p>
+Napoleon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="napoleon.html">Napoleon</a>, only with a
-different screen layout.<br />
-Gameplay is completely equivalent.</p>
+<p>
+Just like <a href="napoleon.html">Napoleon</a>,
+only with a different screen layout.
+<br>Gameplay is completely equivalent.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/gajapati.html
+++ b/html-src/rules/gajapati.html
@@ -1,30 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Gajapati</h1>
 Mughal Ganjifa type. One deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank and by suit.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank and by suit.
+
 <h3>Rules</h3>
-The cards on the tableau build down in ranks of the same suit. The
-foundations build up in rank by suit starting with the Ace. Any
-card or movable pile of cards may be played on an empty row. Cards
-are dealt from the talon three at a time. There is no limit on
-redeals. Cards may be played from the foundations.
-<p>This game is one of a series of games that have names ending in
-"pati" which transliterates as "lord of". Gajapati means "Lord of
-Elephants". The names are the names of the suits in a twelve suit
-Ganjifa deck.</p>
+The cards on the tableau build down in ranks of the same suit.
+The foundations build up in rank by suit starting with the Ace.
+Any card or movable pile of cards may be played on an empty row.
+Cards are dealt from the talon three at a time.  There is no limit
+on redeals.  Cards may be played from the foundations.
+<p>
+This game is one of a series of games that have names ending in "pati"
+which transliterates as "lord of".  Gajapati means "Lord of Elephants".
+The names are the names of the suits in a twelve suit Ganjifa deck.
+
 <h3>Strategy</h3>
-Uncover the deepest row stacks first. Play is simple but the odds
+Uncover the deepest row stacks first.  Play is simple but the odds
 against winning this one are high.
-</body>
-</html>

--- a/html-src/rules/gaji.html
+++ b/html-src/rules/gaji.html
@@ -1,32 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Gaji</h1>
-<p>Hanafuda type. 1 deck. No redeal.</p>
+<p>
+Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>When the cards are dealt, one card of each rank is placed on the
-four foundation stacks. The remaining 44 cards are dealt to the
-tableau. Cards from the tableau can be played on the foundations by
-rank, in circular suit order. That is, Plum 1 plays on Pine 1, Rose
-2 plays on Iris 2, and Pine 3 plays on Phoenix 3. Gaji is wild. It
-can play on any card in the tableau and any card can play on Gaji.
-Any card can also be played on the canvas. Gaji will only play in
-its proper position on the foundation. Cards play on the tableau by
-suit in decending rank order. There can be no more than twelve
-cards in a row. Once a card is played on a foundation stack it
-can't be taken off except by undoing the move.</p>
+<p>
+When the cards are dealt, one card of each rank is placed on the four
+foundation stacks.  The remaining 44 cards are dealt to the tableau.
+Cards from the tableau can be played on the foundations by rank, in
+circular suit order.  That is, Plum 1 plays on Pine 1, Rose 2 plays
+on Iris 2, and Pine 3 plays on Phoenix 3.  Gaji is wild.  It can play
+on any card in the tableau and any card can play on Gaji.  Any card
+can also be played on the canvas.    Gaji will only play in its proper
+position on the foundation.  Cards play on the tableau by suit in
+decending rank order.  There can be no more than twelve cards in a row.
+Once a card is played on a foundation stack it can't be taken off
+except by undoing the move.
+
 <h3>Strategy</h3>
-<p>Hint: try to keep a row open to the canvas.</p>
+<p>
+Hint: try to keep a row open to the canvas.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/gargantua.html
+++ b/html-src/rules/gargantua.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Gargantua</h1>
-<p>Klondike type. 2 decks. 1 redeal.</p>
+<p>
+Klondike type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="doubleklondike.html">Double Klondike</a>, but
-only one redeal.</p>
+<p>
+Just like <a href="doubleklondike.html">Double Klondike</a>,
+but only one redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/garhpati.html
+++ b/html-src/rules/garhpati.html
@@ -1,34 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Garhpati</h1>
 Mughal Ganjifa type. One deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank in "alternate" colors.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank in "alternate" colors.
+
 <h3>Rules</h3>
 The cards on the tableau build down by rank in alternate colors.
 The foundations build up in rank by suit starting with the Ace.
-Only the Mirs (Kings) may be played on an empty row. The Mughal
-Ganjifa deck has eight suits and each suit has it's own color. This
-makes it a bit of a challenge at times to know what colors are the
-"alternates". If a card doesn't play one place, try a different
-card of the same rank. Cards are dealt from the talon three at a
-time. There is no limit on redeals. Cards may not be played from
-the foundations.
-<p>This game is one of a series of games that have names ending in
-"pati" which transliterates as "lord of". Garhpati means "Lord of
-Forts". The names are the names of the suits in a twelve suit
-Ganjifa deck.</p>
+Only the Mirs (Kings) may be played on an empty row.  The Mughal
+Ganjifa deck has eight suits and each suit has it's own color.
+This makes it a bit of a challenge at times to know what colors
+are the "alternates".  If a card doesn't play one place, try
+a different card of the same rank.  Cards are dealt from the talon
+three at a time.  There is no limit on redeals.  Cards may not be
+played from the foundations.
+<p>
+This game is one of a series of games that have names ending in "pati"
+which transliterates as "lord of".  Garhpati means "Lord of Forts".
+The names are the names of the suits in a twelve suit Ganjifa deck.
+
 <h3>Strategy</h3>
-Uncover the deepest row stacks first. Move cards on the tableau to
-allow playing cards from the waste stack.
-</body>
-</html>
+Uncover the deepest row stacks first.  Move cards on the tableau
+to allow playing cards from the waste stack.

--- a/html-src/rules/generalspatience.html
+++ b/html-src/rules/generalspatience.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>General's Patience</h1>
-<p>Terrace type. 2 decks. No redeal.</p>
+<p>
+Terrace type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="terrace.html">Terrace</a>, but the foundations
-build up in suit.</p>
+<p>
+Like <a href="terrace.html">Terrace</a>,
+but the foundations build up in suit.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/ghulam.html
+++ b/html-src/rules/ghulam.html
@@ -1,26 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Ghulam</h1>
 Mughal Ganjifa type. One deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-The cards build down by rank and by suit on the tableau, no more
-than twelve to a row. Any card or movable pile may be played on an
-empty row.
+The cards build down by rank and by suit on the tableau, no more than
+twelve to a row.  Any card or movable pile may be played on an empty row.
+
 <h3>Rules</h3>
-All cards are dealt to the fourteen rows when the games begins.
-Cards on the tableau build down by suit in descending rank order.
-The foundations build up by suit. Any card or movable pile may be
-played on an empty row. The four reserve stacks hold one card each.
+All cards are dealt to the fourteen rows when the games begins.  Cards
+on the tableau build down by suit in descending rank order.  The foundations
+build up by suit.  Any card or movable pile may be played on an empty row.
+The four reserve stacks hold one card each.
+
 <h3>Strategy</h3>
-The first priority is to empty a row. Then don't fill it unless it
-or another row can be emptied by doing so.
-</body>
-</html>
+The first priority is to empty a row.  Then don't fill it
+unless it or another row can be emptied by doing so.

--- a/html-src/rules/giant.html
+++ b/html-src/rules/giant.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Giant</h1>
-<p>Gypsy type. 2 decks. No redeal.</p>
+<p>
+Gypsy type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="gypsy.html">Gypsy</a>, but you are only permitted
-to move cards back out of the foundations if the talon is
-empty.</p>
+<p>
+Like <a href="gypsy.html">Gypsy</a>,
+but you are only permitted to move cards back out of the foundations
+if the talon is empty.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/glenwood.html
+++ b/html-src/rules/glenwood.html
@@ -1,32 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Glenwood</h1>
-<p>Canfield type. 1 deck. One redeal.</p>
+<p>
+Canfield type. 1 deck. One redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The first item of play is to select an available card for the
-first Foundation. Once selected, all other Foundations must also
-start with this value.</p>
-<p>Foundations are built up by suit, wrapping from King to Ace
-where necessary. Once a card is placed on a Foundation pile, it is
-out of play.</p>
-<p>Cards in the Tableau are built down by alternating color. Whole
-piles of cards can be moved on to another Tableau pile. Empty slots
-in the Tableau can be filled by any available card in the Reserves
-or, if all the Reserves are empty, from the Waste.</p>
-<p>Cards are flipped singly from Stock to Waste. There is one
-redeal.</p>
+<p>
+The first item of play is to select an available card for the first
+Foundation. Once selected, all other Foundations must also start with this
+value.
+<p>
+Foundations are built up by suit, wrapping from King to Ace where necessary.
+Once a card is placed on a Foundation pile, it is out of play.
+<p>
+Cards in the Tableau are built down by alternating color. Whole piles of cards
+can be moved on to another Tableau pile. Empty slots in the Tableau can be
+filled by any available card in the Reserves or, if all the Reserves are
+empty, from the Waste.
+<p>
+Cards are flipped singly from Stock to Waste. There is one redeal.
+
 <h3>Strategy</h3>
-<p>Be careful when selecting your first Foundation pile. Try to get
-the cards out of the Reserves as early as possible. Sometimes
-keeping cards in play is more important than moving them to the
-Foundation.</p>
-</body>
-</html>
+<p>
+Be careful when selecting your first Foundation pile. Try to get the cards out
+of the Reserves as early as possible. Sometimes keeping cards in play is more
+important than moving them to the Foundation.

--- a/html-src/rules/golf.html
+++ b/html-src/rules/golf.html
@@ -1,25 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Golf</h1>
-<p>Golf type. 1 deck. No redeal.</p>
+<p>
+Golf type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the waste stack.</p>
+<p>
+Move all cards to the waste stack.
+
 <h3>Rules</h3>
-<p>Build on the waste stack in sequence either up or down
-regardless of suit.</p>
-<p>Only the top card is available for play on the piles. When no
-more moves are possible, click on the talon to deal a new card.</p>
-<p>Sequences do not wrap around, i.e. only Twos may be placed on
-Aces and only Queens may be placed on Kings.</p>
+<p>
+Build on the waste stack in sequence either up or down regardless of suit.
+<p>
+Only the top card is available for play on the piles. When no more moves are
+possible, click on the talon to deal a new card.
+<p>
+Sequences do not wrap around, i.e. only Twos may be placed on Aces
+and only Queens may be placed on Kings.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
+<p>
+<i>Autodrop</i> is disabled for this game.
+
 <h3>Strategy</h3>
-<p>Save Twos for Aces and Queens for Kings.</p>
-</body>
-</html>
+<p>
+Save Twos for Aces and Queens for Kings.

--- a/html-src/rules/goodmeasure.html
+++ b/html-src/rules/goodmeasure.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Good Measure</h1>
-<p>Baker's Dozen type. 1 deck. No redeal.</p>
+<p>
+Baker's Dozen type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="bakersdozen.html">Baker's Dozen</a>, but 10 piles,
-and 2 Aces are moved to the foundations at the start of the
-game.</p>
+<p>
+Like <a href="bakersdozen.html">Baker's Dozen</a>,
+but 10 piles, and 2 Aces are moved to the foundations
+at the start of the game.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/grandfathersclock.html
+++ b/html-src/rules/grandfathersclock.html
@@ -1,24 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Grandfather's Clock</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Move cards to the foundations until the top of each foundation
-is the clock number for that position. Jack equals 11, Queen equals
-12, and Aces must be placed on Kings.</p>
-<p>The playing piles build down by rank regardless of suit. Only
-the top card is available for play, and empty rows may be filled
-with any single card.</p>
+<p>
+Move cards to the foundations until the top of each foundation is the
+clock number for that position. Jack equals 11, Queen equals 12, and
+Aces must be placed on Kings.
+<p>
+The playing piles build down by rank regardless of suit. Only the top card
+is available for play, and empty rows may be filled with any single card.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> and <i>Quickplay</i> are disabled for this
-game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> and <i>Quickplay</i> are disabled for this game.

--- a/html-src/rules/grandmothersgame.html
+++ b/html-src/rules/grandmothersgame.html
@@ -1,40 +1,43 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Grandmother's Game</h1>
-<p>Spider type. 2 decks. No redeal.</p>
+<p>
+Spider type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="relaxedspider.html">Relaxed Spider</a>, but
-deal 60 cards face up at game start.</p>
+<p>
+Just like <a href="relaxedspider.html">Relaxed Spider</a>,
+but deal 60 cards face up at game start.
+
 <h3>Rules</h3>
-<p>60 cards are dealt open face in 10 piles. Piles build down by
-rank, regardless of suit. However, sequences that are all of the
-same suit are preferred because these are available for further
-movement.</p>
-<p>A free space can be filled by any single card or sequence.</p>
-<p>The object is to group the cards in sets of 13 cards, from King
-to Ace of the same suit. Such groups can be moved to a free space
-and then off the game by a mouseclick.</p>
-<p>When no more sensible moves are available, click on the talon.
-One card will be added to each of the playing piles (this includes
-the at this time free spaces too).</p>
-<p>You may deal new cards at any time.</p>
+<p>
+60 cards are dealt open face in 10 piles.
+Piles build down by rank, regardless of suit.
+However, sequences that are all of the same suit are preferred
+because these are available for further movement.
+<p>
+A free space can be filled by any single card or sequence.
+<p>
+The object is to group the cards in sets of 13 cards, from King to Ace
+of the same suit. Such groups can be moved to a free space and then off
+the game by a mouseclick.
+<p>
+When no more sensible moves are available, click on the talon. One card
+will be added to each of the playing piles (this includes the at this time
+free spaces too).
+<p>
+You may deal new cards at any time.
+
 <h3>Strategy</h3>
-<p>Grandmother's Game is a complex strategic solitaire game which
-cannot be solved very often. A good way to get to a satisfactory
-solution is to establish at least one, better two or even more,
-free spaces to get room for moving the cards and fit them together
-to descending suits.</p>
+<p>
+Grandmother's Game is a complex strategic solitaire game which cannot be
+solved very often. A good way to get to a satisfactory solution is to establish
+at least one, better two or even more, free spaces to get room for moving
+the cards and fit them together to descending suits.
+
 <h3>History</h3>
-<p>This is a <a href="spider.html">Spider type game</a> of German
-origin.</p>
-</body>
-</html>
+<p>
+This is a <a href="spider.html">Spider type game</a> of German origin.

--- a/html-src/rules/grasshopper.html
+++ b/html-src/rules/grasshopper.html
@@ -1,35 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Grasshopper</h1>
-<p>Tarock type. 1 deck. 1 redeal.</p>
+<p>
+Tarock type. 1 deck. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The tableau consists of one reserve stack, one Trumps only row
-stack, and five row stacks. Fourteen cards are dealt to the reserve
-stack and one card each to the row stacks. When a row stack is
-emptied it must be filled from the reserve stack first. When the
-reserve stack is empty any card can be played on an empty row
-stack. The Trumps only stack is left empty and can be played on at
-will. The row stacks build down in rank by alternate colors. The
-Trumps can be played as either color. The Trumps only row stack
-also builds down in rank. It will accept a stack of cards that
-contains suit cards as long as the bottom card is a Trump. The
-foundations build up in rank by suit.</p>
+<p>
+The tableau consists of one reserve stack, one Trumps only row stack,
+and five row stacks.  Fourteen cards are dealt to the reserve
+stack and one card each to the row stacks.  When a row stack is emptied
+it must be filled from the reserve stack first.  When the reserve stack
+is empty any card can be played on an empty row stack.  The Trumps only
+stack is left empty and can be played on at will.  The row stacks
+build down in rank by alternate colors.  The Trumps can be played as
+either color.  The Trumps only row stack also builds down in rank.  It
+will accept a stack of cards that contains suit cards as long as the
+bottom card is a Trump.  The foundations build up in rank by suit.
+
 <h3>Strategy</h3>
-<p>The first priority is to empty the reserve stack. Once that's
-done try to keep one or more row stacks open. Play high rank cards
-on the rows and build down on them. The same goes for the Trumps
-only row.</p>
+<p>
+The first priority is to empty the reserve stack.  Once that's done
+try to keep one or more row stacks open.  Play
+high rank cards on the rows and build down on them.  The same goes for
+the Trumps only row.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/greaterqueue.html
+++ b/html-src/rules/greaterqueue.html
@@ -1,25 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Greater Queue</h1>
 Braid type. 4 decks. Two redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="braid.html">Braid</a>.
+Play is similar to
+<a href="braid.html">Braid</a>.
+
 <h3>Rules</h3>
-Twenty five cards are dealt to the Braid when the game begins. The
-foundations build in ascending suit order from Pine to Paulownia by
-rank. Cards are dealt from the talon one at a time and two redeals
-are allowed. Cards may not be played from the foundations.
+Twenty five cards are dealt to the Braid when the game begins.
+The foundations build in ascending suit order from Pine to Paulownia by rank.
+Cards are dealt from the talon one at a time and two redeals are allowed.
+Cards may not be played from the foundations.
+
 <h3>Strategy</h3>
-Build sequences on the rows that will play when the correct card
-turns over from the talon. Braid type games require careful
-strategy to win.
-</body>
-</html>
+Build sequences on the rows that will play when the correct card turns
+over from the talon.  Braid type games require careful strategy to win.

--- a/html-src/rules/greatwall.html
+++ b/html-src/rules/greatwall.html
@@ -1,41 +1,44 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Great Wall</h1>
-<p>Hanafuda type. 4 decks. No redeal.</p>
+<p>
+Hanafuda type. 4 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards can be played on the tableau by suits or by rank. Plum 1
-plays on Pine 1, Maple 3 on Mum 3, Pine 2 on Phoenix 2, etc. Any
-second rank card can be played on any first. The third and fourth
-ranks are interchangeable for all suits. Only first rank cards can
-be played on the canvas. There can be no more than 26 cards in a
-row.</p>
-<p>The foundations are of two types. The finish foundations at the
-top on the left and right, and the build foundations on the bottom.
-Cards must be played on the foundations by rank in suit order. The
-finish foundations will only accept cards as a complete set of all
-twelve suits. The build foundations will accept only one card at a
-time. The finish foundations will accept three complete sets of
-suits. The build foundations will accept one. When all four decks
-are on the foundations in order, you have won. Cards can be moved
-from the build foundations to the finish foundations or to the
-tableau. They cannot be moved from the finish foundations.</p>
+<p>
+Cards can be played on the tableau by suits or by rank.
+Plum 1 plays on Pine 1, Maple 3 on Mum 3, Pine 2 on
+Phoenix 2, etc.  Any second rank card can be played on
+any first.  The third and fourth ranks are interchangeable
+for all suits.  Only first rank cards can be played on the
+canvas.  There can be no more than 26 cards in a row.
+<p>
+The foundations are of two types.  The finish foundations
+at the top on the left and right, and the build foundations
+on the bottom.  Cards must be played on the foundations by
+rank in suit order.  The finish foundations will only accept
+cards as a complete set of all twelve suits.  The build
+foundations will accept only one card at a time.
+The finish foundations will accept three complete sets
+of suits.  The build foundations will accept one.  When
+all four decks are on the foundations in order, you have
+won.  Cards can be moved from the build foundations to
+the finish foundations or to the tableau.  They cannot
+be moved from the finish foundations.
+
 <h3>Strategy</h3>
-<p>Since any particular card will usually play in several different
-places on the tableau it's probably possible to win every hand of
-Great Wall.</p>
-<p>Hint: don't play all your first rank cards on the foundations
-until all the cards are face up.</p>
+<p>
+Since any particular card will usually play in several
+different places on the tableau it's probably possible to
+win every hand of Great Wall.
+<p>
+Hint: don't play all your first rank cards on the foundations
+until all the cards are face up.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/griffon.html
+++ b/html-src/rules/griffon.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Griffon</h1>
-<p>Yukon type. 2 decks. No redeal.</p>
+<p>
+Yukon type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-<p>Just like <a href="milliganharp.html">Milligan Harp</a>, but
-with seven piles, and deal all cards face-up.</p>
+<p>
+Just like <a href="milliganharp.html">Milligan Harp</a>,
+but with seven piles, and deal all cards face-up.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/groundsforadivorce.html
+++ b/html-src/rules/groundsforadivorce.html
@@ -1,34 +1,39 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Grounds for a Divorce</h1>
-<p>Spider type. 2 decks. No redeal.</p>
+<p>
+Spider type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by same suit and move such sets to the foundations. The sequence
-may wrap around.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by same suit and move such sets to the foundations.
+The sequence may wrap around.
+
 <h3>Quick Description</h3>
-<p>Like <a href="spider.html">Spider</a>, but sequences wrap around
-from Ace to King, and no card will be dealt to an empty space.</p>
+<p>
+Like <a href="spider.html">Spider</a>,
+but sequences wrap around from Ace to King,
+and no card will be dealt to an empty space.
+
 <h3>Rules</h3>
-<p>50 cards are dealt in 10 piles. Cards are built down, regardless
-of suit. However, sequences that are all of the same suit are
-preferred because these are available for further movement. A space
-can be filled by any card or legal group of cards.</p>
-<p>Sequences wrap around, i.e. Kings may be placed on Aces.</p>
-<p>The object is to group the cards in descending sets of 13 cards
-of the same suit. These sequences may wrap around as well. Such
-groups can then be moved to the foundations.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each <i>non empty</i> space.</p>
+<p>
+50 cards are dealt in 10 piles. Cards are built down, regardless of suit.
+However, sequences that are all of the same suit are preferred because
+these are available for further movement.
+A space can be filled by any card or legal group of cards.
+<p>
+Sequences wrap around, i.e. Kings may be placed on Aces.
+<p>
+The object is to group the cards in descending sets of 13 cards of the
+same suit. These sequences may wrap around as well.
+Such groups can then be moved to the foundations.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each <i>non empty</i> space.
+
 <h3>History</h3>
-<p>This is my favorite <a href="spider.html">Spider</a> variant.
-Even more decisions, and with a fair chance of coming out. The
-original German name is <i>Scheidungsgrund</i>.</p>
-</body>
-</html>
+<p>
+This is my favorite
+<a href="spider.html">Spider</a>
+variant. Even more decisions, and
+with a fair chance of coming out.
+The original German name is <i>Scheidungsgrund</i>.

--- a/html-src/rules/gypsy.html
+++ b/html-src/rules/gypsy.html
@@ -1,33 +1,35 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Gypsy</h1>
-<p>Gypsy type. 2 decks. No redeal.</p>
+<p>
+Gypsy type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The eight playing piles in the tableau all start with two cards
-face-down and one showing. Piles build down by alternate color, and
-an empty space can be filled with any card or sequence.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles.</p>
-<p>You are also permitted to move cards back out of the
-foundation.</p>
+<p>
+The eight playing piles in the tableau all start with two
+cards face-down and one showing.
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each of the playing piles.
+<p>
+You are also permitted to move cards back out of the foundation.
+
 <h3>Strategy</h3>
-<p>Making heavy use of the Undo key is explicitly encouraged here -
-you can win quite a number of games with a little bit of
-thought.</p>
+<p>
+Making heavy use of the Undo key is explicitly encouraged here - you can win
+quite a number of games with a little bit of thought.
+
 <h3>History</h3>
-<p>Gypsy is my all time favorite - it is probably the reason that I
-started writing PySol at all...</p>
-<p>I first met Gypsy almost fifteen years ago in the nice Atari ST
-game <i>Patience</i> written by Volker Weidner. And as there seems
-to be no official name of this variant I adopted the name Gypsy
-from another game called <i>xpat2</i>.</p>
-</body>
-</html>
+<p>
+Gypsy is my all time favorite - it is probably the reason
+that I started writing PySol at all...
+<p>
+I first met Gypsy almost fifteen years ago in the nice
+Atari ST game <i>Patience</i> written by Volker Weidner.
+And as there seems to be no official name of
+this variant I adopted the name Gypsy from another
+game called <i>xpat2</i>.

--- a/html-src/rules/hanafudafourseasons.html
+++ b/html-src/rules/hanafudafourseasons.html
@@ -1,23 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Four Seasons</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Arrange all the cards on the rows.
+
 <h3>Rules</h3>
-This is a <a href="fan.html">Fan</a> type game adapted to the
-Hanafuda cards. The tableau consists of twelve rows. Any stack may
-be moved, but only a first rank card will play on an empty row. The
-trash cards are not interchangeable, and no more than eight cards
-can be played on a row. The game is won when all twelve suits are
-arranged in order in their respective places on the tableau.
+This is a <a href="fan.html">Fan</a>
+type game adapted to the Hanafuda cards.  The tableau consists of
+twelve rows.  Any stack may be moved, but only a first rank card
+will play on an empty row.  The trash cards are not interchangeable,
+and no more than eight cards can be played on a row.  The game is
+won when all twelve suits are arranged in order in their respective
+places on the tableau.
+
 <h3>Strategy</h3>
-Not all Four Seasons hands are solvable. Try to get an open row.
-</body>
-</html>
+Not all Four Seasons hands are solvable.  Try to get an open row.

--- a/html-src/rules/hanafudafourwinds.html
+++ b/html-src/rules/hanafudafourwinds.html
@@ -1,29 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Four Winds</h1>
-<p>Hanafuda type. 1 deck. 1 redeal.</p>
+<p>
+Hanafuda type. 1 deck. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards play on the four foundation stacks by rank, in ascending
-suit order. Cards play on the four row stacks in descending suit
-order. The row stacks will hold no more than three cards. Only one
-card can be move at a time. Any card can be played on an empty row
-stack, but only cards of the same rank can play on partly filled
-rows. There are only two passes through the talon.</p>
+<p>
+Cards play on the four foundation stacks by rank, in ascending suit order.
+Cards play on the four row stacks in descending suit order.  The row stacks
+will hold no more than three cards.  Only one card can be move at a time.
+Any card can be played on an empty row stack, but only cards of the same
+rank can play on partly filled rows.  There are only two passes through
+the talon.
+
 <h3>Strategy</h3>
-<p>Winning at Four Winds requires a bit of luck and a lot of skill
-at using the row stacks to the best advantage.</p>
-<p>Hint: try to keep one row stack open.</p>
+<p>
+Winning at Four Winds requires a bit of luck and a lot of skill at
+using the row stacks to the best advantage.
+<p>
+Hint: try to keep one row stack open.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/hanoisequence.html
+++ b/html-src/rules/hanoisequence.html
@@ -1,24 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Hanoi Sequence</h1>
-<p>Puzzle game type. 9 cards. No redeal.</p>
+<p>
+Puzzle game type. 9 cards. No redeal.
+
 <h3>Object</h3>
-<p>Build a pile containing all 9 cards down by sequence.</p>
+<p>
+Build a pile containing all 9 cards down by sequence.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Tower of Hanoy</a>, but build a
-pile down <b>by sequence</b>.</p>
+<p>
+Like <a href="klondike.html">Tower of Hanoy</a>,
+but build a pile down <b>by sequence</b>.
+
 <h3>Rules</h3>
-<p>A card may only be placed onto another card that is of higher
-rank.</p>
-<p>Only the top card may be moved, and spaces may be filled with
-any single card.</p>
+<p>
+A card may only be placed onto another card that is of higher rank.
+<p>
+Only the top card may be moved, and spaces may be filled
+with any single card.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/hayagriva.html
+++ b/html-src/rules/hayagriva.html
@@ -1,25 +1,14 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Hayagriva</h1>
 Dashavatara Ganjifa type. One deck. No redeal.
 <h3>Object</h3>
 Move all cards to the foundations.
 <h3>Quick description</h3>
-The cards build down by rank only on the tableau, no more than
-twelve to a row. Only the Rajas may be played on an empty row.
+The cards build down by rank only on the tableau, no more
+than twelve to a row.  Only the Rajas may be played on an empty row.
 <h3>Rules</h3>
-All cards are dealt to the sixteen rows when the games begins.
-Cards on the tableau build down in rank only. The foundations build
-up by suit. Only a Raja or sequence may be played on an empty row.
-The four reserve stacks hold one card each.
+All cards are dealt to the sixteen rows when the games begins.  Cards
+on the tableau build down in rank only.  The foundations build up by suit.
+Only a Raja or sequence may be played on an empty row.  The four reserve
+stacks hold one card each.
 <h3>Strategy</h3>
-An empty row is somewhat more useful than the reserve stacks. Try
-for an empty row.
-</body>
-</html>
+An empty row is somewhat more useful than the reserve stacks.  Try for an empty row.

--- a/html-src/rules/hexaklon.html
+++ b/html-src/rules/hexaklon.html
@@ -1,38 +1,36 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Hex A Klon</h1>
-<p>Hex A Deck type. 1 deck. Unlimited redeals.</p>
+<p>
+Hex A Deck type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, except any card can
-be played on an empty row and the Wizards (Jokers) are wild.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>, except any card can
+be played on an empty row and the Wizards (Jokers) are wild.
+
 <h3>Rules</h3>
-<p>Game play is like Klondike with the Wizards being wild. They can
-be played on the tableau as any rank or color. Once a Wizard is
-played on a row however that row may become unmovable. The Wizards
-have ranks like the suit cards corresponding to Ace through Four.
-If a Wizard is played in it's proper rank position the row can
-still be moved. The rank can be determined by the height of the
-hat. The Ace Wizard has the tallest hat. A stack with two Wizards
-can be moved only if they are both in their rank position and they
-are not ajacent to each other. The Wizards will not move off of the
-tableau until all the other cards have been moved to the
-foundations.</p>
+<p>
+Game play is like Klondike with the Wizards being wild.  They can be played
+on the tableau as any rank or color.  Once a Wizard is played on a row however
+that row may become unmovable.  The Wizards have ranks like the suit cards
+corresponding to Ace through Four.  If a Wizard is played in it's proper rank
+position the row can still be moved.  The rank can be determined by the height
+of the hat.  The Ace Wizard has the tallest hat.  A stack with two Wizards can
+be moved only if they are both in their rank position and they are not ajacent
+to each other.  The Wizards will not move off of the tableau until all the other
+cards have been moved to the foundations.
+
 <h3>Strategy</h3>
-<p>Keep the Wizards off of piles that contain face down cards. Once
-all the cards on the tableau are face up try to get the Wizards out
-of the way. Put them all on one row stack until the suit cards have
-been moved to the foundations.</p>
+<p>
+Keep the Wizards off of piles that contain face down cards.  Once all the
+cards on the tableau are face up try to get the Wizards out of the way.  Put
+them all on one row stack until the suit cards have been moved to the foundations.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/hexaklonbythrees.html
+++ b/html-src/rules/hexaklonbythrees.html
@@ -1,33 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Hex A Klon by Three</h1>
 Klondike type. One deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="klondike.html">Klondike</a> with <a href=
-"../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="klondike.html">Klondike</a>
+with <a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like Klondike with the Wizards being wild. They can be
-played on the tableau as any rank or color. Once a Wizard is played
-on a row however that row may become unmovable. If a Wizard is
-played in it's proper rank position the row can still be moved. A
-stack with two Wizards can be moved only if they are both in their
-rank position and they are not adjacent to each other. The Wizards
-will not move off of the tableau until all the other cards have
-been moved to the foundations. Cards are dealt from the talon three
-at a time. Any card or sequence may be played on the canvas. Cards
-may be played from the foundations.
+Game play is like Klondike with the Wizards being wild.  They can be played
+on the tableau as any rank or color.  Once a Wizard is played on a row however
+that row may become unmovable.  If a Wizard is played in it's proper rank
+position the row can still be moved.  A stack with two Wizards can be moved
+only if they are both in their rank position and they are not adjacent to
+each other.  The Wizards will not move off of the tableau until all the other
+cards have been moved to the foundations.  Cards are dealt from the talon three
+at a time.  Any card or sequence may be played on the canvas.  Cards may
+be played from the foundations.
+
 <h3>Strategy</h3>
-Keep the Wizards off of piles that contain face down cards. Once
-all the cards on the tableau are face up try to get the Wizards out
-of the way. Put them all on one row stack until the suit cards have
-been moved to the foundations.
-</body>
-</html>
+Keep the Wizards off of piles that contain face down cards.  Once all the
+cards on the tableau are face up try to get the Wizards out of the way.  Put
+them all on one row stack until the suit cards have been moved to the foundations.

--- a/html-src/rules/hexlabyrinth.html
+++ b/html-src/rules/hexlabyrinth.html
@@ -1,23 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Hex Labyrinth</h1>
-<p>FreeCell type. Two Hex A Decks. No redeal.</p>
+<p>
+FreeCell type.  Two Hex A Decks.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, with the Hex A Deck
-Variations and the number of cards you can move as a sequence is
-not restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+with the Hex A Deck Variations and the number of cards you can move as a
+sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-King or "Ten" (hexadecimal) starting a new pile. Rows build down in
-rank and alternate colors. The Wizards play as any color. Empty
-rows cannot be filled.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each King or "Ten"
+(hexadecimal) starting a new pile.  Rows build down in rank and alternate
+colors.  The Wizards play as any color.  Empty rows cannot be filled.

--- a/html-src/rules/hiddenpassages.html
+++ b/html-src/rules/hiddenpassages.html
@@ -1,28 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Hidden Passages</h1>
 Klondike type. One deck. One redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="blindalleys.html">Blind Alleys</a> with
-<a href="../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="blindalleys.html">Blind Alleys</a>
+with <a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like Blind Alleys. The rows build down in rank in
-alternate color. Any card or sequence may be played on an empty
-row. The Wizards will play in their proper rank position on the
-tableau as the alternate of either red or black. Cards are dealt
-from the talon one at a time. The four suit Aces are dealt to the
-foundations at the start of the game. Cards may be played from the
-foundations.
+Game play is like Blind Alleys.  The rows build down in rank in alternate
+color.  Any card or sequence may be played on an empty row.  The Wizards
+will play in their proper rank position on the tableau as the alternate
+of either red or black.  Cards are dealt from the talon one at a time.
+The four suit Aces are dealt to the foundations at the start of the
+game.  Cards may be played from the foundations.
 <h3>Strategy</h3>
-The Wizards will not play to their foundation until all the suit
-cards are on theirs. This can make the end game a real challenge.
-</body>
-</html>
+The Wizards will not play to their foundation until all the suit cards
+are on theirs.  This can make the end game a real challenge.

--- a/html-src/rules/hiranyaksha.html
+++ b/html-src/rules/hiranyaksha.html
@@ -1,23 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Hiranyaksha</h1>
-<p>FreeCell type. One Dashavatara Ganjifa Deck. No redeal.</p>
+<p>
+FreeCell type.  One Dashavatara Ganjifa Deck.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, using the ten suit
-Dashavatara Ganjifa deck and the number of cards you can move as a
-sequence is not restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+using the ten suit Dashavatara Ganjifa deck and the number of cards you can
+move as a sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-Raja or King starting a new pile. Rows build down in rank
-regardless of suit. Empty rows cannot be filled. The ten free cells
-will hold one card each.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each Raja or King
+starting a new pile.  Rows build down in rank regardless of suit.
+Empty rows cannot be filled. The ten free cells will hold one card each.

--- a/html-src/rules/hopscotch.html
+++ b/html-src/rules/hopscotch.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Hopscotch</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="calculation.html">Calculation</a>, but the
-initial foundation cards are in club suit.</p>
+<p>
+Just like <a href="calculation.html">Calculation</a>,
+but the initial foundation cards are in club suit.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/imperialtrumps.html
+++ b/html-src/rules/imperialtrumps.html
@@ -1,34 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Imperial Trumps</h1>
-<p>Tarock type. 1 deck. Unlimited redeals.</p>
+<p>
+Tarock type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>This game is similar to Klondike except the twenty-two trump
-cards will play on any suit card of the next higher rank. Cards
-will play on the foundation only if the trump card of equal rank is
-played first. That means the Ace of Spades won't play on the Spade
-foundation until the Ace of Trumps is played on the Trump
-foundation. Only Kings or the highest ranked Trump can be played on
-an empty row stack. The highest Trump is called either the Fool or
-the Skiz depending on the type of deck. It has either the number 0
-or is not numbered. Cards can be played from the foundations to the
-tableau.</p>
+<p>
+This game is similar to Klondike except the twenty-two trump
+cards will play on any suit card of the next higher rank.
+Cards will play on the foundation only if the trump card of
+equal rank is played first.  That means the Ace of Spades
+won't play on the Spade foundation until the Ace of Trumps
+is played on the Trump foundation.  Only Kings or the highest
+ranked Trump can be played on an empty row stack.  The highest
+Trump is called either the Fool or the Skiz depending on the
+type of deck.  It has either the number 0 or is not numbered.
+Cards can be played from the foundations to the tableau.
+
 <h3>Strategy</h3>
-<p>Skillful tableau play with the trumps can make all the
-difference in this game. You can move a trump from a red card to a
-black card of the same rank. This will open the red card for a
-black one of the next lower rank.</p>
+<p>
+Skillful tableau play with the trumps can make all the difference
+in this game.  You can move a trump from a red card to a
+black card of the same rank.  This will open the red card for
+a black one of the next lower rank.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/indian.html
+++ b/html-src/rules/indian.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Indian</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the
-piles build down by any suit but own.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the piles build down by any suit but own.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/interregnum.html
+++ b/html-src/rules/interregnum.html
@@ -1,28 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Interregnum</h1>
-<p>Numerica type. 2 decks. No redeal.</p>
+<p>
+Numerica type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations build up by rank ignoring suit. The base rank
-for each foundation is one higher than the reserve above it.</p>
-<p>Each foundation must be completed by using the card from the
-reserve above it.</p>
-<p>There is no building on the tableau piles - cards can only be
-moved to the foundations, and spaces are not filled.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles.</p>
+<p>
+The foundations build up by rank ignoring suit. The base rank for
+each foundation is one higher than the reserve above it.
+<p>
+Each foundation must be completed by using the card from the reserve above it.
+<p>
+There is no building on the tableau piles - cards can only be
+moved to the foundations, and spaces are not filled.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each of the playing piles.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
+<p>
+<i>Autodrop</i> is disabled for this game.
+
 <h3>Histoy</h3>
-<p>This is a two-deck variation of <a href="auldlangsyne.html">Auld
-Lang Syne</a>.</p>
-</body>
-</html>
+<p>
+This is a two-deck variation of
+<a href="auldlangsyne.html">Auld Lang Syne</a>.

--- a/html-src/rules/iris.html
+++ b/html-src/rules/iris.html
@@ -1,27 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Iris</h1>
 Hanafuda type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="paulownia.html">Iris</a>. The rows
-build down in rank by same suit. The foundations build up in rank
-by suit.
+Play is similar to
+<a href="paulownia.html">Iris</a>.
+The rows build down in rank by same suit.  The foundations
+build up in rank by suit.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build from fourth to first. The third and fourth rank
-(trash) cards are not interchangeable on the tableau. Cards may not
-be played from the foundations. Cards are dealt from the talon
-three at a time. Only first rank cards or correctly ordered piles
-may be played on an empty row.
+The rows build from first rank to fourth rank by suit.  The foundations
+build from fourth to first.  The third and fourth rank (trash) cards are
+not interchangeable on the tableau.  Cards may not be played from the
+foundations.  Cards are dealt from the talon three at a time.  Only first
+rank cards or correctly ordered piles may be played on an empty row.
+
 <h3>Strategy</h3>
 Uncover the deepest row stacks first.
-</body>
-</html>

--- a/html-src/rules/irmgard.html
+++ b/html-src/rules/irmgard.html
@@ -1,29 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Irmgard</h1>
-<p>Gypsy type. 2 decks. No redeal.</p>
+<p>
+Gypsy type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="gypsy.html">Gypsy</a>, but 9 piles and only Kings
-on empty spaces.</p>
+<p>
+Like <a href="gypsy.html">Gypsy</a>,
+but 9 piles and only Kings on empty spaces.
+
 <h3>Rules</h3>
-<p>The playing piles build down by alternate color, and an empty
-space can only be filled by a King or a sequence starting with a
-King.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles, except for the last
-turn where only 7 cards will be dealt.</p>
-<p>You are also permitted to move cards back out of the
-foundation.</p>
+<p>
+The playing piles build down by alternate color, and an empty space
+can only be filled by a King or a sequence starting with a King.
+<p>
+When no more moves are possible, click on the talon.  One card will be
+added to each of the playing piles, except for the last turn where only
+7 cards will be dealt.
+<p>
+You are also permitted to move cards back out of the foundation.
+
 <h3>Notes</h3>
-<p>As with Gypsy you are allowed to make heavy use of the Undo
-key.</p>
-</body>
-</html>
+<p>
+As with Gypsy you are allowed to make heavy use of the Undo key.

--- a/html-src/rules/jane.html
+++ b/html-src/rules/jane.html
@@ -1,34 +1,32 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Jane</h1>
-<p>Raglan type. 1 deck. No redeals.</p>
+<p>
+Raglan type. 1 deck. No redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards in the Tableau are built down by alternating color. Groups
-of cards can be moved. An empty pile in the Tableau can be filled
-with a card whose rank is one lower than the base card or with a
-group of cards starting with a card with this rank.</p>
-<p>Cards are dealt from the Stock to the Reserve. Each deal places
-one card on each pile of the Reserve.</p>
-<p>The top card of each Reserve pile is always available for play
-on to either the Tableau or the Foundation. There is no building on
-the Reserve piles.</p>
-<p>Foundations are built up in suit from the base card. New
-Foundations are started when a card of the same rank as the first
-card placed during the dealing period are placed on empty
-Foundation piles. Aces are placed on Kings, and twos on Aces. Cards
-in Foundations are still in play. Double clicking on a card will
-move it to the appropriate Foundation pile if such a move is
-possible.</p>
+<p>
+Cards in the Tableau are built down by alternating color. Groups of cards can
+be moved. An empty pile in the Tableau can be filled with a card whose rank is
+one lower than the base card or with a group of cards starting with a card
+with this rank.
+<p>
+Cards are dealt from the Stock to the Reserve. Each deal places one card on
+each pile of the Reserve.
+<p>
+The top card of each Reserve pile is always available for play on to either
+the Tableau or the Foundation. There is no building on the Reserve piles.
+<p>
+Foundations are built up in suit from the base card. New Foundations are
+started when a card of the same rank as the first card placed during the
+dealing period are placed on empty Foundation piles. Aces are placed on Kings,
+and twos on Aces. Cards in Foundations are still in play. Double clicking on a
+card will move it to the appropriate Foundation pile if such a move is
+possible.
+
 <h3>Strategy</h3>
-<p>The deeper something is, the harder it is to get to. Try and
-move cards out of the Reserve whenever possible.</p>
-</body>
-</html>
+<p>
+The deeper something is, the harder it is to get to. Try and move cards out of
+the Reserve whenever possible.

--- a/html-src/rules/japanesegarden.html
+++ b/html-src/rules/japanesegarden.html
@@ -1,27 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Japanese Garden</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Rules</h3>
-This is a <a href="fan.html">Fan</a> type game adapted to the
-Hanafuda cards. The tableau consists of six flower beds in two rows
-above and a Koi pond below with the foundations at the top. Cards
-build from first to fourth rank on the tableau by suit and from
-fourth to first on the foundations. Only first rank cards may be
-played on an empty row. No more than six cards may be played on a
-row. Cards may be moved from the Koi pond to either the rows or the
-foundations but may not be moved to the pond. Only one card may be
-moved at a time.
+This is a <a href="fan.html">Fan</a>
+type game adapted to the Hanafuda cards.  The tableau consists of
+six flower beds in two rows above and a Koi pond below with the
+foundations at the top.  Cards build from first to fourth rank
+on the tableau by suit and from fourth to first on the foundations.
+Only first rank cards may be played on an empty row.  No more than
+six cards may be played on a row.  Cards may be moved from the Koi
+pond to either the rows or the foundations but may not be moved to
+the pond.  Only one card may be moved at a time.
+
 <h3>Strategy</h3>
 It's not at all unusual to have no possible moves after dropping
-cards to the foundations. Try to get an open row.
-</body>
-</html>
+cards to the foundations.  Try to get an open row.

--- a/html-src/rules/japanesegardenii.html
+++ b/html-src/rules/japanesegardenii.html
@@ -1,18 +1,11 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Japanese Garden II</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Rules</h3>
-Play is identical to <a href="japanesegarden.html">Japanese
-Garden</a> except cards may only be played from the Koi pond to the
-foundations, not to the rows.
-</body>
-</html>
+Play is identical to
+<a href="japanesegarden.html">Japanese Garden</a>
+except cards may only be played from the Koi pond to the foundations,
+not to the rows.

--- a/html-src/rules/japanesegardeniii.html
+++ b/html-src/rules/japanesegardeniii.html
@@ -1,18 +1,11 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Japanese Garden III</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Rules</h3>
-Play is identical to <a href="japanesegarden.html">Japanese
-Garden</a> except there are eight flower bed row stacks that will
-each hold up to seven cards. There is no Koi pond in this garden.
-</body>
-</html>
+Play is identical to
+<a href="japanesegarden.html">Japanese Garden</a>
+except there are eight flower bed row stacks that will each
+hold up to seven cards.  There is no Koi pond in this garden.

--- a/html-src/rules/journeytocuddapah.html
+++ b/html-src/rules/journeytocuddapah.html
@@ -1,34 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Journey to Cuddapah</h1>
 Braid type. One deck. Two redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
 <h3>Quick description</h3>
-Similar to <a href="braid.html">Braid</a> played with a single
-Dashavatara <a href="../ganjifa.html">Ganjifa</a> deck.
+Similar to <a href="braid.html">Braid</a>
+played with a single Dashavatara
+<a href="../ganjifa.html">Ganjifa</a>
+deck.
+
 <h3>Rules</h3>
-Game play is like Braid. In this variation there are two Braid
-stacks that each have their own set of Braid reserve stacks. The
-game lay out starts with the ten foundations in the outer most
-columns. The next two columns inwards are the ten Braid reserves.
-Then there are two columns with five general reserves each. The
-inner most two columns are the two Braid stacks. Each Braid starts
-with fifteen cards. When one of the Braid reserves becomes open the
-card at the top of the corresponding Braid will be moved there.
-When all the cards from one of the Braids are removed a card from
-the other Braid will be used.
-<p>Cuddapah is a city in India with a history in the production of
-Ganjifa cards.</p>
+Game play is like Braid.  In this variation there are two Braid
+stacks that each have their own set of Braid reserve stacks.  The
+game lay out starts with the ten foundations in the outer most columns.
+The next two columns inwards are the ten Braid reserves.  Then there
+are two columns with five general reserves each.  The inner most two
+columns are the two Braid stacks.  Each Braid starts with fifteen cards.
+When one of the Braid reserves becomes open the card at the top of the
+corresponding Braid will be moved there.  When all the cards from one
+of the Braids are removed a card from the other Braid will be used.
+<p>
+Cuddapah is a city in India with a history in the production of Ganjifa cards.
 <h3>Strategy</h3>
-Build sequences on the rows that will play when the correct card
-turns over from the talon. This game type requires careful strategy
-to win.
-</body>
-</html>
+Build sequences on the rows that will play when the correct card turns
+over from the talon.  This game type requires careful strategy to win.

--- a/html-src/rules/jumbo.html
+++ b/html-src/rules/jumbo.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Jumbo</h1>
-<p>Klondike type. 2 decks. One redeal.</p>
+<p>
+Klondike type. 2 decks. One redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but with two decks
-and nine playing piles.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but with two decks and nine playing piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/justforfun.html
+++ b/html-src/rules/justforfun.html
@@ -1,30 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Just For Fun</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="freecell.html">Free Cell</a>. The rows
-build down by rank in the same suit. The foundations build with
-cards of the same rank in suit order.
+Play is similar to
+<a href="freecell.html">Free Cell</a>.
+The rows build down by rank in the same suit.  The foundations
+build with cards of the same rank in suit order.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build in ascending suit order from Pine to Phoenix by
-rank. The third and fourth rank (trash) cards are not
-interchangeable on the tableau. Cards may not be played from the
-foundations. Only first rank cards or correctly ordered piles may
-be played on an empty row.
+The rows build from first rank to fourth rank by suit.  The foundations
+build in ascending suit order from Pine to Phoenix by rank.  The third
+and fourth rank (trash) cards are not interchangeable on the tableau.
+Cards may not be played from the foundations.  Only first rank cards
+or correctly ordered piles may be played on an empty row.
+
 <h3>Strategy</h3>
 Use the reserve stacks to release the fourth rank cards first.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/kalisgame.html
+++ b/html-src/rules/kalisgame.html
@@ -1,27 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Kali's Game</h1>
 Dashavatara Ganjifa game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with twelve
-rows and two redeals.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with twelve rows and two redeals.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to thirteen piles instead
-of fourteen and if a dealt card is of rank Pradhan or over one card
-is dealt to the talon. Only one 120 card Dashavatara deck is used.
-Otherwise the dealing rules are the same.
-<p>Play is the same as Lara's Game except that there are two
-redeals. When the talon is empty after each round the cards are
-gathered up from the tableau and dealt to the rows without being
-shuffled using the same dealing rules as in the first round.</p>
-</body>
-</html>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to thirteen piles instead of fourteen
+and if a dealt card is of rank Pradhan or over one card is dealt to the
+talon.  Only one 120 card Dashavatara deck is used.  Otherwise the
+dealing rules are the same.
+<p>
+Play is the same as Lara's Game except that there are two redeals.  When
+the talon is empty after each round the cards are gathered up from the
+tableau and dealt to the rows without being shuffled using the same
+dealing rules as in the first round.

--- a/html-src/rules/kalisgamedoubled.html
+++ b/html-src/rules/kalisgamedoubled.html
@@ -1,34 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Kali's Game</h1>
 Dashavatara Ganjifa game type. 2 decks. 3 redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with twelve
-rows, three redeals and a reserve stack.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with twelve rows, three redeals and a reserve stack.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to thirteen piles instead
-of fourteen and if a dealt card is of rank Pradhan or over one card
-is dealt to the talon. Only one 120 card Dashavatara deck is used.
-Otherwise the dealing rules are the same.
-<p>Play is the same as Lara's Game except that there are three
-redeals. When the talon is empty after each round the cards are
-gathered up from the tableau and dealt to the rows without being
-shuffled using the same dealing rules as in the first round. The
-foundations take two complete rounds of a suit. After the first
-Raja is played to a foundation the second Ace will play.</p>
-<p>The reserve stack will take any four cards from the rows.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to thirteen piles instead of fourteen
+and if a dealt card is of rank Pradhan or over one card is dealt to the
+talon.  Only one 120 card Dashavatara deck is used.  Otherwise the
+dealing rules are the same.
+<p>
+Play is the same as Lara's Game except that there are three redeals.  When
+the talon is empty after each round the cards are gathered up from the
+tableau and dealt to the rows without being shuffled using the same
+dealing rules as in the first round.  The foundations take two complete
+rounds of a suit.  After the first Raja is played to a foundation the
+second Ace will play.
+
+<p>
+The reserve stack will take any four cards from the rows.
+
 <h3>Strategy</h3>
-Use the reserve stack to allow buried cards to play. The best times
-to use it are just before a redeal. Once played to the reserve a
+Use the reserve stack to allow buried cards to play.  The best times
+to use it are just before a redeal.  Once played to the reserve a
 card may only be moved from it to a foundation.
-</body>
-</html>

--- a/html-src/rules/kalisgamerelaxed.html
+++ b/html-src/rules/kalisgamerelaxed.html
@@ -1,32 +1,30 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relaxed Kali's Game</h1>
 Dashavatara Ganjifa game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with twelve
-rows, two redeals and a reserve stack which will hold two cards.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with twelve rows, two redeals and a reserve stack
+which will hold two cards.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to thirteen piles instead
-of fourteen and if a dealt card is of rank Pradhan or over one card
-is dealt to the talon. Only one 120 card Dashavatara deck is used.
-Otherwise the dealing rules are the same.
-<p>Play is the same as Lara's Game except that there are two
-redeals. When the talon is empty after each round the cards are
-gathered up from the tableau and dealt to the rows without being
-shuffled using the same dealing rules as in the first round.</p>
-<p>The reserve stack will take any two cards from the rows.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to thirteen piles instead of fourteen
+and if a dealt card is of rank Pradhan or over one card is dealt to the
+talon.  Only one 120 card Dashavatara deck is used.  Otherwise the
+dealing rules are the same.
+<p>
+Play is the same as Lara's Game except that there are two redeals.  When
+the talon is empty after each round the cards are gathered up from the
+tableau and dealt to the rows without being shuffled using the same
+dealing rules as in the first round.
+
+<p>
+The reserve stack will take any two cards from the rows.
+
 <h3>Strategy</h3>
-Use the reserve stack to allow buried cards to play. The best times
-to use it are just before a redeal. Once played to the reserve a
+Use the reserve stack to allow buried cards to play.  The best times
+to use it are just before a redeal.  Once played to the reserve a
 card may only be moved from it to a foundation.
-</body>
-</html>

--- a/html-src/rules/katrinasgame.html
+++ b/html-src/rules/katrinasgame.html
@@ -1,31 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Katrina's Game</h1>
 Tarock game type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with twenty two
-rows and one redeal, using the Tarock deck.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with twenty two rows and one redeal, using the Tarock deck.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to twenty three piles
-instead of fourteen and if a dealt card is of rank Page or over one
-card is dealt to the talon. Otherwise the dealing rules are the
-same.
-<p>Play is the same as Lara's Game except that there is one redeal.
-When the talon is empty after the first round the cards are
-gathered up from the tableau and dealt to the rows without being
-shuffled using the same dealing rules as in the first round.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to twenty three piles instead of fourteen
+and if a dealt card is of rank Page or over one card is dealt to the
+talon.  Otherwise the dealing rules are the same.
+<p>
+Play is the same as Lara's Game except that there is one redeal.  When
+the talon is empty after the first round the cards are gathered up from
+the tableau and dealt to the rows without being shuffled using the same
+dealing rules as in the first round.
+
 <h3>Strategy</h3>
-If row two cards will play on the same foundation pick the card
-that is on the row that holds the most cards. Move cards from one
-set of foundations to the other to get extra plays.
-</body>
-</html>
+If row two cards will play on the same foundation pick the card that is on
+the row that holds the most cards.  Move cards from one set of foundations
+to the other to get extra plays.

--- a/html-src/rules/katrinasgamedoubled.html
+++ b/html-src/rules/katrinasgamedoubled.html
@@ -1,38 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Katrina's Game</h1>
 Tarock game type. 4 decks. 2 redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with twenty two
-rows and one redeal, using the Tarock deck. This is the same as
-<a href="katrinasgamerelaxed.html">Relaxed Katrina's Game</a> using
-four decks.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with twenty two rows and one redeal, using the Tarock deck.
+This is the same as <a href="katrinasgamerelaxed.html">Relaxed Katrina's Game</a>
+using four decks.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to twenty three piles
-instead of fourteen and if a dealt card is of rank Page or over one
-card is dealt to the talon. Otherwise the dealing rules are the
-same.
-<p>Play is the same as Lara's Game with two exceptions. The first
-exception is that there are two redeals. When the talon is empty
-after the one round the cards are gathered up from the tableau and
-dealt to the rows without being shuffled using the same dealing
-rules as in the first round.</p>
-<p>The other exception is the reserve stack just to the right of
-the foundations. This stack will take any three cards from any of
-the rows. Once played there however, a card may not be removed
-except by playing it to a foundation.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to twenty three piles instead of fourteen
+and if a dealt card is of rank Page or over one card is dealt to the
+talon.  Otherwise the dealing rules are the same.
+<p>
+Play is the same as Lara's Game with two exceptions.  The first exception
+is that there are two redeals.  When the talon is empty after the one
+round the cards are gathered up from the tableau and dealt to the rows
+without being shuffled using the same dealing rules as in the first round.
+<p>
+The other exception is the reserve stack just to the right of the foundations.
+This stack will take any three cards from any of the rows.  Once played there
+however, a card may not be removed except by playing it to a foundation.
+
 <h3>Strategy</h3>
-If two row cards will play on the same foundation pick the card
-that is on the row that holds the most cards. Move cards from one
-set of foundations to the other to get extra plays.
-</body>
-</html>
+If two row cards will play on the same foundation pick the card that is on
+the row that holds the most cards.  Move cards from one set of foundations
+to the other to get extra plays.

--- a/html-src/rules/katrinasgamerelaxed.html
+++ b/html-src/rules/katrinasgamerelaxed.html
@@ -1,38 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relaxed Katrina's Game</h1>
 Tarock game type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with twenty two
-rows and one redeal, using the Tarock deck. This is the same as
-<a href="katrinasgame.html">Katrina's Game</a> with a reserve
-stack.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with twenty two rows and one redeal, using the Tarock deck.
+This is the same as <a href="katrinasgame.html">Katrina's Game</a>
+with a reserve stack.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are that the cards are dealt to twenty three piles
-instead of fourteen and if a dealt card is of rank Page or over one
-card is dealt to the talon. Otherwise the dealing rules are the
-same.
-<p>Play is the same as Lara's Game with two exceptions. The first
-exception is that there is one redeal. When the talon is empty
-after the first round the cards are gathered up from the tableau
-and dealt to the rows without being shuffled using the same dealing
-rules as in the first round.</p>
-<p>The other exception is the reserve stack just to the right of
-the foundations. This stack will take any two cards from any of the
-rows. Once played there however, a card may not be removed except
-by playing it to a foundation.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are that the cards are dealt to twenty three piles instead of fourteen
+and if a dealt card is of rank Page or over one card is dealt to the
+talon.  Otherwise the dealing rules are the same.
+<p>
+Play is the same as Lara's Game with two exceptions.  The first exception
+is that there is one redeal.  When the talon is empty after the first
+round the cards are gathered up from the tableau and dealt to the rows
+without being shuffled using the same dealing rules as in the first round.
+<p>
+The other exception is the reserve stack just to the right of the foundations.
+This stack will take any two cards from any of the rows.  Once played there
+however, a card may not be removed except by playing it to a foundation.
+
 <h3>Strategy</h3>
-If two row cards will play on the same foundation pick the card
-that is on the row that holds the most cards. Move cards from one
-set of foundations to the other to get extra plays.
-</body>
-</html>
+If two row cards will play on the same foundation pick the card that is on
+the row that holds the most cards.  Move cards from one set of foundations
+to the other to get extra plays.

--- a/html-src/rules/khadga.html
+++ b/html-src/rules/khadga.html
@@ -1,24 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Khadga</h1>
-<p>FreeCell type. One Moghul Ganjifa Deck. No redeal.</p>
+<p>
+FreeCell type.  One Moghul Ganjifa Deck.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, using the eight suit Moghul
-Ganjifa deck and the number of cards you can move as a sequence is
-not restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>, using the eight suit Moghul Ganjifa deck
+and the number of cards you can move as a sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-Raja or King starting a new pile. Rows build down in rank and
-alternate color. Refer to the general <a href=
-"../ganjifa.html">Ganjifa</a> page. Empty rows cannot be filled.
-The eight free cells will hold one card each.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each Raja or King
+starting a new pile.  Rows build down in rank and alternate color.
+Refer to the general <a href="../ganjifa.html">Ganjifa</a> page.
+Empty rows cannot be filled. The eight free cells will hold one card each.

--- a/html-src/rules/kingalbert.html
+++ b/html-src/rules/kingalbert.html
@@ -1,24 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>King Albert</h1>
-<p>Raglan type. 1 deck. No redeal.</p>
+<p>
+Raglan type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards in the Tableau are built down by alternating color. Empty
-Tableau slots can be filled by any card or build of cards.</p>
-<p>Cards in the Reserve can be played on to the Tableau or the
-Foundation. Empty Reserve piles cannot be filled.</p>
-<p>Foundation piles are built up in suit from Ace to King. Cards in
-Foundation are still in play.</p>
+<p>
+Cards in the Tableau are built down by alternating color. Empty Tableau slots
+can be filled by any card or build of cards.
+<p>
+Cards in the Reserve can be played on to the Tableau or the Foundation. Empty
+Reserve piles cannot be filled.
+<p>
+Foundation piles are built up in suit from Ace to King. Cards in Foundation
+are still in play.
+
 <h3>Strategy</h3>
-<p>Remember that any card can be placed on an empty Tableau slot.
-Exposing new cards is the top priority in this game.</p>
-</body>
-</html>
+<p>
+Remember that any card can be placed on an empty Tableau slot. Exposing new
+cards is the top priority in this game.

--- a/html-src/rules/kingdom.html
+++ b/html-src/rules/kingdom.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Kingdom</h1>
-<p>Two-Deck game type. 2 decks. No redeal.</p>
+<p>
+Two-Deck game type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations build up by rank igonoring suit.</p>
-<p>The reserve piles can hold a single card and are automatically
-filled from the waste or talon.</p>
-<p>There is no building on the tableau piles, so you can only move
-cards to the foundations.</p>
+<p>
+The foundations build up by rank igonoring suit.
+<p>
+The reserve piles can hold a single card and
+are automatically filled from the waste or talon.
+<p>
+There is no building on the tableau piles, so you can
+only move cards to the foundations.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/kingonlybakersgame.html
+++ b/html-src/rules/kingonlybakersgame.html
@@ -1,27 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>King Only Baker's Game</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="bakersgame.html">Baker's Game</a>, but only
-Kings on empty spaces.</p>
+<p>
+Just like <a href="bakersgame.html">Baker's Game</a>,
+but only Kings on empty spaces.
+
 <h3>Rules</h3>
-<p>All cards are dealt at the start of the game. To compensate for
-this there are 4 free cells which can hold any - and just one -
-card.</p>
-<p>Piles build down by suit, and you can only move Kings to empty
-slots.</p>
-<p>The number of cards you can move as a sequence is restricted by
+<p>
+All cards are dealt at the start of the game. To compensate for this
+there are 4 free cells which can hold any - and just one - card.
+<p>
+Piles build down by suit, and you can only move Kings to empty slots.
+<p>
+The number of cards you can move as a sequence is restricted by
 the number of free cells - the number of free cells required is the
-same as if you would make an equivalent sequence of moves with
-single cards.</p>
-</body>
-</html>
+same as if you would make an equivalent sequence of moves with single cards.

--- a/html-src/rules/kingonlyhexaklon.html
+++ b/html-src/rules/kingonlyhexaklon.html
@@ -1,37 +1,30 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>King Only Hex A Klon</h1>
 Klondike type. One deck. One redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="klondike.html">Klondike</a> with <a href=
-"../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="klondike.html">Klondike</a>
+with <a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like Klondike with the Wizards being wild. They can be
-played on the tableau as any rank or color. Once a Wizard is played
-on a row however that row may become unmovable. If a Wizard is
-played in it's proper rank position the row can still be moved. A
-stack with two Wizards can be moved only if they are both in their
-rank position and they are not adjacent to each other. The Wizards
-will not move off of the tableau until all the other cards have
-been moved to the foundations. Only Kings may be played on the
-canvas. Cards may be played from the foundations.
+Game play is like Klondike with the Wizards being wild.  They can be played
+on the tableau as any rank or color.  Once a Wizard is played on a row however
+that row may become unmovable.  If a Wizard is played in it's proper rank
+position the row can still be moved.  A stack with two Wizards can be moved
+only if they are both in their rank position and they are not adjacent to each
+other.  The Wizards will not move off of the tableau until all the other cards
+have been moved to the foundations.  Only Kings may be played on the canvas.
+Cards may be played from the foundations.
+
 <h3>Strategy</h3>
-Keep the Wizards off of piles that contain face down cards. Once
-all the cards on the tableau are face up try to get the Wizards out
-of the way. Put them all on one row stack until the suit cards have
-been moved to the foundations. Since the Wizards will not play to
-the foundation until all the suit cards are on the foundations, and
-since only Kings will play on an empty row, one Wizard is dealt to
-the bottom of the second row from the left. If you move that Wizard
-and there is no other Wizard on the canvas, you will not be able to
-win the game.
-</body>
-</html>
+Keep the Wizards off of piles that contain face down cards.  Once all the
+cards on the tableau are face up try to get the Wizards out of the way.  Put
+them all on one row stack until the suit cards have been moved to the foundations.
+Since the Wizards will not play to the foundation until all the suit cards are on
+the foundations, and since only Kings will play on an empty row, one Wizard is
+dealt to the bottom of the second row from the left.  If you move that Wizard
+and there is no other Wizard on the canvas, you will not be able to win the
+game.

--- a/html-src/rules/kings.html
+++ b/html-src/rules/kings.html
@@ -1,23 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Kings</h1>
-<p>FreeCell type. 2 decks. No redeal.</p>
+<p>
+FreeCell type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="relaxedfreecell.html">Relaxed FreeCell</a>, but
-with 2 decks, and empty rows are not filled.</p>
+<p>
+Like <a href="relaxedfreecell.html">Relaxed FreeCell</a>,
+but with 2 decks, and empty rows are not filled.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 8 piles at the start of the game, each
-King starting a new pile. To compensate for this there are 8 free
-cells which can hold any - and just one - card.</p>
-<p>Piles build down by alternate color, and an empty space cannot
-be filled.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 8 piles at the start of the game, each King
+starting a new pile.
+To compensate for this there are 8 free cells which can hold any
+- and just one - card.
+<p>
+Piles build down by alternate color, and an empty space cannot be filled.

--- a/html-src/rules/klondike.html
+++ b/html-src/rules/klondike.html
@@ -1,24 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Klondike</h1>
-<p>Klondike type. 1 deck. Unlimited redeals.</p>
+<p>
+Klondike type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Foundations are built up in suit from Ace to King.</p>
-<p>The playing piles build down by alternate color, and an empty
-space can only be filled by a King or a sequence starting with a
-King.</p>
-<p>When you click on the talon, one card is turned over onto the
-waste pile. There is no limit to the number of times you go through
-the talon.</p>
-<p>You are also permitted to move cards back out of the
-foundations.</p>
-</body>
-</html>
+<p>
+Foundations are built up in suit from Ace to King.
+<p>
+The playing piles build down by alternate color, and an empty space
+can only be filled by a King or a sequence starting with a King.
+<p>
+When you click on the talon, one card is turned over onto the waste pile.
+There is no limit to the number of times you go through the talon.
+<p>
+You are also permitted to move cards back out of the foundations.

--- a/html-src/rules/klondikebythrees.html
+++ b/html-src/rules/klondikebythrees.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Klondike by Threes</h1>
-<p>Klondike type. 1 deck. Unlimited redeals.</p>
+<p>
+Klondike type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but deal three
-cards.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but deal three cards.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/klondikeplus16.html
+++ b/html-src/rules/klondikeplus16.html
@@ -1,35 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Klondike Plus 16</h1>
 Klondike type. One deck. One redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="klondike.html">Klondike</a> with <a href=
-"../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="klondike.html">Klondike</a>
+with <a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like Klondike with the Wizards being wild. They can be
-played on the tableau as any rank or color. Once a Wizard is played
-on a row however that row may become unmovable. The Wizards have
-ranks like the suit cards corresponding to Ace through four. If a
-Wizard is played in it's proper rank position the row can still be
-moved. The rank can be determined comparing some distinctive
-element of the images. The first rank Wizard will be the most
-elaborate in some way such as the fattest, the tallest hat etc. A
-stack with two Wizards can be moved only if they are both in their
-rank position and they are not adjacent to each other. Cards are
-dealt from the talon one at a time. Only Kings may be played on an
-empty row. The Wizards may be played to the foundation at any time
-in their proper rank order. Cards may be played from the
-foundations.
+Game play is like Klondike with the Wizards being wild.  They can be played
+on the tableau as any rank or color.  Once a Wizard is played on a row however
+that row may become unmovable.  The Wizards have ranks like the suit cards
+corresponding to Ace through four.  If a Wizard is played in it's proper rank
+position the row can still be moved.  The rank can be determined comparing some
+distinctive element of the images.  The first rank Wizard will be the most elaborate
+in some way such as the fattest, the tallest hat etc.  A stack with two Wizards can
+be moved only if they are both in their rank position and they are not adjacent
+to each other.  Cards are dealt from the talon one at a time.  Only Kings may
+be played on an empty row.  The Wizards may be played to the foundation at any
+time in their proper rank order.  Cards may be played from the foundations.
+
 <h3>Strategy</h3>
-The Wizards may play to the foundation at any time, but they can be
-very helpful in moving cards on the tableau.
-</body>
-</html>
+The Wizards may play to the foundation at any time, but they can be very helpful
+in moving cards on the tableau.

--- a/html-src/rules/kurma.html
+++ b/html-src/rules/kurma.html
@@ -1,26 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Kurma</h1>
 Dashavatara Ganjifa type. One deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by suit and rank.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by suit and rank.
+
 <h3>Rules</h3>
-The cards on the tableau build down in rank of the same suit. The
-foundations build up in rank by suit starting with the Ace. The
-cards are dealt from the talon one at a time. Any card or movable
-pile may be played on an empty row. Cards may be played from the
-foundations.
+The cards on the tableau build down in rank of the same suit.    The
+foundations build up in rank by suit starting with the Ace.  The cards
+are dealt from the talon one at a time.  Any card or movable pile may
+be played on an empty row.  Cards may be played from the foundations.
+
 <h3>Strategy</h3>
-The odds against winning this game are high. Try moving cards off
-of the deepest piles first.
-</body>
-</html>
+The odds against winning this game are high.  Try moving cards off of
+the deepest piles first.

--- a/html-src/rules/labellelucie.html
+++ b/html-src/rules/labellelucie.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>La Belle Lucie</h1>
-<p>Fan game type. 1 deck. 2 redeals.</p>
+<p>
+Fan game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The 18 piles build down by suit. Only one card can be moved at a
-time. Empty piles are not filled.</p>
-<p>When no more moves are possible, click on the talon. All cards
-on the tableau will be re-shuffled.</p>
+<p>
+The 18 piles build down by suit.
+Only one card can be moved at a time.
+Empty piles are not filled.
+<p>
+When no more moves are possible, click on the talon.
+All cards on the tableau will be re-shuffled.
+
 <h3>History</h3>
-<p>This game is also known under names such as <i>Clover Leaf</i>
-and <i>Midnight Oil</i>.</p>
-</body>
-</html>
+<p>
+This game is also known under names such as
+<i>Clover Leaf</i> and <i>Midnight Oil</i>.

--- a/html-src/rules/ladybetty.html
+++ b/html-src/rules/ladybetty.html
@@ -1,22 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Lady Betty</h1>
-<p>Numerica type. 1 deck. No redeal.</p>
+<p>
+Numerica type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="numerica.html">Numerica</a>, but the foundations
-build up in suit, and 6 row stacks.</p>
+<p>
+Like <a href="numerica.html">Numerica</a>,
+but the foundations build up in suit, and 6 row stacks.
+
 <h3>Rules</h3>
-<p>The foundations build up in suit from Ace to King.</p>
-<p>One card is flipped over at a time and moved onto the stacks.
-There are no restrictions on which card may go where on the stacks.
-Once on a stack, a card can only be moved onto a foundation.</p>
-</body>
-</html>
+<p>
+The foundations build up in suit from Ace to King.
+<p>
+One card is flipped over at a time and moved onto the stacks. There are no
+restrictions on which card may go where on the stacks. Once on a stack,
+a card can only be moved onto a foundation.

--- a/html-src/rules/ladypalk.html
+++ b/html-src/rules/ladypalk.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Lady Palk</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the 8
-piles build down by rank ignoring suit, and sequences can be
-moved.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the 8 piles build down by rank ignoring suit,
+and sequences can be moved.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/larasgame.html
+++ b/html-src/rules/larasgame.html
@@ -1,46 +1,48 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Lara's Game</h1>
-<p>Two-Deck game type. 2 decks. No redeal.</p>
+<p>
+Two-Deck game type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards are dealt to 14 piles. The piles are organized Ace through
-five, six through ten, and then the three face cards, followed by
-the Talon. [Yes, cards are dealt to the talon!] The rules for this
-deal are as follows:</p>
-<p>Cards are dealt to the first thirteen piles in order, until the
-104 cards have been used up. If the dealt card matches the place of
-the pile it is placed on, one card is dealt to the talon. If the
-card is a face card, one card is dealt to the talon. If the card is
-an Ace, two cards are dealt to the talon. Each time the deal
-reaches the King pile, two cards are dealt to the talon and the
-deal starts over at the Ace pile.</p>
-<p>The four top foundations build up from Ace, while the left four
-Foundations build down from King. Only the top card of any stack is
-playable, and the rest of the cards are hidden.</p>
-<p>The piles at the bottom of the screen represent the player's
-hand. Whenever a card is dealt from the talon, the player picks up
-the corresponding pile, places the dealt card at the bottom of the
-hand plays any cards that can be played, and replaces the hand to
-the pile that was picked up.</p>
-<p>There is no redeal.</p>
+<p>
+Cards are dealt to 14 piles.  The piles are organized Ace through
+five, six through ten, and then the three face cards, followed by the
+Talon.  [Yes, cards are dealt to the talon!]  The rules for this deal
+are as follows:
+<p>
+Cards are dealt to the first thirteen piles in order, until the 104
+cards have been used up.  If the dealt card matches the place of the
+pile it is placed on, one card is dealt to the talon.  If the card is
+a face card, one card is dealt to the talon.  If the card is an Ace,
+two cards are dealt to the talon.  Each time the deal reaches the King
+pile, two cards are dealt to the talon and the deal starts over at the
+Ace pile.
+<p>
+The four top foundations build up from Ace, while the left four
+Foundations build down from King.  Only the top card of any stack is
+playable, and the rest of the cards are hidden.
+<p>
+The piles at the bottom of the screen represent the player's hand.
+Whenever a card is dealt from the talon, the player picks up the
+corresponding pile, places the dealt card at the bottom of the hand
+plays any cards that can be played, and replaces the hand to the pile
+that was picked up.
+<p>
+There is no redeal.
+
 <h3>Notes</h3>
-<p>This game was taught to me by a wonderful woman. Neither she nor
-I knows where the game originated (it was taught to her by her
-older sister). This game is dedicated to her. Note: it was taught
-to her by her *other* older sister. So it really shouldn't be
-called Lara's game. But that's what I'm used to calling it, so thus
-it remains.</p>
+<p>
+This game was taught to me by a wonderful woman.  Neither she nor I
+knows where the game originated (it was taught to her by her older
+sister).  This game is dedicated to her.  Note: it was taught to her
+by her *other* older sister.  So it really shouldn't be called Lara's
+game.  But that's what I'm used to calling it, so thus it remains.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:hohlfeld@cs.ucsd.edu">Matthew W. Hohlfeld</a> and is part
-of the official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:hohlfeld@cs.ucsd.edu">Matthew W. Hohlfeld</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/larasgamedoubled.html
+++ b/html-src/rules/larasgamedoubled.html
@@ -1,33 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Double Lara's Game</h1>
 Lara's game type. 4 decks. 2 redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with four
-decks, two redeals and a reserve stack.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with four decks, two redeals and a reserve stack.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are the use of four decks instead of two two redeals
-and a reserve stack. Otherwise the play and dealing rules are the
-same.
-<p>When the talon is empty after each round the cards are gathered
-up from the tableau and dealt to the rows without being shuffled
-using the same dealing rules as in the first round. The foundations
-take two complete rounds of a suit. After the last card of the
-first round is played to a foundation the first card of the second
-round will play.</p>
-<p>The reserve stack will take any two cards from the rows.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are the use of four decks instead of two two redeals and a reserve stack.
+Otherwise the play and dealing rules are the same.
+<p>
+When the talon is empty after each round the cards are gathered up from
+the tableau and dealt to the rows without being shuffled using the same
+dealing rules as in the first round.  The foundations take two complete
+rounds of a suit.  After the last card of the first round is played to
+a foundation the first card of the second round will play.
+
+<p>
+The reserve stack will take any two cards from the rows.
+
 <h3>Strategy</h3>
-Use the reserve stack to allow buried cards to play. The best times
-to use it are just before a redeal. Once played to the reserve a
+Use the reserve stack to allow buried cards to play.  The best times
+to use it are just before a redeal.  Once played to the reserve a
 card may only be played from it to a foundation.
-</body>
-</html>

--- a/html-src/rules/larasgamerelaxed.html
+++ b/html-src/rules/larasgamerelaxed.html
@@ -1,33 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relaxed Lara's Game</h1>
 Lara's game type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="larasgame.html">Lara's Game</a> with a redeal
-and a reserve stack.
+Similar to <a href="larasgame.html">Lara's Game</a>
+with a redeal and a reserve stack.
+
 <h3>Rules</h3>
-Refer to the description of the deal in Lara's Game. The
-differences are the use of four decks instead of two two redeals
-and a reserve stack. Otherwise the play and dealing rules are the
-same.
-<p>When the talon is empty after each round the cards are gathered
-up from the tableau and dealt to the rows without being shuffled
-using the same dealing rules as in the first round. The foundations
-take two complete rounds of a suit. After the last card of the
-first round is played to a foundation the first card of the second
-round will play.</p>
-<p>The reserve stack will take any single card from the rows.</p>
+Refer to the description of the deal in Lara's Game.  The differences
+are the use of four decks instead of two two redeals and a reserve stack.
+Otherwise the play and dealing rules are the same.
+<p>
+When the talon is empty after each round the cards are gathered up from
+the tableau and dealt to the rows without being shuffled using the same
+dealing rules as in the first round.  The foundations take two complete
+rounds of a suit.  After the last card of the first round is played to
+a foundation the first card of the second round will play.
+
+<p>
+The reserve stack will take any single card from the rows.
+
 <h3>Strategy</h3>
-Use the reserve stack to allow buried cards to play. The best time
-to use it is just before the redeal. Once played to the reserve a
+Use the reserve stack to allow buried cards to play.  The best time
+to use it is just before the redeal.  Once played to the reserve a
 card may only be played from it to a foundation.
-</body>
-</html>

--- a/html-src/rules/lesserqueue.html
+++ b/html-src/rules/lesserqueue.html
@@ -1,25 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Lesser Queue</h1>
 Braid type. 2 decks. Two redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="braid.html">Braid</a>.
+Play is similar to
+<a href="braid.html">Braid</a>.
+
 <h3>Rules</h3>
-The foundations build in ascending suit order from Pine to
-Paulownia by rank. Cards are dealt from the talon one at a time and
-two redeals are allowed. Cards may not be played from the
-foundations.
+The foundations build in ascending suit order from Pine to Paulownia by rank.
+Cards are dealt from the talon one at a time and two redeals are allowed.
+Cards may not be played from the foundations.
+
 <h3>Strategy</h3>
-Build sequences on the rows that will play when the correct card
-turns over from the talon. Braid type games require careful
-strategy to win.
-</body>
-</html>
+Build sequences on the rows that will play when the correct card turns
+over from the talon.  Braid type games require careful strategy to win.

--- a/html-src/rules/lexingtonharp.html
+++ b/html-src/rules/lexingtonharp.html
@@ -1,25 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Lexington Harp</h1>
-<p>Yukon type. 2 decks. No redeal.</p>
+<p>
+Yukon type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards in tableau are built down by alternate color. Groups of
-cards can be moved regardless of sequence. An empty space can be
-filled with any card or sequence.</p>
-<p>Foundations are built up in suit from Ace to King. Cards in
-foundations are no longer in play.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles.</p>
+<p>
+Cards in tableau are built down by alternate color.
+Groups of cards can be moved regardless of sequence.
+An empty space can be filled with any card or sequence.
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in foundations are no longer in play.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each of the playing piles.
+
 <h3>History</h3>
-<p>This is a combination of <a href="yukon.html">Yukon type</a> and
-<a href="gypsy.html">Gypsy type</a> game elements.</p>
-</body>
-</html>
+<p>
+This is a combination of
+<a href="yukon.html">Yukon type</a> and
+<a href="gypsy.html">Gypsy type</a>
+game elements.

--- a/html-src/rules/littleeasy.html
+++ b/html-src/rules/littleeasy.html
@@ -1,33 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Little Easy</h1>
 Hanafuda type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank in the same suit. The foundations build with
-cards of the same rank in suit order.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank in the same suit.  The foundations
+build with cards of the same rank in suit order.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build in ascending suit order from Pine to Phoenix by
-rank. The third and fourth rank (trash) cards are not
-interchangeable on the tableau. Cards are dealt from the talon
-three at a time and there is no limit to the number of redeals.
-Cards may not be played from the foundations. Only first rank cards
-may be played on an empty row.
+The rows build from first rank to fourth rank by suit.  The foundations
+build in ascending suit order from Pine to Phoenix by rank.  The third
+and fourth rank (trash) cards are not interchangeable on the tableau.
+Cards are dealt from the talon three at a time and there is no limit to
+the number of redeals.  Cards may not be played from the foundations.
+Only first rank cards may be played on an empty row.
+
 <h3>Strategy</h3>
-Disable auto drop and build on the rows until all cards are face
-up. These games may be easy by name and easy to play but they're
-not easy to win.
+Disable auto drop and build on the rows until all cards are face up.
+These games may be easy by name and easy to play but they're not easy
+to win.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/littleforty.html
+++ b/html-src/rules/littleforty.html
@@ -1,25 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Little Forty</h1>
-<p>Forty Thieves type. 2 decks. 3 redeals.</p>
+<p>
+Forty Thieves type. 2 decks. 3 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the
-piles build down by rank only, sequences can be moved if they build
-down by suit and rank, empty piles are automatically filled from
-the waste or talon, deal 3 cards each time, and 3 redeals.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the piles build down by rank only,
+sequences can be moved if they build down by suit and rank,
+empty piles are automatically filled from the waste or talon,
+deal 3 cards each time, and 3 redeals.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>History</h3>
-<p>This is a combination of <a href="fortythieves.html">Forty
-Thieves type</a> and <a href="spider.html">Spider type</a> game
-elements.</p>
-</body>
-</html>
+<p>
+This is a combination of
+<a href="fortythieves.html">Forty Thieves type</a> and
+<a href="spider.html">Spider type</a>
+game elements.

--- a/html-src/rules/longbraid.html
+++ b/html-src/rules/longbraid.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Long Braid (Der lange Zopf)</h1>
-<p>Napoleon type. 2 decks. 2 redeals.</p>
+<p>
+Napoleon type. 2 decks. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="braid.html">Braid</a>, but deal 24 cards to
-the Braid stack at game start.</p>
+<p>
+Just like <a href="braid.html">Braid</a>,
+but deal 24 cards to the Braid stack at game start.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/longjourneytocuddapah.html
+++ b/html-src/rules/longjourneytocuddapah.html
@@ -1,34 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Long Journey to Cuddapah</h1>
 Braid type. Two decks. Two redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
 <h3>Quick description</h3>
-Similar to <a href="braid.html">Braid</a> played with two
-Dashavatara <a href="../ganjifa.html">Ganjifa</a> decks.
+Similar to <a href="braid.html">Braid</a>
+played with two Dashavatara
+<a href="../ganjifa.html">Ganjifa</a>
+decks.
+
 <h3>Rules</h3>
-Game play is like Braid. In this variation there are two Braid
-stacks that each have their own set of Braid reserve stacks. The
-game lay out starts with the twenty foundations in the outer most
-columns. The next two columns inwards are the ten Braid reserves.
-Then there are two columns with five general reserves each. The
-inner most two columns are the two Braid stacks. Each Braid starts
-with twenty cards. When one of the Braid reserves becomes open the
-card at the top of the corresponding Braid will be moved there.
-When all the cards from one of the Braids are removed a card from
-the other Braid will be used.
-<p>Cuddapah is a city in India with a history in the production of
-Ganjifa cards.</p>
+Game play is like Braid.  In this variation there are two Braid
+stacks that each have their own set of Braid reserve stacks.  The
+game lay out starts with the twenty foundations in the outer most columns.
+The next two columns inwards are the ten Braid reserves.  Then there
+are two columns with five general reserves each.  The inner most two
+columns are the two Braid stacks.  Each Braid starts with twenty cards.
+When one of the Braid reserves becomes open the card at the top of the
+corresponding Braid will be moved there.  When all the cards from one
+of the Braids are removed a card from the other Braid will be used.
+<p>
+Cuddapah is a city in India with a history in the production of Ganjifa cards.
 <h3>Strategy</h3>
-Build sequences on the rows that will play when the correct card
-turns over from the talon. This game type requires careful strategy
-to win.
-</body>
-</html>
+Build sequences on the rows that will play when the correct card turns
+over from the talon.  This game type requires careful strategy to win.

--- a/html-src/rules/lucas.html
+++ b/html-src/rules/lucas.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Lucas</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but with 13
-piles, and sequences can be moved.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but with 13 piles, and sequences can be moved.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/magesgame.html
+++ b/html-src/rules/magesgame.html
@@ -1,26 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Mage's Game</h1>
 Baker's Dozen type. One deck. No redeals.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="bakersdozen.html">Baker's Dozen</a> with one
-row of twelve alternate color row stacks and <a href=
-"../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="bakersdozen.html">Baker's Dozen</a>
+with one row of twelve alternate color row stacks and
+<a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like Baker's Dozen. The rows build down in rank in
-alternate color. The Wizards will play in their proper rank
-position on the tableau as the alternate of either red or black.
-Any card or sequence may be played on an empty row. Cards may be
-played from the foundations.
+Game play is like Baker's Dozen.  The rows build down in rank in alternate
+color.  The Wizards will play in their proper rank position on the
+tableau as the alternate of either red or black.  Any card or sequence
+may be played on an empty row.  Cards may be played from the foundations.
 <h3>Strategy</h3>
 Try to open a row to the canvas.
-</body>
-</html>

--- a/html-src/rules/mahjongg.html
+++ b/html-src/rules/mahjongg.html
@@ -1,37 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Mahjongg</h1>
 Mahjongg tile based solitaire games.
+
 <h3>Object</h3>
 Remove all tiles from the tableau.
+
 <h3>Quick description</h3>
 Click on two matching tiles to remove them from the tableau.
+
 <h3>Rules</h3>
-Tiles may be removed from the tableau only in matching pairs and
-only if both tiles are free. A tile is free if there are no tiles
-on top of it and no tiles either to the right or left of it. A set
-of Mahjongg tiles has three suits of nine tiles plus three Dragons
-and four Winds, each of which is repeated four times. And there
-four Seasons and four Flowers. This makes a total of 144 tiles in a
-complete set. The three suits are usually called Sticks, Coins and
-Strings although other names are sometimes used. A three of Sticks
-will only match another three of Sticks. The Dragons are known by
-their colors which are usually red, green and white. A green Dragon
-will only match another green Dragon. The Winds are North, South,
-East and West. North will only match North etc. Any Flower will
-match any other Flower and any Season will match any other Season.
+Tiles may be removed from the tableau only in matching pairs and only
+if both tiles are free.  A tile is free if there are no tiles on top
+of it and no tiles either to the right or left of it.  A set of Mahjongg
+tiles has three suits of nine tiles plus three Dragons and four Winds,
+each of which is repeated four times.  And there four Seasons and four
+Flowers.  This makes a total of 144 tiles in a complete set.  The three
+suits are usually called Sticks, Coins and Strings although other names
+are sometimes used.  A three of Sticks will only match another three of
+Sticks.  The Dragons are known by their colors which are usually red,
+green and white.  A green Dragon will only match another green Dragon.
+The Winds are North, South, East and West.  North will only match North
+etc.  Any Flower will match any other Flower and any Season will match
+any other Season.
+
 <h3>Strategy</h3>
 Remove tiles from the deepest stacks first.
+
 <h3>Notes</h3>
-Mahjongg is a game that requires four players referred to as the
-four winds. The first widely distributed computer solitaire game
-that used the Mahjongg tiles was called Shanghai and was produced
-by Activision.
-</body>
-</html>
+Mahjongg is a game that requires four players referred to as the four
+winds.  The first widely distributed computer solitaire game that used
+the Mahjongg tiles was called Shanghai and was produced by Activision.

--- a/html-src/rules/mainecoon.html
+++ b/html-src/rules/mainecoon.html
@@ -1,17 +1,12 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Maine Coon</h1>
-<p>Two-Deck game type. 2 decks. No redeal.</p>
+<p>
+Two-Deck game type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundation.</p>
+<p>
+Move all cards to the foundation.
+
 <h3>Rules</h3>
-<p>Like <a href='tabbycat.html'>Tabby Cat</a>, but with 2 decks and
-8 foundations.</p>
-</body>
-</html>
+<p>
+Like <a href='tabbycat.html'>Tabby Cat</a>, but with 2 decks and 8
+foundations.

--- a/html-src/rules/makara.html
+++ b/html-src/rules/makara.html
@@ -1,24 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Makara</h1>
-<p>FreeCell type. One Moghul Ganjifa Deck. No redeal.</p>
+<p>
+FreeCell type.  One Moghul Ganjifa Deck.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, using the eight suit Moghul
-Ganjifa deck and the number of cards you can move as a sequence is
-not restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+using the eight suit Moghul Ganjifa deck and the number of cards you can move as a
+sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-Raja or King starting a new pile. Rows build down in rank and suit.
-Refer to the general <a href="ganjifa.html">Ganjifa</a> page. Empty
-rows cannot be filled. The eight free cells will hold one card
-each.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each Raja or King
+starting a new pile.  Rows build down in rank and suit.
+Refer to the general <a href="ganjifa.html">Ganjifa</a> page.
+Empty rows cannot be filled. The eight free cells will hold one card each.

--- a/html-src/rules/manx.html
+++ b/html-src/rules/manx.html
@@ -1,17 +1,12 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Manx</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundation.</p>
+<p>
+Move all cards to the foundation.
+
 <h3>Rules</h3>
-<p>Like <a href='tabbycat.html'>Tabby Cat</a>, but the reserve may
-hold only a single card.</p>
-</body>
-</html>
+<p>
+Like <a href='tabbycat.html'>Tabby Cat</a>, but the reserve may hold
+only a single card.

--- a/html-src/rules/maria.html
+++ b/html-src/rules/maria.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Maria</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the 9
-piles build down by alternate color.<br />
-Much like <a href="streets.html">Streets</a>.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the 9 piles build down by alternate color.
+<br>Much like <a href="streets.html">Streets</a>.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/martha.html
+++ b/html-src/rules/martha.html
@@ -1,19 +1,15 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Martha</h1>
-<p>Baker's Dozen type. 1 deck. No redeal.</p>
+<p>
+Baker's Dozen type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The four Aces are dealt to the foundations at game start.</p>
-<p>The piles build down by alternate color. Sequences may be moved,
-but an empty pile can be only be filled with a <i>single</i>
-card.</p>
-</body>
-</html>
+<p>
+The four Aces are dealt to the foundations at game start.
+<p>
+The piles build down by alternate color.
+Sequences may be moved, but an empty pile can be only
+be filled with a <i>single</i> card.

--- a/html-src/rules/matriarchy.html
+++ b/html-src/rules/matriarchy.html
@@ -1,28 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Matriarchy</h1>
-<p>Two-Deck game type. 2 decks. Varying number of redeals.</p>
+<p>
+Two-Deck game type. 2 decks. Varying number of redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the tableau piles.</p>
+<p>
+Move all cards to the tableau piles.
+
 <h3>Rules</h3>
-<p>The object of this game is to build sequences until all the
-cards are used up. Cards are placed on Queens in descending order,
-following suit. Kings are placed on the empty spaces above the
-queens, and then cards are placed on the Kings in ascending order,
-starting with Ace, also following suit. For each rank you complete,
-(that is, having one card of each value) you get an extra chance at
-going through the talon. You are permitted to move cards from one
-pile to another, as long as you still follow the rules. The first
-time you go through the talon, the cards are given two at a time.
-The second time, it is three cards, and so on up to twelve. If by
-that time you have completed any ranks, your bonus runs start at
-eleven, then ten, and so on. You win if you complete all the
-ranks.</p>
-</body>
-</html>
+<p>
+The object of this game is to build sequences until all the cards are
+used up. Cards are placed on Queens in descending order, following suit.
+Kings are placed on the empty spaces above the queens, and then cards are
+placed on the Kings in ascending order, starting with Ace, also following
+suit. For each rank you complete, (that is, having one card of each value)
+you get an extra chance at going through the talon. You are permitted to
+move cards from one pile to another, as long as you still follow the rules.
+The first time you go through the talon, the cards are given two at a time.
+The second time, it is three cards, and so on up to twelve. If by that time
+you have completed any ranks, your bonus runs start at eleven, then ten, and
+so on. You win if you complete all the ranks.

--- a/html-src/rules/matrix.html
+++ b/html-src/rules/matrix.html
@@ -1,33 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Matrix</h1>
 Matrix type. One deck. No redeals.
+
 <h3>Object</h3>
 Restore game pieces to their proper order.
+
 <h3>Rules</h3>
-When the game opens the all game pieces except for the final piece
-are dealt to the tableau in their proper order. The pieces are then
-scrambled to a random pattern. With the larger grids it may take
-several seconds for the scrambling to be completed. Pieces may not
-be lifted from the canvas. They may be moved by clicking on a piece
-which is in either the row or the column which has the empty spot.
-That piece and all intervening pieces will move one space towards
-the empty spot. The image game piece sets are best used with the
-grid size for which they are designed. The size is indicated in the
-name of the set. King of Hearts 4x4, Players Trumps 10x10, etc. The
-default set of numbered pieces works with any grid size. When all
-the pieces have been restored to their correct order the final
-piece will be dealt to the tableau and the game has been won. Every
-Matrix game can be solved.
+When the game opens the all game pieces except for the final piece are
+dealt to the tableau in their proper order.  The pieces are then scrambled
+to a random pattern.  With the larger grids it may take several seconds for
+the scrambling to be completed.  Pieces may not be lifted from the canvas.
+They may be moved by clicking on a piece which is in either the row or the
+column which has the empty spot.  That piece and all intervening pieces will
+move one space towards the empty spot.  The image game piece sets are best used
+with the grid size for which they are designed.  The size is indicated in the
+name of the set.  King of Hearts 4x4, Players Trumps 10x10, etc.  The default
+set of numbered pieces works with any grid size.  When all the pieces have been
+restored to their correct order the final piece will be dealt to the tableau and
+the game has been won.  Every Matrix game can be solved.
+
 <h3>Strategy</h3>
-Begin in the upper left hand corner and complete one row before
-starting the next. Take a screen shot of the image sets before the
-game is scrambled.
-</body>
-</html>
+Begin in the upper left hand corner and complete one row before starting the next.
+Take a screen shot of the image sets before the game is scrambled.

--- a/html-src/rules/matsukiri.html
+++ b/html-src/rules/matsukiri.html
@@ -1,39 +1,38 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>MatsuKiri</h1>
-<p>Hanafuda type. 1 deck. No redeal.</p>
+<p>
+Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundation.</p>
+<p>
+Move all cards to the foundation.
+
 <h3>Rules</h3>
-<p>The cards can only be moved to the foundation as entire suits,
-in order. As in <a href="oonsoo.html">Oonsoo</a>, the third and
-fourth rank cards are interchangeable for all suits except Rain.
-Only first rank cards can play on the canvas. First build the suits
-on the tableau. Then pick up all four cards at once and drop them
-on the foundation. The foundation will only accept a completed suit
-if the internal rank order is correct and it's played in suit
-order. Plum after Pine, Phoenix after Rain, etc. Stacks in the
-tableau can be moved if the cards in the stack are in order or not.
-There can be no more than twelve cards in a row. The play in this
-game is similar to Seahaven Towers, except there are no reserve
-stacks.</p>
-<p>This game can have "unbeatable" deals. For instance, if the
-second rank card of suit "a" is on the first rank card of suit "b",
-and the second rank card of "b" is on the first rank card of "a",
-neither second rank card can be moved. You've lost. It's also
-possible to play yourself into a similar situation.</p>
+<p>
+The cards can only be moved to the foundation as entire suits, in order.
+As in <a href="oonsoo.html">Oonsoo</a>,
+the third and fourth rank cards are interchangeable
+for all suits except Rain.  Only first rank cards can play on the canvas.
+First build the suits on the tableau.  Then pick up all four cards at
+once and drop them on the foundation.  The foundation will only accept
+a completed suit if the internal rank order is correct and it's played
+in suit order.  Plum after Pine, Phoenix after Rain, etc.  Stacks in
+the tableau can be moved if the cards in the stack are in order or
+not.  There can be no more than twelve cards in a row.  The play in
+this game is similar to Seahaven Towers, except there are no reserve
+stacks.
+<p>
+This game can have "unbeatable" deals.  For instance, if the second
+rank card of suit "a" is on the first rank card of suit "b", and the
+second rank card of "b" is on the first rank card of "a", neither second
+rank card can be moved.  You've lost.  It's also possible to play
+yourself into a similar situation.
+
 <h3>Strategy</h3>
-<p>Hint: try to build more than one suit on the tableau at a
-time.</p>
+<p>
+Hint: try to build more than one suit on the tableau at a time.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/matsukiristrict.html
+++ b/html-src/rules/matsukiristrict.html
@@ -1,17 +1,10 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>MatsuKiri Strict</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the single foundation.
+
 <h3>Rules</h3>
-Play is identical to <a href="matsukiri.html">MatsuKiri</a> except
-the trash (third and forth rank) cards are not interchangeable.
-</body>
-</html>
+Play is identical to
+<a href="matsukiri.html">MatsuKiri</a>
+except the trash (third and forth rank) cards are not interchangeable.

--- a/html-src/rules/matsya.html
+++ b/html-src/rules/matsya.html
@@ -1,26 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Matsya</h1>
 Dashavatara Ganjifa type. One deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank only.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank only.
+
 <h3>Rules</h3>
-The cards on the tableau build down in rank regardless of suit. The
-foundations build up in rank by suit starting with the Ace. The
-cards are dealt from the talon one at a time. There is no redeal.
-Only Mirs (Kings) may be played on an empty row. Cards may not be
-played from the foundations.
+The cards on the tableau build down in rank regardless of suit.  The
+foundations build up in rank by suit starting with the Ace.  The cards
+are dealt from the talon one at a time.  There is no redeal.  Only Mirs
+(Kings) may be played on an empty row.  Cards may not be played from the
+foundations.
+
 <h3>Strategy</h3>
-The waste stack will be the biggest problem area. Play from it
-first.
-</body>
-</html>
+The waste stack will be the biggest problem area.  Play from it first.

--- a/html-src/rules/maze.html
+++ b/html-src/rules/maze.html
@@ -1,29 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Maze</h1>
-<p>Montana type. 1 deck. No redeal.</p>
+<p>
+Montana type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 12 cards in ascending sequence by
-suit from Ace to Queen. There may be empty spaces between but not
-within such sequences. The tableau wraps around.</p>
+<p>
+Group all the cards in sets of 12 cards in ascending sequence
+by suit from Ace to Queen. There may be empty spaces between
+but not within such sequences. The tableau wraps around.
+
 <h3>Rules</h3>
-<p>This solitaire starts with the entire deck shuffled and dealt
+<p>
+This solitaire starts with the entire deck shuffled and dealt
 out to 54 piles. The Kings are then removed making a total of 6
-initial free spaces.</p>
-<p>You may move to a space only the card that matches the neighbor
-in suit, and is one greater in rank than the left neighbour or one
-less in rank than the right neighbour.</p>
-<p>As a special rule you may place an Ace of any suit to the right
-of a Queen.</p>
-<p>The tableau wraps around at the end of rows and from the
-bottom-right to the top-left.</p>
+initial free spaces.
+<p>
+You may move to a space only the card that
+matches the neighbor in suit, and is one greater in rank than the left
+neighbour or one less in rank than the right neighbour.
+<p>
+As a special rule you may place an Ace of any suit to the right
+of a Queen.
+<p>
+The tableau wraps around at the end of rows and from the
+bottom-right to the top-left.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/memory24.html
+++ b/html-src/rules/memory24.html
@@ -1,27 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Memory 24</h1>
-<p>Memory game type. 24 cards. No redeal.</p>
+<p>
+Memory game type. 24 cards. No redeal.
+
 <h3>Object</h3>
-<p>Flip all pairs of matching cards and get a score of 40 points or
-more.</p>
+<p>
+Flip all pairs of matching cards and get a score of 40 points or more.
+
 <h3>Rules</h3>
-<p>At game start 12 pairs of cards are dealt to the tableau
-piles.</p>
-<p>Flip any 2 cards that match in suit and rank.</p>
-<p>Any pair that matches will gain you 5 points, while a pair that
-doesn't match will cost you 1 point.</p>
-<p>You win if your final score reaches 40 points.</p>
+<p>
+At game start 12 pairs of cards are dealt to the tableau piles.
+<p>
+Flip any 2 cards that match in suit and rank.
+<p>
+Any pair that matches will gain you 5 points, while a pair that
+doesn't match will cost you 1 point.
+<p>
+You win if your final score reaches 40 points.
+
 <h3>Notes</h3>
-<p>To get awarded for a perfect game you must reach the maximum
-score of 60 points. You can reach this by restarting the game.</p>
-<p><i>Undo</i>, <i>Bookmarks</i>, <i>Autodrop</i> and
-<i>Quickplay</i> are disabled for this game.</p>
-</body>
-</html>
+<p>
+To get awarded for a perfect game you must reach the maximum score of
+60 points. You can reach this by restarting the game.
+<p>
+<i>Undo</i>, <i>Bookmarks</i>, <i>Autodrop</i> and <i>Quickplay</i>
+are disabled for this game.

--- a/html-src/rules/memory40.html
+++ b/html-src/rules/memory40.html
@@ -1,27 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Memory 40</h1>
-<p>Memory game type. 40 cards. No redeal.</p>
+<p>
+Memory game type. 40 cards. No redeal.
+
 <h3>Object</h3>
-<p>Flip all pairs of matching cards and get a score of 50 points or
-more.</p>
+<p>
+Flip all pairs of matching cards and get a score of 50 points or more.
+
 <h3>Rules</h3>
-<p>At game start 20 pairs of cards are dealt to the tableau
-piles.</p>
-<p>Flip any 2 cards that match in suit and rank.</p>
-<p>Any pair that matches will gain you 5 points, while a pair that
-doesn't match will cost you 1 point.</p>
-<p>You win if your final score reaches 50 points.</p>
+<p>
+At game start 20 pairs of cards are dealt to the tableau piles.
+<p>
+Flip any 2 cards that match in suit and rank.
+<p>
+Any pair that matches will gain you 5 points, while a pair that
+doesn't match will cost you 1 point.
+<p>
+You win if your final score reaches 50 points.
+
 <h3>Notes</h3>
-<p>To get awarded for a perfect game you must reach the maximum
-score of 100 points. You can reach this by restarting the game.</p>
-<p><i>Undo</i>, <i>Bookmarks</i>, <i>Autodrop</i> and
-<i>Quickplay</i> are disabled for this game.</p>
-</body>
-</html>
+<p>
+To get awarded for a perfect game you must reach the maximum score of
+100 points. You can reach this by restarting the game.
+<p>
+<i>Undo</i>, <i>Bookmarks</i>, <i>Autodrop</i> and <i>Quickplay</i>
+are disabled for this game.

--- a/html-src/rules/merlinsmeander.html
+++ b/html-src/rules/merlinsmeander.html
@@ -1,27 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Merlin's Meander</h1>
 Braid type. Two decks. Two redeals.
+
 <h3>Object</h3>
 Move all suit cards to the Foundations.
 <h3>Quick description</h3>
-Similar to <a href="braid.html">Braid</a> with <a href=
-"../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="braid.html">Braid</a>
+with <a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like Braid. In the Hex A Deck variation the Wizards
-don't have their own foundations. There are two reserve stacks to
-the left of the foundations that will hold up to three Wizards
-each. The game is won when all the suit cards have been moved to
-the foundations.
+Game play is like Braid.  In the Hex A Deck variation the Wizards
+don't have their own foundations.  There are two reserve stacks to
+the left of the foundations that will hold up to three Wizards each.
+The game is won when all the suit cards have been moved to the foundations.
 <h3>Strategy</h3>
 Build sequences on the rows that will play when the correct card
-turns over from the talon. Don't fill the Wizard stacks until you
+turns over from the talon.  Don't fill the Wizard stacks until you
 need to.
-</body>
-</html>

--- a/html-src/rules/midshipman.html
+++ b/html-src/rules/midshipman.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Midshipman</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the 9
-piles build down by any suit but own.<br />
-Much like <a href="indian.html">Indian</a>.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the 9 piles build down by any suit but own.
+<br>Much like <a href="indian.html">Indian</a>.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/milligancell.html
+++ b/html-src/rules/milligancell.html
@@ -1,22 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Milligan Cell</h1>
-<p>Gypsy type. 2 decks. No redeal.</p>
+<p>
+Gypsy type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="gypsy.html">Gypsy</a>, but only Kings on empty
-spaces, and with four extra free cells.<br />
-Easy.</p>
+<p>
+Like <a href="gypsy.html">Gypsy</a>,
+but only Kings on empty spaces, and with four extra free cells.
+<br>Easy.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-<p>You are <em>not</em> permitted to move cards back out of the
-foundations.</p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>
+<p>
+You are <em>not</em> permitted to move cards back out of the foundations.

--- a/html-src/rules/milliganharp.html
+++ b/html-src/rules/milliganharp.html
@@ -1,25 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Milligan Harp</h1>
-<p>Yukon type. 2 decks. No redeal.</p>
+<p>
+Yukon type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Rules</h3>
-<p>Cards in Tableau are built down by alternate color. Groups of
-cards can be moved regardless of sequence. An empty space can be
-filled with any card or sequence.</p>
-<p>Foundations are built up in suit from Ace to King. Cards in
-Foundations are no longer in play.</p>
-<p>When no more moves are possible, click on the Talon. One card
-will be added to each of the playing piles.</p>
+<p>
+Cards in Tableau are built down by alternate color.
+Groups of cards can be moved regardless of sequence.
+An empty space can be filled with any card or sequence.
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in Foundations are no longer in play.
+<p>
+When no more moves are possible, click on the Talon. One card will be
+added to each of the playing piles.
+
 <h3>History</h3>
-<p>This is a combination of <a href="yukon.html">Yukon type</a> and
-<a href="gypsy.html">Gypsy type</a> game elements.</p>
-</body>
-</html>
+<p>
+This is a combination of
+<a href="yukon.html">Yukon type</a> and
+<a href="gypsy.html">Gypsy type</a>
+game elements.

--- a/html-src/rules/mississippi.html
+++ b/html-src/rules/mississippi.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Mississippi</h1>
-<p>Yukon type. 2 decks. No redeal.</p>
+<p>
+Yukon type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-<p>Just like <a href="milliganharp.html">Milligan Harp</a>, but
-with seven piles.</p>
+<p>
+Just like <a href="milliganharp.html">Milligan Harp</a>,
+but with seven piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/missmilligan.html
+++ b/html-src/rules/missmilligan.html
@@ -1,25 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Miss Milligan</h1>
-<p>Gypsy type. 2 decks. No redeal.</p>
+<p>
+Gypsy type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="gypsy.html">Gypsy</a>, but only Kings on empty
-spaces, and with an extra reserve stack that can be used once the
-talon is empty.</p>
+<p>
+Like <a href="gypsy.html">Gypsy</a>,
+but only Kings on empty spaces, and with an extra reserve stack
+that can be used once the talon is empty.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-<p>After the talon is exhausted, you can use the reserve stack for
-storing any card or legal sequence (this process is called
-<i>weaving</i>).</p>
-<p>You are <em>not</em> permitted to move cards back out of the
-foundations.</p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>
+<p>
+After the talon is exhausted, you can use the reserve stack
+for storing any card or legal sequence
+(this process is called <i>weaving</i>).
+<p>
+You are <em>not</em> permitted to move cards back out of the foundations.

--- a/html-src/rules/missmuffet.html
+++ b/html-src/rules/missmuffet.html
@@ -1,17 +1,12 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Miss Muffet</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Quick Description</h3>
-<p>Like <a href="curdsandwhey.html">Curds and Whey</a>, but with 10
-piles.</p>
+<p>
+Like <a href="curdsandwhey.html">Curds and Whey</a>,
+but with 10 piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/montana.html
+++ b/html-src/rules/montana.html
@@ -1,33 +1,35 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Montana</h1>
-<p>Montana type. 1 deck. 2 redeals.</p>
+<p>
+Montana type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 12 cards in acscending sequence
-by suit from Two to King.</p>
+<p>
+Group all the cards in sets of 12 cards in acscending sequence
+by suit from Two to King.
+
 <h3>Rules</h3>
-<p>This solitaire starts with the entire deck shuffled and dealt
-out in four rows. The Aces are then removed making 4 initial free
-spaces. You may move to a space only the card that matches the left
-neighbor in suit, and is one greater in rank. Kings are high, so no
-cards may be placed to their right (they create dead spaces).</p>
-<p>When no moves can be made, cards still out of sequence are
-reshuffled and dealt face up after the ends of the partial
-sequences, leaving a card space after each sequence, so that each
-row looks like a partial sequence followed by a space, followed by
-enough cards to make a row of 13.</p>
+<p>
+This solitaire starts with the entire deck shuffled and dealt
+out in four rows.  The Aces are then removed
+making 4 initial free spaces.  You may move to a space only the card that
+matches the left neighbor in suit, and is one greater in rank.  Kings are
+high, so no cards may be placed to their right (they create dead spaces).
+<p>
+When no moves can be made, cards still out of sequence are reshuffled
+and dealt face up after the ends of the partial sequences, leaving a card
+space after each sequence, so that each row looks like a partial sequence
+followed by a space, followed by enough cards to make a row of 13.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
+<p>
+<i>Autodrop</i> is disabled for this game.
+
 <h3>Strategy</h3>
-<p>A moment's reflection will show that this game cannot take more
-than 12 redeals. But only 2 redeals are allowed...</p>
+<p>
+A moment's reflection will show that this game cannot take more than 12
+redeals. But only 2 redeals are allowed...
+
 <h3>History</h3>
-<p>This game is also known under names such as <i>Gaps</i>.</p>
-</body>
-</html>
+<p>
+This game is also known under names such as
+<i>Gaps</i>.

--- a/html-src/rules/montecarlo.html
+++ b/html-src/rules/montecarlo.html
@@ -1,26 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Monte Carlo</h1>
-<p>Pairing game type. 1 deck. No redeal.</p>
+<p>
+Pairing game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Discard all pairs of cards of the same rank.</p>
+<p>
+Discard all pairs of cards of the same rank.
+
 <h3>Rules</h3>
-<p>The object is to use up all the cards from the tableau by
-discarding pairs of cards of the same rank.</p>
-<p>You can only put a card on top of another card when the two
-cards are touching horizontally, vertically or diagonally (i.e. the
-cards have to be neighbours).</p>
-<p>When no more moves are possible, click on the talon. The cards
-will be shifted up and the empty spaces at the bottom will be
-filled.</p>
-<p>You win when the tableau piles are all gone.</p>
+<p>
+The object is to use up all the cards from the tableau by
+discarding pairs of cards of the same rank.
+<p>
+You can only put a card on top of another card
+when the two cards are touching horizontally, vertically or diagonally
+(i.e. the cards have to be neighbours).
+<p>
+When no more moves are possible, click on the talon.
+The cards will be shifted up and the empty spaces at
+the bottom will be filled.
+<p>
+You win when the tableau piles are all gone.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/moosehide.html
+++ b/html-src/rules/moosehide.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Moosehide</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="yukon.html">Yukon</a>, but build down in any suit
-but the same.</p>
+<p>
+Like <a href="yukon.html">Yukon</a>,
+but build down in any suit but the same.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/mughalcircles.html
+++ b/html-src/rules/mughalcircles.html
@@ -1,27 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Mughal Circles</h1>
 Mughal Ganjifa type. One deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-The cards build down by rank and by suit on the tableau. Any card
-may be played on an empty row. Only one card may be moved at a
-time.
+The cards build down by rank and by suit on the tableau.  Any card may be
+played on an empty row.  Only one card may be moved at a time.
+
 <h3>Rules</h3>
-All cards are dealt to the twenty four rows when the games begins.
-Cards on the tableau build down by suit in descending rank order.
-The foundations build up by suit. Any card may be played on an
-empty row. The reserve stacks hold one card each. Only one card at
-a time may be moved.
+All cards are dealt to the twenty four rows when the games begins.  Cards
+on the tableau build down by suit in descending rank order.  The foundations
+build up by suit.  Any card may be played on an empty row. The reserve stacks
+hold one card each. Only one card at a time may be moved.
+
 <h3>Strategy</h3>
-Try to keep a reserve stack open. Play higher ranked cards on empty
-rows.
-</body>
-</html>
+Try to keep a reserve stack open.  Play higher ranked cards on empty rows.

--- a/html-src/rules/napoleon.html
+++ b/html-src/rules/napoleon.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Napoleon</h1>
-<p>Napoleon type. 1 deck. No redeal.</p>
+<p>
+Napoleon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="derkleinenapoleon.html">Der kleine Napoleon</a>,
-but a little bit easier because there are 2 free cells, each of
-which is blocked by the corresponding reserve stack.</p>
+<p>
+Like <a href="derkleinenapoleon.html">Der kleine Napoleon</a>,
+but a little bit easier because there are 2 free cells,
+each of which is blocked by the corresponding reserve stack.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/napoleonsexile.html
+++ b/html-src/rules/napoleonsexile.html
@@ -1,26 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Napoleon's Exile</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the
-piles build down by rank ignoring suit.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the piles build down by rank ignoring suit.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>Similar Games</h3>
 <ul>
-<li><a href="doublerail.html">Double Rail</a></li>
-<li><a href="congress.html">Congress</a></li>
-<li><a href="diplomat.html">Diplomat</a></li>
-<li><a href="ladypalk.html">Lady Palk</a></li>
+<li> <a href="doublerail.html">Double Rail</a>
+<li> <a href="congress.html">Congress</a>
+<li> <a href="diplomat.html">Diplomat</a>
+<li> <a href="ladypalk.html">Lady Palk</a>
 </ul>
-</body>
-</html>

--- a/html-src/rules/narasimha.html
+++ b/html-src/rules/narasimha.html
@@ -1,30 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Narasimha</h1>
 Dashavatara Ganjifa type. One deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank in "alternate" colors.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank in "alternate" colors.
+
 <h3>Rules</h3>
-The cards on the tableau build down in rank in alternate colors.
-The Dashavatara Ganjifa deck has ten suits and each suit has it's
-own color. This makes it a bit problematic at times knowing which
-colors are alternate. If a card of one suit doesn't play in a spot,
-try a different card of the same rank. The foundations build up in
-rank by suit starting with the Ace. The cards are dealt from the
-talon one at a time. There is no redeal. Only the Mirs (Kings) may
-be played on an empty row. Cards may be played from the
+The cards on the tableau build down in rank in alternate colors.  The
+Dashavatara Ganjifa deck has ten suits and each suit has it's own color.
+This makes it a bit problematic at times knowing which colors are alternate.
+If a card of one suit doesn't play in a spot, try a different card of the
+same rank.  The foundations build up in rank by suit starting with the Ace.
+The cards are dealt from the talon one at a time.  There is no redeal.  Only
+the Mirs (Kings) may be played on an empty row.  Cards may be played from the
 foundations.
+
 <h3>Strategy</h3>
-The waste stack will be the biggest problem area. Play from it
-first.
-</body>
-</html>
+The waste stack will be the biggest problem area.  Play from it first.

--- a/html-src/rules/narpati.html
+++ b/html-src/rules/narpati.html
@@ -1,34 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Narpati</h1>
 Mughal Ganjifa type. One deck. No redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank in "alternate" colors.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank in "alternate" colors.
+
 <h3>Rules</h3>
 The cards on the tableau build down by rank in alternate colors.
 The foundations build up in rank by suit starting with the Ace.
-Only the Mirs (Kings) may be played on an empty row. The Mughal
-Ganjifa deck has eight suits and each suit has it's own color. This
-makes it a bit of a challenge at times to know what colors are the
-"alternates". If a card doesn't play one place, try a different
-card of the same rank. Cards are dealt from the talon three at a
-time. There are no redeals. Cards may be played from the
-foundations.
-<p>This game is one of a series of games that have names ending in
-"pati" which transliterates as "lord of". Narpati means "Lord of
-Men". The names are the names of the suits in a twelve suit Ganjifa
-deck.</p>
+Only the Mirs (Kings) may be played on an empty row.  The Mughal
+Ganjifa deck has eight suits and each suit has it's own color.
+This makes it a bit of a challenge at times to know what colors
+are the "alternates".  If a card doesn't play one place, try
+a different card of the same rank.  Cards are dealt from the talon
+three at a time.  There are no redeals.  Cards may be played from
+the foundations.
+<p>
+This game is one of a series of games that have names ending in "pati"
+which transliterates as "lord of".  Narpati means "Lord of Men".
+The names are the names of the suits in a twelve suit Ganjifa deck.
+
 <h3>Strategy</h3>
-Uncover the deepest row stacks first. Move cards around on the
+Uncover the deepest row stacks first.  Move cards around on the
 tableau to open spots for cards from the waste stack.
-</body>
-</html>

--- a/html-src/rules/nasty.html
+++ b/html-src/rules/nasty.html
@@ -1,26 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Nasty</h1>
 Tarock type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-This game is similar to <a href="cruel.html">Cruel</a> played with
-the 78 card Tarock deck. Piles build down in rank in by suit. Only
-one card may be moved at a time.
+This game is similar to
+<a href="cruel.html">Cruel</a>
+played with the 78 card Tarock deck.  Piles build down in rank in
+by suit.  Only one card may be moved at a time.
+
 <h3>Rules</h3>
-Rows build down in rank by suit. Only one card may be moved at a
-time. Only Kings or Skis (the highest Trump) may be played on an
-empty row. When no more moves can be made click the talon for a
-redeal.
+Rows build down in rank by suit.  Only one card may be moved at a time.
+Only Kings or Skis (the highest Trump) may be played on an empty row.
+When no more moves can be made click the talon for a redeal.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/neighbour.html
+++ b/html-src/rules/neighbour.html
@@ -1,30 +1,34 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Neighbour</h1>
-<p>Pairing game type. 1 deck. No redeal.</p>
+<p>
+Pairing game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundation.</p>
+<p>
+Move all cards to the foundation.
+
 <h3>Rules</h3>
-<p>The object is to use up all the cards from the tableau, placing
-them on the single foundation. You can only put a card on top of
-another card when the numerical values of the two cards adds up to
-13 and the two cards are touching horizontally, vertically or
-diagonally (i.e. the cards have to be <i>Neighbours</i>).</p>
-<p>You do not have to follow suit. Jack is worth 11 and Queen is
-worth 12. All Kings go off alone.</p>
-<p>Empty spaces are filled automatically by shifting cards up and
-dealing from the talon to the bottom piles.</p>
-<p>You win when the tableau piles are all gone.</p>
+<p>
+The object is to use up all the cards from the tableau, placing them
+on the single foundation. You can only put a card on top of another card
+when the numerical values of the two cards adds up to 13
+and the two cards are touching horizontally, vertically or diagonally
+(i.e. the cards have to be <i>Neighbours</i>).
+<p>
+You do not have to follow suit.
+Jack is worth 11 and Queen is worth 12.
+All Kings go off alone.
+<p>
+Empty spaces are filled automatically by shifting cards up and
+dealing from the talon to the bottom piles.
+<p>
+You win when the tableau piles are all gone.
+
 <h3>Notes</h3>
-<p><i>Quickplay</i> is disabled for this game.</p>
+<p>
+<i>Quickplay</i> is disabled for this game.
+
 <h3>History</h3>
-<p>This is a combination of <a href="montecarlo.html">Monte
-Carlo</a> and <a href="pyramid.html">Pyramid</a> game elements.</p>
-</body>
-</html>
+<p>
+This is a combination of
+<a href="montecarlo.html">Monte Carlo</a> and
+<a href="pyramid.html">Pyramid</a> game elements.

--- a/html-src/rules/newbritishconstitution.html
+++ b/html-src/rules/newbritishconstitution.html
@@ -1,20 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>New British Constitution</h1>
-<p>Two-Deck game type. 2 decks. No redeals.</p>
+<p>
+Two-Deck game type. 2 decks. No redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="britishconstitution.html">British
-Constitution</a>, but only Jacks on empty spaces and the piles
-build down by rank ignoring suit.</p>
+<p>
+Like <a href="britishconstitution.html">British Constitution</a>,
+but only Jacks on empty spaces and the piles build down by rank ignoring suit.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/newtowerofhanoi.html
+++ b/html-src/rules/newtowerofhanoi.html
@@ -1,21 +1,14 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>New Tower of Hanoi</h1>
 Matrix type. One deck. No redeals.
+
 <h3>Object</h3>
 Move the tower to either of the other stacks.
+
 <h3>Rules</h3>
-Only one disk may be moved at a time. A larger disk may not be
-placed on top of a smaller one. Click on the pile to be moved
-<b>from</b> to high light it. Then click the pile to be moved
-<b>to</b>.
+Only one disk may be moved at a time.  A larger disk may not be placed on
+top of a smaller one.  Click on the pile to be moved <b>from</b> to high
+light it.  Then click the pile to be moved <b>to</b>.
+
 <h3>Strategy</h3>
-Ask <a href="mailto:grania@telestream.com">T</a>
-</body>
-</html>
+Ask
+<a href="mailto:grania@telestream.com">T</a>

--- a/html-src/rules/nomad.html
+++ b/html-src/rules/nomad.html
@@ -1,43 +1,44 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Nomad</h1>
-<p>Gypsy type. 2 decks. No redeal.</p>
+<p>
+Gypsy type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="gypsy.html">Gypsy</a>, but with one extra free
-cell.</p>
+<p>
+Like <a href="gypsy.html">Gypsy</a>,
+but with one extra free cell.
+
 <h3>Rules</h3>
-<p>The eight playing piles in the tableau all start with four cards
-showing. Piles build down by alternate color, and an empty space
-can be filled with any card or sequence. The single free cell at
-the bottom may hold one card at a time.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles.</p>
-<p>You are also permitted to move cards back out of the
-foundation.</p>
+<p>
+The eight playing piles in the tableau all start with four cards showing.
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence. The single free cell at the bottom may hold one
+card at a time.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each of the playing piles.
+<p>
+You are also permitted to move cards back out of the foundation.
+
 <h3>Strategy</h3>
-<p>Making heavy use of the Undo key is explicitly encouraged here -
-you can win many games with a little bit of thought. Keeping the
-free cell open for sorting is usually a good idea.</p>
+<p>
+Making heavy use of the Undo key is explicitly encouraged here - you can win
+many games with a little bit of thought. Keeping the free cell open for sorting
+is usually a good idea.
+
 <h3>History</h3>
-<p>Nomad was created to be more strategic than Gypsy (hence all the
-open cards), and be solvable more often than it under optimal play.
-From empiric data, I find it's solvable in all but one in ten
-games, where I was solving only slightly above a quarter of the
-Gypsy games. At the same time, the single free cell gives it a very
-rich complexity.</p>
+<p>
+Nomad was created to be more strategic than Gypsy (hence all the open cards),
+and be solvable more often than it under optimal play. From empiric data, I
+find it's solvable in all but one in ten games, where I was solving only
+slightly above a quarter of the Gypsy games. At the same time, the single free
+cell gives it a very rich complexity.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"http://furry.de/miavir/index.html">Deon Ramsey</a>&lt;<a href=
-"mailto:miavir@furry.de">miavir@furry.de</a>&gt; (based on code and
-documentation by Markus Oberhumer) and is part of the official
-PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="http://furry.de/miavir/index.html">Deon Ramsey</a>&lt;<a href="mailto:miavir@furry.de">miavir@furry.de</a>&gt; (based on code and documentation by
+Markus Oberhumer) and is part of the official PySol distribution.

--- a/html-src/rules/nordic.html
+++ b/html-src/rules/nordic.html
@@ -1,17 +1,12 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Nordic</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Quick Description</h3>
-<p>Like <a href="curdsandwhey.html">Curds and Whey</a>, but ten
-piles, and anything on an empty space.</p>
+<p>
+Like <a href="curdsandwhey.html">Curds and Whey</a>,
+but ten piles, and anything on an empty space.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/numberten.html
+++ b/html-src/rules/numberten.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Number Ten</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the
-piles build down by alternate color, and sequences can be
-moved.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the piles build down by alternate color, and sequences can
+be moved.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/numerica.html
+++ b/html-src/rules/numerica.html
@@ -1,34 +1,35 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Numerica</h1>
-<p>Numerica type. 1 deck. No redeal.</p>
+<p>
+Numerica type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations build up by rank - suits and colors are
-irrelevant.</p>
-<p>One card is flipped over at a time and moved onto the stacks.
-There are no restrictions on which card may go where on the stacks.
-Once on a stack, a card can only be moved onto a foundation.</p>
+<p>
+The foundations build up by rank - suits and colors are irrelevant.
+<p>
+One card is flipped over at a time and moved onto the stacks. There are no
+restrictions on which card may go where on the stacks. Once on a stack,
+a card can only be moved onto a foundation.
+
 <h3>Strategy</h3>
-<p>To solve this, you will need to plan carefully when placing the
-cards onto the stacks - one wrong move and you'll never be able to
-untangle the mess.</p>
-<p>A good player can win about one out of three games without
-taking back moves.</p>
-<p>The auto-solver is hopeless. Don't believe the hints.</p>
+<p>
+To solve this, you will need to plan carefully when placing the cards onto
+the stacks - one wrong move and you'll never be able to untangle the mess.
+<p>
+A good player can win about one out of three games without taking back moves.
+<p>
+The auto-solver is hopeless.  Don't believe the hints.
+
 <h3>History</h3>
-<p>This game is also known under names such as <i>Sir
-Tommy</i>.</p>
+<p>
+This game is also known under names such as
+<i>Sir Tommy</i>.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:galen@nine.com">Galen Brooks</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:galen@nine.com">Galen Brooks</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/oddandeven.html
+++ b/html-src/rules/oddandeven.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Odd and Even</h1>
-<p>Two-Deck game type. 2 decks. 1 redeal.</p>
+<p>
+Two-Deck game type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations build up in suit by steps of two.</p>
-<p>The 9 reserve piles can hold a single card and are automatically
-filled from the waste or talon.</p>
-<p>There is no building on the tableau piles, so you can only move
-cards to the foundations.</p>
+<p>
+The foundations build up in suit by steps of two.
+<p>
+The 9 reserve piles can hold a single card and are automatically
+filled from the waste or talon.
+<p>
+There is no building on the tableau piles, so you can
+only move cards to the foundations.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/odessa.html
+++ b/html-src/rules/odessa.html
@@ -1,24 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Odessa</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="russiansolitaire.html">Russian Solitaire</a>,
-only with a different initial card layout.</p>
+<p>
+Just like <a href="russiansolitaire.html">Russian Solitaire</a>,
+only with a different initial card layout.
+
 <h3>Rules</h3>
-<p>Cards in tableau are built down by suit. Groups of cards can be
-moved regardless of sequence. An empty pile in the tableau can be
-filled with a King or a group of cards with a King on the
-bottom.</p>
-<p>Foundations are built up in suit from Ace to King. Cards in
-foundations are no longer in play.</p>
-</body>
-</html>
+<p>
+Cards in tableau are built down by suit.
+Groups of cards can be moved regardless of sequence.
+An empty pile in the tableau can be filled with a King or a group
+of cards with a King on the bottom.
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in foundations are no longer in play.

--- a/html-src/rules/oonsoo.html
+++ b/html-src/rules/oonsoo.html
@@ -1,27 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Oonsoo</h1>
-<p>Hanafuda type. 1 deck. No redeal.</p>
+<p>
+Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Arrange all twelve suits in order.</p>
+<p>
+Arrange all twelve suits in order.
+
 <h3>Rules</h3>
-<p>When the hand is dealt there are two rows of six cards face down
-with six more face up on top. You can play a card on another card
-if it's in the same suit and in descending rank order. The third
-and fourth rank cards are interchangeable for all suits except
-Rain. Plum 4 on Plum 3 is OK. Plum 3 on Plum 4 is OK. Gaji can only
-be played on Rain 3.</p>
+<p>
+When the hand is dealt there are two rows of six cards face down with
+six more face up on top.  You can play a card on another card if it's
+in the same suit and in descending rank order.  The third and fourth
+rank cards are interchangeable for all suits except Rain.  Plum 4 on
+Plum 3 is OK.  Plum 3 on Plum 4 is OK.  Gaji can only be played on
+Rain 3.
+
 <h3>Strategy</h3>
-<p>Hint: try to keep a row open to the canvas.</p>
+<p>
+Hint: try to keep a row open to the canvas.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/oonsooopen.html
+++ b/html-src/rules/oonsooopen.html
@@ -1,24 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Oonsoo Open</h1>
-<p>Hanafuda type. 1 deck. No redeal.</p>
+<p>
+Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Arrange all twelve suits in order.</p>
+<p>
+Arrange all twelve suits in order.
+
 <h3>Rules</h3>
-<p>This game is identical to <a href="oonsoo.html">Oonsoo</a>
-except any card or correctly ordered pile may be played on an empty
-row.</p>
+<p>
+This game is identical to
+<a href="oonsoo.html"> Oonsoo </a>
+except any card or correctly
+ordered pile may be played on an empty row.
+
 <h3>Strategy</h3>
 Try to keep a row open to the canvas.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/oonsoostrict.html
+++ b/html-src/rules/oonsoostrict.html
@@ -1,25 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Oonsoo Strict</h1>
-<p>Hanafuda type. 1 deck. No redeal.</p>
+<p>
+Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Arrange all twelve suits in order.</p>
+<p>
+Arrange all twelve suits in order.
+
 <h3>Rules</h3>
-<p>The third and fourth rank (trash) cards are not interchangeable
-in this version of <a href="oonsoo.html">Oonsoo</a> , but there are
-two reserve stacks.</p>
+<p>
+The third and fourth rank (trash) cards are not
+interchangeable in this version of
+<a href="oonsoo.html"> Oonsoo </a>, but there are two reserve stacks.
+
 <h3>Strategy</h3>
-Try to keep a row open to the canvas. Keep one or both of the
-reserves open until all the cards are dealt.
+Try to keep a row open to the canvas.  Keep one or both of the reserves
+open until all the cards are dealt.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/oonsootimestwo.html
+++ b/html-src/rules/oonsootimestwo.html
@@ -1,23 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Oonsoo</h1>
-<p>Hanafuda type. 1 deck. No redeal.</p>
+<p>
+Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Arrange all twelve suits in order.</p>
+<p>
+Arrange all twelve suits in order.
+
 <h3>Rules</h3>
-<p>When the hand is dealt there are two rows of six cards face down
-with six more face up on top. You can play a card on another card
-if it's in the same suit and in descending rank order. The third
-and fourth rank cards are interchangeable for all suits except
-Rain. Plum 4 on Plum 3 is ok. Plum 3 on Plum 4 is ok. Gaji can only
-be played on Rain 3.</p>
+<p>
+When the hand is dealt there are two rows of six cards face down with
+six more face up on top.  You can play a card on another card if it's
+in the same suit and in descending rank order.  The third and fourth
+rank cards are interchangeable for all suits except Rain.  Plum 4 on
+Plum 3 is ok.  Plum 3 on Plum 4 is ok.  Gaji can only be played on
+Rain 3.
+
 <h3>Strategy</h3>
-<p>Hint: try to keep a row open to the canvas.</p>
-</body>
-</html>
+<p>
+Hint: try to keep a row open to the canvas.

--- a/html-src/rules/oonsootoo.html
+++ b/html-src/rules/oonsootoo.html
@@ -1,24 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Oonsoo</h1>
-<p>Hanafuda type. 1 deck. No redeal.</p>
+<p>
+Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Arrange all twelve suits in order.</p>
+<p>
+Arrange all twelve suits in order.
+
 <h3>Rules</h3>
-This game is identical to <a href="oonsoo.html">Oonsoo</a> except
-there is one reserve stack.
+This game is identical to
+<a href="oonsoo.html"> Oonsoo </a>
+except there is one reserve stack.
+
 <h3>Strategy</h3>
-Try to keep a row open to the canvas. Keep the reserve stack open
+Try to keep a row open to the canvas.  Keep the reserve stack open
 until all the cards are dealt.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/osmosis.html
+++ b/html-src/rules/osmosis.html
@@ -1,16 +1,11 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Osmosis</h1>
-<p>One-Deck game type. 1 deck. Unlimited redeals.</p>
+<p>
+One-Deck game type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/pagat.html
+++ b/html-src/rules/pagat.html
@@ -1,26 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Pagat</h1>
-<p>Tarock type. 1 deck. No redeal.</p>
+<p>
+Tarock type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>This is a Freecell type of game. Cards on the tableau build down
-in rank by suit. Cards build up in rank on the foundations. A stack
-can be moved if the cards are in decending rank order regardless of
-the suit. Any card or stack can be played on an empty row.</p>
+<p>
+This is a Freecell type of game.  Cards on the tableau build down in rank
+by suit.  Cards build up in rank on the foundations.
+A stack can be moved if the cards are in decending rank order
+regardless of the suit.  Any card or stack can be played on an empty
+row.
+
 <h3>Strategy</h3>
-<p>The foundations are less important early in the game than
-building movable stacks. Use the reserve stacks carefully.</p>
+<p>
+The foundations are less important early in the game than
+building movable stacks.  Use the reserve stacks carefully.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/pagoda.html
+++ b/html-src/rules/pagoda.html
@@ -1,34 +1,34 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Pagoda</h1>
-<p>Hanafuda type. 2 decks. No redeal.</p>
+<p>
+Hanafuda type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>When the hand is dealt, the twenty reserve stacks of the pagoda
-are filled with cards. The twelve foundation stacks on the right
-are labeled with the names of the twelve suits. Cards are played on
-the foundations first upwards from the fourth rank to the first,
-then downwards from first to fourth. When the first card is played
-on a foundation, the label changes from the suit name to "Rising".
-When the fifth card is played, the label changes to "Setting". When
-the last card is played, the label reverts to the suit name. Cards
-can be played on the foundations from the reserve stacks or from
-the waste stack. An empty foundation will only accept the fourth
-rank card of the correct suit. Cards are dealt from the talon four
-at a time, and there is only one round.</p>
+<p>
+When the hand is dealt, the twenty reserve stacks of the pagoda
+are filled with cards.  The twelve foundation stacks on the
+right are labeled with the names of the twelve suits.  Cards are
+played on the foundations first upwards from the fourth rank to
+the first, then downwards from first to fourth.  When the first
+card is played on a foundation, the label changes from the suit
+name to "Rising".  When the fifth card is played, the label
+changes to "Setting".  When the last card is played, the label
+reverts to the suit name.  Cards can be played on the foundations
+from the reserve stacks or from the waste stack.  An empty foundation
+will only accept the fourth rank card of the correct suit.  Cards
+are dealt from the talon four at a time, and there is only one
+round.
+
 <h3>Strategy</h3>
-<p>Hint: it's important to keep one or more reserve stacks open
-during the early stages of the game.</p>
+<p>
+Hint: it's important to keep one or more reserve stacks open
+during the early stages of the game.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/parashurama.html
+++ b/html-src/rules/parashurama.html
@@ -1,27 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Parashumrama</h1>
 Dashavatara Ganjifa type. One deck. One redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank only.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank only.
+
 <h3>Rules</h3>
-The cards on the tableau build down in rank regardless of suit. The
-foundations build up in rank by suit starting with the Ace. The
-cards are dealt from the talon three at a time. There is one
-redeal. Only Mirs (Kings) may be played on an empty row. Cards may
-not be played from the foundations.
+The cards on the tableau build down in rank regardless of suit.  The
+foundations build up in rank by suit starting with the Ace.  The cards
+are dealt from the talon three at a time.  There is one redeal.  Only Mirs
+(Kings) may be played on an empty row.  Cards may not be played from the
+foundations.
+
 <h3>Strategy</h3>
-The waste stack will be the biggest problem area. Play from it
-first. Move cards on the tableau to make every play possible before
-dealing more cards.
-</body>
-</html>
+The waste stack will be the biggest problem area.  Play from it first.
+Move cards on the tableau to make every play possible before dealing
+more cards.

--- a/html-src/rules/pasdedeux.html
+++ b/html-src/rules/pasdedeux.html
@@ -1,29 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Pas de Deux</h1>
-<p>Montana type. 2 decks. 1 redeal.</p>
+<p>
+Montana type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
-<p>Group all cards on the tableau in sets of 13 cards in acscending
-sequence by suit from Ace to King. The first row in Club, the
-second in Spade, the third in Heart and the last in Diamond.</p>
+<p>
+Group all cards on the tableau in sets of 13 cards in acscending sequence
+by suit from Ace to King.
+The first row in Club, the second in Spade, the third in Heart and
+the last in Diamond.
+
 <h3>Rules</h3>
-<p>This solitaire is played with two separate decks. The first deck
-is shuffled and dealt out in four rows. The second deck is shuffled
-and becomes the talon.</p>
-<p>Only the card that is of the same rank and suit as the top card
-of the waste can be moved. This card can be exchanged with any card
-on the same row or on the same column of the tableau.</p>
-<p>After each move a new card is dealt from the talon to the waste.
-There is one redeal.</p>
-<p>If you do not want to exchange a card just click on the
-talon.</p>
+<p>
+This solitaire is played with two separate decks.
+The first deck is shuffled and dealt out in four rows.
+The second deck is shuffled and becomes the talon.
+<p>
+Only the card that is of the same rank and suit as the top card
+of the waste can be moved. This card can be exchanged with any
+card on the same row or on the same column of the tableau.
+<p>
+After each move a new card is dealt from the talon to the waste.
+There is one redeal.
+<p>
+If you do not want to exchange a card just click on the talon.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/passeul.html
+++ b/html-src/rules/passeul.html
@@ -1,26 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Pas Seul</h1>
-<p>Klondike type. 1 deck. No redeal.</p>
+<p>
+Klondike type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but 6 piles, anything
-on an empty space, and no redeal.<br />
-Much like <a href="blindalleys.html">Blind Alleys</a>.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but 6 piles, anything on an empty space, and no redeal.
+<br>Much like <a href="blindalleys.html">Blind Alleys</a>.
+
 <h3>Rules</h3>
-<p>Piles build down by alternate color, and an empty space can be
-filled with any card or sequence.</p>
-<p>Cards from the talon are turned over to the waste pile, one at a
-time. You can move the top card to the playing piles or the
-foundations. There is no redeal.</p>
-<p>You are also permitted to move cards back out of the
-foundations.</p>
-</body>
-</html>
+<p>
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence.
+<p>
+Cards from the talon are turned over to the waste pile, one at a time.
+You can move the top card to the playing piles or the foundations.
+There is no redeal.
+<p>
+You are also permitted to move cards back out of the foundations.

--- a/html-src/rules/paulownia.html
+++ b/html-src/rules/paulownia.html
@@ -1,29 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Paulownia</h1>
 Hanafuda type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down in rank by same suit. The foundations build up in rank
-by suit.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down in rank by same suit.  The foundations
+build up in rank by suit.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build from fourth to first. The third and fourth rank
-(trash) cards are not interchangeable on the tableau. Cards may not
-be played from the foundations. Only first rank cards or correctly
-ordered piles may be played on an empty row.
+The rows build from first rank to fourth rank by suit.  The foundations
+build from fourth to first.  The third and fourth rank (trash) cards are
+not interchangeable on the tableau.  Cards may not be played from the
+foundations.  Only first rank cards or correctly ordered piles may be
+played on an empty row.
+
 <h3>Strategy</h3>
 Uncover the deepest row stacks first.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/peek.html
+++ b/html-src/rules/peek.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Peek</h1>
-<p>One-Deck game type. 1 deck. Unlimited redeals.</p>
+<p>
+One-Deck game type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="osmosis.html">Osmosis</a>, but the rows are
-dealt face-up.</p>
+<p>
+Just like <a href="osmosis.html">Osmosis</a>,
+but the rows are dealt face-up.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/pegged.html
+++ b/html-src/rules/pegged.html
@@ -1,24 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Pegged</h1>
-<p>Puzzle game type. 1 deck. No redeal.</p>
+<p>
+Puzzle game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Remove all but one card.</p>
+<p>
+Remove all but one card.
+
 <h3>Rules</h3>
-<p>This is a classic puzzle game. Cards are removed by jumping over
-neighbour cards, and the space beyond the neighbour must be
-empty.</p>
-<p>You win when there is only one card left.</p>
+<p>
+This is a classic puzzle game. Cards are removed by jumping over
+neighbour cards, and the space beyond the neighbour must be empty.
+<p>
+You win when there is only one card left.
+
 <h3>Notes</h3>
-<p>To get awarded for a perfect game the remaining card must be in
-the position of the initial free space.</p>
-<p><i>Autodrop</i> and <i>Quickplay</i> are disabled for this
-game.</p>
-</body>
-</html>
+<p>
+To get awarded for a perfect game the remaining card must be
+in the position of the initial free space.
+<p>
+<i>Autodrop</i> and <i>Quickplay</i> are disabled for this game.

--- a/html-src/rules/penguin.html
+++ b/html-src/rules/penguin.html
@@ -1,23 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Penguin</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The top left card is called the <i>Beak</i> and determines the
-base rank for the foundations. The three other cards of the same
-rank are placed to the foundations.</p>
-<p>The seven piles build down by same suit, wrapping around from
-Ace to King. Empty spaces may only be filled by a card or a
-sequence one below the Beak's rank.</p>
-<p>The seven free cells (also called <i>Flipper</i>) can hold any -
-and just one - card.</p>
-</body>
-</html>
+<p>
+The top left card is called the <i>Beak</i> and determines the base
+rank for the foundations. The three other cards of the same rank
+are placed to the foundations.
+<p>
+The seven piles build down by same suit, wrapping around from Ace to King.
+Empty spaces may only be filled by a card or a sequence
+one below the Beak's rank.
+<p>
+The seven free cells (also called <i>Flipper</i>) can hold
+any - and just one - card.

--- a/html-src/rules/peony.html
+++ b/html-src/rules/peony.html
@@ -1,27 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Peony</h1>
 Hanafuda type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="paulownia.html">Peony</a>. The rows
-build down in rank by same suit. The foundations build up in rank
-by suit.
+Play is similar to
+<a href="paulownia.html">Peony</a>.
+The rows build down in rank by same suit.  The foundations
+build up in rank by suit.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build from fourth to first. The third and fourth rank
-(trash) cards are not interchangeable on the tableau. Cards may not
-be played from the foundations. Cards are dealt from the talon
-three at a time. Any card or sequence stack may be played on an
-empty row.
+The rows build from first rank to fourth rank by suit.  The foundations
+build from fourth to first.  The third and fourth rank (trash) cards are
+not interchangeable on the tableau.  Cards may not be played from the
+foundations.  Cards are dealt from the talon three at a time.  Any card
+or sequence stack may be played on an empty row.
+
 <h3>Strategy</h3>
 Uncover the deepest row stacks first.
-</body>
-</html>

--- a/html-src/rules/perpetualmotion.html
+++ b/html-src/rules/perpetualmotion.html
@@ -1,24 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Perpetual Motion</h1>
-<p>One-Deck game type. 1 deck. Unlimited redeals.</p>
+<p>
+One-Deck game type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the single foundation.</p>
+<p>
+Move all cards to the single foundation.
+
 <h3>Rules</h3>
-<p>The piles build by <b>cards of same rank</b>.</p>
-<p>Four cards of the same rank can be moved to the single
-foundation.</p>
-<p>After all cards have been dealt click on the talon for a redeal.
-The cards are not re-shuffled, but re-dealt in a certain
-pattern.</p>
+<p>
+The piles build by <b>cards of same rank</b>.
+<p>
+Four cards of the same rank can be moved to the single foundation.
+<p>
+After all cards have been dealt click on the talon for a redeal.
+The cards are not re-shuffled, but re-dealt in a certain pattern.
+
 <h3>Strategy</h3>
-<p>Good for mindless playing as sooner or later every game should
-come out.</p>
-</body>
-</html>
+<p>
+Good for mindless playing as sooner or later every game should come out.

--- a/html-src/rules/picturegallery.html
+++ b/html-src/rules/picturegallery.html
@@ -1,40 +1,38 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Picture Gallery (Die Bildgallerie)</h1>
-<p>Two-Deck game type. 2 decks. No redeal.</p>
+<p>
+Two-Deck game type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Fill the entire Gallery with pictures.</p>
+<p>
+Fill the entire Gallery with pictures.
+
 <h3>Rules</h3>
-<p>The layout consists of three rows of playing piles, a row for
-newly- dealt cards, and a castoff pile for Aces.</p>
-<p>All Aces are cast off to the pile on the right. Use the
-&lt;A&gt; key. When you clear a space on the tableau, you can only
-fill it with the right card:</p>
+<p>
+The layout consists of three rows of playing piles, a row for newly-
+dealt cards, and a castoff pile for Aces.
+<p>
+All Aces are cast off to the pile on the right.  Use the &lt;A&gt; key.
+When you clear a space on the tableau,
+you can only fill it with the right card:
 <ul>
-<li>In the first row, you build up sequences starting with a
-Four,</li>
-<li>in the second row with a Three, and in the</li>
-<li>third row with a Two.</li>
+<li>In the first row, you build up sequences starting with a Four,
+<li>in the second row with a Three, and in the
+<li>third row with a Two.
 </ul>
-You build up sequences incrementing by three, up to the face cards.
-Thus, in the first row, each pile is 4-7-10-K, in the second row
-3-6-9-D, and in the third row, 2-5-8-B. Once a sequence has been
+You build up sequences incrementing by three, up to
+the face cards.  Thus, in the first row, each pile is 4-7-10-K, in the
+second row 3-6-9-D, and in the third row, 2-5-8-B. Once a sequence has been
 started, you have to follow suit.
-<p>If you clear a space at the bottom it will get automatically
-filled with a card from the talon. But if the talon is gone and you
-clear a space at the bottom, then you can fill it with any card.
-When no further moves are possible, click on the talon for a fresh
-row of cards at the bottom.</p>
-<p>You win when the entire Gallery is filled with pictures, that
-is, face cards.</p>
+<p>
+If you clear a space at the bottom it will get automatically filled
+with a card from the talon. But if the talon is gone and you clear a space
+at the bottom, then you can fill it with any card.
+When no further moves are possible, click on the talon for a fresh row
+of cards at the bottom.
+<p>
+You win when the entire Gallery is filled with pictures, that is, face cards.
+
 <h3>Strategy</h3>
-<p>Because of the many piles involved the Picture Gallery requires
-some concentration, but it is not too hard to win.</p>
-</body>
-</html>
+<p>
+Because of the many piles involved the Picture Gallery requires some
+concentration, but it is not too hard to win.

--- a/html-src/rules/pileon.html
+++ b/html-src/rules/pileon.html
@@ -1,28 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>PileOn</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Rearrange the cards so that each pile contains four cards with
-the same rank.</p>
+<p>
+Rearrange the cards so that each pile contains four cards with the
+same rank.
+
 <h3>Rules</h3>
-<p>Rearrange the cards so that each pile contains four cards with
-the same rank. This should leave two piles empty.</p>
-<p>Cards can be moved on top of any other card or cards of the same
-rank. Groups of cards can be moved if they are of the same
-rank.</p>
-<p>A pile cannot have more than four cards, and an empty slot can
-be filled with any card or group of cards with the same rank.</p>
+<p>
+Rearrange the cards so that each pile contains four cards with the
+same rank. This should leave two piles empty.
+<p>
+Cards can be moved on top of any other card or cards of the same rank.
+Groups of cards can be moved if they are of the same rank.
+<p>
+A pile cannot have more than four cards, and an empty slot
+can be filled with any card or group of cards with the same rank.
+
 <h3>Strategy</h3>
-<p>Keep one of the piles clear as much as possible. Don't allow a
-pile of three cards to build up on top of a single card, especially
-if the final card from the set is not a bottom card in another
-pile.</p>
-</body>
-</html>
+<p>
+Keep one of the piles clear as much as possible. Don't allow a pile of
+three cards to build up on top of a single card, especially if the
+final card from the set is not a bottom card in another pile.

--- a/html-src/rules/pine.html
+++ b/html-src/rules/pine.html
@@ -1,26 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Pine</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="paulownia.html">Pine</a>. The rows
-build down in rank by same suit. The foundations build up in rank
-by suit.
+Play is similar to
+<a href="paulownia.html">Pine</a>.
+The rows build down in rank by same suit.  The foundations
+build up in rank by suit.
+
 <h3>Rules</h3>
-The rows build from first rank to fourth rank by suit. The
-foundations build from fourth to first. The third and fourth rank
-(trash) cards are not interchangeable on the tableau. Cards may not
-be played from the foundations. Cards are dealt from the talon
-three at a time and there is no redeal.
+The rows build from first rank to fourth rank by suit.  The foundations
+build from fourth to first.  The third and fourth rank (trash) cards are
+not interchangeable on the tableau.  Cards may not be played from the
+foundations.  Cards are dealt from the talon three at a time and
+there is no redeal.
+
 <h3>Strategy</h3>
 Uncover the deepest row stacks first.
-</body>
-</html>

--- a/html-src/rules/pokershuffle.html
+++ b/html-src/rules/pokershuffle.html
@@ -1,21 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Poker Shuffle</h1>
-<p>Poker type. 1 deck. No redeal.</p>
+<p>
+Poker type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Arrange the 10 Poker hands for a total score of 200 points or
-more.</p>
+<p>
+Arrange the 10 Poker hands for a total score of 200 points or more.
+
 <h3>Rules</h3>
-<p>At game start 25 cards are dealt to the tableau piles.</p>
-<p>Swap any 2 cards on the tableau to maximize your score.</p>
-<p>Points are awarded for the 5 Poker hands from left to right and
-for the 5 hands from top to bottom.</p>
-<p>You win if your score reaches 200 points.</p>
-</body>
-</html>
+<p>
+At game start 25 cards are dealt to the tableau piles.
+<p>
+Swap any 2 cards on the tableau to maximize your score.
+<p>
+Points are awarded for the 5 Poker hands from left to right and for
+the 5 hands from top to bottom.
+<p>
+You win if your score reaches 200 points.

--- a/html-src/rules/pokersquare.html
+++ b/html-src/rules/pokersquare.html
@@ -1,21 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Poker Square</h1>
-<p>Poker type. 1 deck. No redeal.</p>
+<p>
+Poker type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Arrange the 10 Poker hands for a total score of 100 points or
-more.</p>
+<p>
+Arrange the 10 Poker hands for a total score of 100 points or more.
+
 <h3>Rules</h3>
-<p>Place the 25 cards on the tableau to get a score of 100 points
-or more.</p>
-<p>Once on a stack, a card cannot be moved.</p>
-<p>Points are awarded for the 5 Poker hands from left to right and
-for the 5 hands from top to bottom.</p>
-</body>
-</html>
+<p>
+Place the 25 cards on the tableau to get a score of 100 points or more.
+<p>
+Once on a stack, a card cannot be moved.
+<p>
+Points are awarded for the 5 Poker hands from left to right and for
+the 5 hands from top to bottom.

--- a/html-src/rules/ponytail.html
+++ b/html-src/rules/ponytail.html
@@ -1,22 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Ponytail</h1>
-<p>Tarock type. 2 decks. 2 redeals.</p>
+<p>
+Tarock type. 2 decks. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="braid.html">Braid</a>, but with Tarock cards.</p>
+<p>
+Like <a href="braid.html">Braid</a>,
+but with Tarock cards.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/pyramid.html
+++ b/html-src/rules/pyramid.html
@@ -1,23 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Pyramid</h1>
-<p>Pairing game type. 1 deck. 2 redeals.</p>
+<p>
+Pairing game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the single foundation.</p>
+<p>
+Move all cards to the single foundation.
+
 <h3>Rules</h3>
-<p>The object is to use up all the cards by placing them on the
-single foundation.</p>
-<p>You can only put a card on top of another card when the
-numerical values of the two cards adds up to 13. Queen is worth 12
-and Jack is worth 11. You do not have to follow suit.</p>
-<p>All Kings go off alone.</p>
+<p>
+The object is to use up all the cards by placing them
+on the single foundation.
+<p>
+You can only put a card on top of another card
+when the numerical values of the two cards adds up to 13.
+Queen is worth 12 and Jack is worth 11. You do not have to follow suit.
+<p>
+All Kings go off alone.
+
 <h3>Notes</h3>
-<p><i>Quickplay</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Quickplay</i> is disabled for this game.

--- a/html-src/rules/quadrangle.html
+++ b/html-src/rules/quadrangle.html
@@ -1,21 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Quadrangle</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but with a
-varying base card, the foundations and the 12 piles wrap around,
-and empty piles are automatically filled from the waste or
-talon.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but with a varying base card,
+the foundations and the 12 piles wrap around,
+and empty piles are automatically filled from the waste or talon.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/queenie.html
+++ b/html-src/rules/queenie.html
@@ -1,26 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Queenie</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="yukon.html">Yukon</a>, but don't deal all cards at
-game start.</p>
+<p>
+Like <a href="yukon.html">Yukon</a>,
+but don't deal all cards at game start.
+
 <h3>Rules</h3>
-<p>Cards in Tableau are built down by alternate color. Groups of
-cards can be moved regardless of sequence. An empty pile in the
-Tableau can be filled with a King or a group of cards with a King
-on the bottom.</p>
-<p>Foundations are built up in suit from Ace to King. Cards in
-Foundations are no longer in play.</p>
-<p>When no more moves are possible, click on the Talon. One card
-will be added to each of the playing piles.</p>
-</body>
-</html>
+<p>
+Cards in Tableau are built down by alternate color.
+Groups of cards can be moved regardless of sequence.
+An empty pile in the Tableau can be filled with a King or a group
+of cards with a King on the bottom.
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in Foundations are no longer in play.
+<p>
+When no more moves are possible, click on the Talon.
+One card will be added to each of the playing piles.

--- a/html-src/rules/rachel.html
+++ b/html-src/rules/rachel.html
@@ -1,23 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Rachel</h1>
-<p>Spider type. 1 deck. No redeal.</p>
+<p>
+Spider type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the Foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the Foundations.
+
 <h3>Rules</h3>
-<p>Cards are built down, regardless of suit. A space can be filled
-by any card or legal group of cards.</p>
-<p>The object is to group the cards in sets of 13 cards, from King
-to Ace of the same suit. Such groups can be moved to the
-Foundations.</p>
-<p>When you click on the Talon, one card is turned over onto the
-Waste pile. There is no redeal.</p>
-</body>
-</html>
+<p>
+Cards are built down, regardless of suit.
+A space can be filled by any card or legal group of cards.
+<p>
+The object is to group the cards in sets of 13 cards, from King to Ace
+of the same suit. Such groups can be moved to the Foundations.
+<p>
+When you click on the Talon, one card is turned over onto the Waste pile.
+There is no redeal.

--- a/html-src/rules/rainbow.html
+++ b/html-src/rules/rainbow.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Rainbow</h1>
-<p>Canfield type. 1 deck. No redeal.</p>
+<p>
+Canfield type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="canfield.html">Canfield</a>, but piles build down
-by rank, cards are dealt singly, and no redeal.</p>
+<p>
+Like <a href="canfield.html">Canfield</a>,
+but piles build down by rank, cards are dealt singly, and no redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/rainfall.html
+++ b/html-src/rules/rainfall.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Rainfall</h1>
-<p>Canfield type. 1 deck. 2 redeals.</p>
+<p>
+Canfield type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="canfield.html">Canfield</a>, but cards are dealt
-singly, and two redeals.</p>
+<p>
+Like <a href="canfield.html">Canfield</a>,
+but cards are dealt singly, and two redeals.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/rambling.html
+++ b/html-src/rules/rambling.html
@@ -1,23 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Rambling</h1>
-<p>FreeCell type. Two Tarock Decks. No redeal.</p>
+<p>
+FreeCell type.  Two Tarock Decks.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, using two 78 card Tarock
-decks and the number of cards you can move as a sequence is not
-restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+using two 78 card Tarock decks and the number of cards you can move as a
+sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-King or Skiz starting a new pile. Rows build down in rank and suit.
-The trumps will only play on other trumps. Empty rows cannot be
-filled. The eight free cells will hold one card each.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each King or Skiz
+starting a new pile.  Rows build down in rank and suit.  The
+trumps will only play on other trumps.  Empty rows cannot be filled.
+The eight free cells will hold one card each.

--- a/html-src/rules/rankandfile.html
+++ b/html-src/rules/rankandfile.html
@@ -1,21 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Rank and File</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the
-piles build down by alternate color, and sequences can be
-moved.<br />
-Much like <a href="numberten.html">Number Ten</a>.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the piles build down by alternate color, and sequences can
+be moved.
+<br>Much like <a href="numberten.html">Number Ten</a>.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/redandblack.html
+++ b/html-src/rules/redandblack.html
@@ -1,20 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Red and Black</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the 8
-piles build down by alternate color, the foundations <b>build up by
-alternate color</b>, and sequences can be moved.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the 8 piles build down by alternate color,
+the foundations <b>build up by alternate color</b>,
+and sequences can be moved.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/redmoon.html
+++ b/html-src/rules/redmoon.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Red Moon</h1>
-<p>Montana type. 1 deck. 2 redeals.</p>
+<p>
+Montana type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in ascending sequence by
-suit from Ace to King.</p>
+<p>
+Group all the cards in sets of 13 cards in ascending sequence
+by suit from Ace to King.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="bluemoon.html">Blue Moon</a>, but easier
-because of a different initial layout.</p>
+<p>
+Just like <a href="bluemoon.html">Blue Moon</a>,
+but easier because of a different initial layout.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/relax.html
+++ b/html-src/rules/relax.html
@@ -1,32 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relax</h1>
 Hanafuda type. 1 deck. One redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-This is a variation of <a href="littleeasy.html">Little Easy</a>.
-The rows build down by rank in the same suit. The foundations build
-with cards of the same rank in suit order. Only first rank cards
-may be played on an empty row. Trash card ranks are
-interchangeable.
+This is a variation of
+<a href="littleeasy.html">Little Easy</a>.
+The rows build down by rank in the same suit.  The foundations
+build with cards of the same rank in suit order.  Only first
+rank cards may be played on an empty row.  Trash card ranks
+are interchangeable.
+
 <h3>Rules</h3>
-The rules are the same as in <a href="littleeasy.html">Little
-Easy</a> except that the cards deal from the talon one at a time,
-there is only one redeal and the third and fourth rank (trash)
-cards are interchangeable.
+The rules are the same as in
+<a href="littleeasy.html">Little Easy</a>
+except that the cards deal from the talon one at a time, there
+is only one redeal and the third and fourth rank (trash) cards
+are interchangeable.
+
 <h3>Strategy</h3>
-Disable auto drop and build on the rows until all cards are face
-up. These games may be easy by name and easy to play but they're
-not easy to win.
+Disable auto drop and build on the rows until all cards are face up.
+These games may be easy by name and easy to play but they're not easy
+to win.
+
 <h3>Author</h3>
-This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.
-</body>
-</html>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/relaxedaccordion.html
+++ b/html-src/rules/relaxedaccordion.html
@@ -1,17 +1,12 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Westcliff</h1>
-<p>One deck type. 1 deck. No redeal.</p>
+<p>
+One deck type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Compress the entire deck into one pile.</p>
+<p>
+Compress the entire deck into one pile.
+
 <h3>Quick Description</h3>
-<p>Like <a href="accordion.html">Accordion</a>, but you can move
-piles to left and to right.</p>
-</body>
-</html>
+<p>
+Like <a href="accordion.html">Accordion</a>,
+but you can move piles to left and to right.

--- a/html-src/rules/relaxedfreecell.html
+++ b/html-src/rules/relaxedfreecell.html
@@ -1,19 +1,15 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relaxed FreeCell</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="freecell.html">FreeCell</a>, but the number
-of cards you can move as a sequence is not restricted.</p>
+<p>
+Just like <a href="freecell.html">FreeCell</a>,
+but the number of cards you can move as a sequence is not restricted.
+
 <h3>Rules</h3>
 <i>[To be written]</i>
-</body>
-</html>

--- a/html-src/rules/relaxedgolf.html
+++ b/html-src/rules/relaxedgolf.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relaxed Golf</h1>
-<p>Golf type. 1 deck. No redeal.</p>
+<p>
+Golf type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the waste stack.</p>
+<p>
+Move all cards to the waste stack.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="golf.html">Golf</a>, but sequences do wrap
-around, i.e. Twos and Kings may be placed on Aces and Queens and
-Aces may be placed on Kings.</p>
+<p>
+Just like <a href="golf.html">Golf</a>,
+but sequences do wrap around,
+i.e. Twos and Kings may be placed on Aces
+and Queens and Aces may be placed on Kings.
+
 <h3>Rules</h3>
 <i>[To be written]</i>
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/relaxedpyramid.html
+++ b/html-src/rules/relaxedpyramid.html
@@ -1,21 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relaxed Pyramid</h1>
-<p>Pairing game type. 1 deck. 2 redeals.</p>
+<p>
+Pairing game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Remove all cards from the Pyramid.</p>
+<p>
+Remove all cards from the Pyramid.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="pyramid.html">Pyramid</a>, but you win as
-soon as the Pyramid is cleared.</p>
+<p>
+Just like <a href="pyramid.html">Pyramid</a>,
+but you win as soon as the Pyramid is cleared.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>Notes</h3>
-<p><i>Quickplay</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Quickplay</i> is disabled for this game.

--- a/html-src/rules/relaxedseahaventowers.html
+++ b/html-src/rules/relaxedseahaventowers.html
@@ -1,20 +1,15 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relaxed Seahaven Towers</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="seahaventowers.html">Seahaven Towers</a>, but
-the number of cards you can move as a sequence is not
-restricted.</p>
+<p>
+Just like <a href="seahaventowers.html">Seahaven Towers</a>,
+but the number of cards you can move as a sequence is not restricted.
+
 <h3>Rules</h3>
 <i>[To be written]</i>
-</body>
-</html>

--- a/html-src/rules/relaxedspider.html
+++ b/html-src/rules/relaxedspider.html
@@ -1,20 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Relaxed Spider</h1>
-<p>Spider type. 2 decks. No redeal.</p>
+<p>
+Spider type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="spider.html">Spider</a>, but you may deal new
-cards even if there are empty rows.</p>
+<p>
+Just like <a href="spider.html">Spider</a>,
+but you may deal new cards even if there are empty rows.
+
 <h3>Rules</h3>
 <i>[To be written]</i>
-</body>
-</html>

--- a/html-src/rules/retinue.html
+++ b/html-src/rules/retinue.html
@@ -1,27 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Retinue</h1>
-<p>FreeCell type. 2 decks. No redeal.</p>
+<p>
+FreeCell type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="freecell.html">FreeCell</a>, but with 2 decks, and
-empty rows are not filled.</p>
+<p>
+Like <a href="freecell.html">FreeCell</a>,
+but with 2 decks, and empty rows are not filled.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 8 piles at the start of the game, each
-King starting a new pile. To compensate for this there are 8 free
-cells which can hold any - and just one - card.</p>
-<p>Piles build down by alternate color, and an empty space cannot
-be filled.</p>
-<p>The number of cards you can move as a sequence is restricted by
+<p>
+All cards are dealt to 8 piles at the start of the game, each King
+starting a new pile.
+To compensate for this there are 8 free cells which can hold any
+- and just one - card.
+<p>
+Piles build down by alternate color, and an empty space cannot be filled.
+<p>
+The number of cards you can move as a sequence is restricted by
 the number of free cells - the number of free cells required is the
-same as if you would make an equivalent sequence of moves with
-single cards.</p>
-</body>
-</html>
+same as if you would make an equivalent sequence of moves with single cards.

--- a/html-src/rules/roslin.html
+++ b/html-src/rules/roslin.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Roslin</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="yukon.html">Yukon</a>, but piles build up or down
-by alternate color.</p>
+<p>
+Like <a href="yukon.html">Yukon</a>,
+but piles build up or down by alternate color.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/royalcotillion.html
+++ b/html-src/rules/royalcotillion.html
@@ -1,24 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Royal Cotillion</h1>
-<p>Two-Deck game type. 2 decks. No redeal.</p>
+<p>
+Two-Deck game type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations build up in suit by steps of two.</p>
-<p>The 4 reserve piles on the left can only play to the
-foundations.</p>
-<p>The 16 reserve piles on the right can hold a single card and are
-automatically filled from the waste or talon.</p>
-<p>There is no building on the tableau piles, so you can only move
-cards to the foundations.</p>
+<p>
+The foundations build up in suit by steps of two.
+<p>
+The 4 reserve piles on the left can only play to the foundations.
+<p>
+The 16 reserve piles on the right can hold a single card and
+are automatically filled from the waste or talon.
+<p>
+There is no building on the tableau piles, so you can
+only move cards to the foundations.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/royaleast.html
+++ b/html-src/rules/royaleast.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Royal East</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The four foundations in the corners build up in suit, wrapping
-around from King to Ace. The base rank is determined at initial
-dealing.</p>
-<p>The five tableau piles build down by rank, wrapping around from
-Ace to King. Only the top card can be moved.</p>
-</body>
-</html>
+<p>
+The four foundations in the corners build up in suit,
+wrapping around from King to Ace.
+The base rank is determined at initial dealing.
+<p>
+The five tableau piles build down by rank,
+wrapping around from Ace to King.
+Only the top card can be moved.

--- a/html-src/rules/rushdike.html
+++ b/html-src/rules/rushdike.html
@@ -1,26 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Rushdike</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="russiansolitaire.html">Russian Solitaire</a>, but
-don't deal all cards at game start.</p>
+<p>
+Like <a href="russiansolitaire.html">Russian Solitaire</a>,
+but don't deal all cards at game start.
+
 <h3>Rules</h3>
-<p>Cards in Tableau are built down by suit. Groups of cards can be
-moved regardless of sequence. An empty pile in the Tableau can be
-filled with a King or a group of cards with a King on the
-bottom.</p>
-<p>Foundations are built up in suit from Ace to King. Cards in
-Foundations are no longer in play.</p>
-<p>When no more moves are possible, click on the Talon. One card
-will be added to each of the playing piles.</p>
-</body>
-</html>
+<p>
+Cards in Tableau are built down by suit.
+Groups of cards can be moved regardless of sequence.
+An empty pile in the Tableau can be filled with a King or a group
+of cards with a King on the bottom.
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in Foundations are no longer in play.
+<p>
+When no more moves are possible, click on the Talon.
+One card will be added to each of the playing piles.

--- a/html-src/rules/russianpatience.html
+++ b/html-src/rules/russianpatience.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Russian Patience (Die Russische)</h1>
-<p>Two-Deck game type. 2 stripped decks. No redeal.</p>
+<p>
+Two-Deck game type. 2 stripped decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>This game is played with two stripped decks.</p>
-<p>The foundations build up in suit starting with Ace, then from
-Seven up to King.</p>
-<p>The row stacks build down in alternate color. Sequences may be
-moved, and spaces may be filled by any <i>single</i> card.</p>
-</body>
-</html>
+<p>
+This game is played with two stripped decks.
+<p>
+The foundations build up in suit starting with Ace, then from Seven up to King.
+<p>
+The row stacks build down in alternate color.
+Sequences may be moved, and
+spaces may be filled by any <i>single</i> card.

--- a/html-src/rules/russianpoint.html
+++ b/html-src/rules/russianpoint.html
@@ -1,26 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Russian Point</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="russiansolitaire.html">Russian Solitaire</a>, but
-don't deal all cards at game start.</p>
+<p>
+Like <a href="russiansolitaire.html">Russian Solitaire</a>,
+but don't deal all cards at game start.
+
 <h3>Rules</h3>
-<p>Cards in Tableau are built down by suit. Groups of cards can be
-moved regardless of sequence. An empty pile in the Tableau can be
-filled with a King or a group of cards with a King on the
-bottom.</p>
-<p>Foundations are built up in suit from Ace to King. Cards in
-Foundations are no longer in play.</p>
-<p>When no more moves are possible, click on the Talon. One card
-will be added to each of the playing piles.</p>
-</body>
-</html>
+<p>
+Cards in Tableau are built down by suit.
+Groups of cards can be moved regardless of sequence.
+An empty pile in the Tableau can be filled with a King or a group
+of cards with a King on the bottom.
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in Foundations are no longer in play.
+<p>
+When no more moves are possible, click on the Talon.
+One card will be added to each of the playing piles.

--- a/html-src/rules/russiansolitaire.html
+++ b/html-src/rules/russiansolitaire.html
@@ -1,24 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Russian Solitaire</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="yukon.html">Yukon</a>, but piles build down by
-suit.</p>
+<p>
+Like <a href="yukon.html">Yukon</a>,
+but piles build down by suit.
+
 <h3>Rules</h3>
-<p>Cards in tableau are built down by suit. Groups of cards can be
-moved regardless of sequence. An empty pile in the tableau can be
-filled with a King or a group of cards with a King on the
-bottom.</p>
-<p>Foundations are built up in suit from Ace to King. Cards in
-foundations are no longer in play.</p>
-</body>
-</html>
+<p>
+Cards in tableau are built down by suit.
+Groups of cards can be moved regardless of sequence.
+An empty pile in the tableau can be filled with a King or a group
+of cards with a King on the bottom.
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in foundations are no longer in play.

--- a/html-src/rules/samuri.html
+++ b/html-src/rules/samuri.html
@@ -1,30 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Samuri</h1>
-<p>Hanafuda type. 1 deck. No redeal.</p>
+<p>
+Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Samuri is a Klondike type game. Play begins with a similar
-layout. There are seven row stacks with six foundations to either
-side. The Talon is in the middle. Cards are dealt from the talon to
-the waste stack one at a time. There is only one round. The cards
-play on the foundations from fourth rank to first by suits. They
-play on the rows from first to fourth, also by suits. Rank order is
-strict for all suits. Only first rank cards will play on the
-canvas. Cards cannot be removed from a foundation once played
-there.</p>
+<p>
+Samuri is a Klondike type game.  Play begins with a similar layout.
+There are seven row stacks with six foundations to either side.  The
+Talon is in the middle.  Cards are dealt from the talon to the waste
+stack one at a time.  There is only one round.  The cards play on the
+foundations from fourth rank to first by suits.  They play on the rows
+from first to fourth, also by suits.  Rank order is strict for all suits.
+Only first rank cards will play on the canvas.  Cards cannot be removed
+from a foundation once played there.
+
 <h3>Strategy</h3>
-<p>Hint: try not to let the waste stack get too deep.</p>
+<p>
+Hint: try not to let the waste stack get too deep.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/sanibel.html
+++ b/html-src/rules/sanibel.html
@@ -1,75 +1,72 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Sanibel</h1>
-<p>Yukon / Forty Thieves hybrid. 2 decks. No redeal.</p>
+<p>
+Yukon / Forty Thieves hybrid. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Foundations are built up in suit from Ace to King. Cards in the
-Foundations are no longer available for play in the Tableau. It is
-not compulsory to play any card to the Foundations.</p>
-<p>The Tableau is built down by alternate color. Any group of cards
-may be moved regardless of sequence, so long as the bottom card of
-the group is placed on top of a card (in a different pile) that is
-the next higher card in rank and of the opposite color. An empty
-pile in the Tableau can be filled with any group of cards, even a
-single card.</p>
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in the Foundations are no longer available for play in
+the Tableau. It is not compulsory to play any card to the Foundations.
+<p>
+The Tableau is built down by alternate color. Any group of cards may be
+moved regardless of sequence, so long as the bottom card of the group is
+placed on top of a card (in a different pile) that is the next higher card in
+rank and of the opposite color.  An empty pile in the Tableau can be filled
+with any group of cards, even a single card.
+
 <h3>History</h3>
-<p><i>From John Stoneham, Sanibel's inventor:</i></p>
-<p>Sanibel and Captiva are islands off the coast of Ft. Meyers,
-Florida. One summer while vacationing there, I played through all
-the games described in <i>The Complete Book of Solitaire &amp;
-Patience Games</i> by Albert H. Morehead and Geoffrey Mott-Smith
-(published by Bantam, I believe). I really liked the play of Yukon
-but thought the Tableau limited the strategic potential of the
-game, so I added an extra deck and experimented with the Tableau
-layout, aiming for a game that was almost entirely strategic in
-nature but not on the 10th order of mental magnitude. The result is
-Sanibel. The number of face-up cards initially dealt to the Tableau
-determines how much "luck" will play a factor in the game. If you
-only deal 3 or 4 face-up cards to each pile retaining the balance
-in the Reserve, chances are you will loose some games. Technically,
-there is nothing wrong with that, and sometimes I will play it this
-way. On the other hand, dealing every card face up (except the last
-4) takes away nothing from the game and only serves to increase the
-strategy involved. I prefer the 3-down-7-up layout, since the face
-down cards and the small Reserve give you something immediate to
-work for, and it can generate a little suspense when you know there
-is a card buried that you need and you're trying to find a way to
-uncover it...</p>
+<p>
+<i>From John Stoneham, Sanibel's inventor:</i>
+<p>
+Sanibel and Captiva are islands off the coast of Ft. Meyers, Florida. One
+summer while vacationing there, I played through all the games described in
+<i>The Complete Book of Solitaire & Patience Games</i> by Albert H. Morehead
+and Geoffrey Mott-Smith (published by Bantam, I believe). I really liked the
+play of Yukon but thought the Tableau limited the strategic potential of the
+game, so I added an extra deck and experimented with the Tableau layout,
+aiming for a game that was almost entirely strategic in nature but not on the
+10th order of mental magnitude. The result is Sanibel. The number of face-up
+cards initially dealt to the Tableau determines how much "luck" will play a
+factor in the game. If you only deal 3 or 4 face-up cards to each pile
+retaining the balance in the Reserve, chances are you will loose some games.
+Technically, there is nothing wrong with that, and sometimes I will play it
+this way. On the other hand, dealing every card face up (except the last 4)
+takes away nothing from the game and only serves to increase the strategy
+involved. I prefer the 3-down-7-up layout, since the face down cards and the
+small Reserve give you something immediate to work for, and it can generate a
+little suspense when you know there is a card buried that you need and you're
+trying to find a way to uncover it...
+
 <h3>Strategy</h3>
-<p>This is entirely a game of skill: if you loose, you just weren't
-paying attention. Your first priority should be to expose all the
-face-down cards and get the rest of the Reserve into play. Also, do
-not play a card onto a Foundation simply because you can (Aces are
-OK; Twos are probably safe as well): you may need it for building
-in the Tableau. You will find that you do not need to calculate
-very long sequences to finish the game, but sometimes a bit of
-calculation is necessary to expose the buried cards. Sometimes the
-piles can grow longer than can be displayed in the window. This
-usually isn't a problem, since you can break up the pile fairly
-often when other plays become available. Here's something that's a
-lot of fun: If you have arranged the cards in proper sequence,
-playing as few to the Foundations as possible during the game, one
-press of the "Auto" button can play 90 or more cards to the
-Foundations. It is possible to have every card in the Tableau at
-the end of the game, even the Aces; the "Auto" button shoots them
-all up to the Foundations in one long riffle!</p>
+<p>
+This is entirely a game of skill: if you loose, you just weren't paying
+attention. Your first priority should be to expose all the face-down cards and
+get the rest of the Reserve into play. Also, do not play a card onto a
+Foundation simply because you can (Aces are OK; Twos are probably safe as
+well): you may need it for building in the Tableau. You will find that you do
+not need to calculate very long sequences to finish the game, but sometimes a
+bit of calculation is necessary to expose the buried cards. Sometimes the piles
+can grow longer than can be displayed in the window. This usually isn't a
+problem, since you can break up the pile fairly often when other plays
+become available. Here's something that's a lot of fun: If you have arranged
+the cards in proper sequence, playing as few to the Foundations as possible
+during the game, one press of the "Auto" button can play 90 or more cards to
+the Foundations. It is possible to have every card in the Tableau at the end
+of the game, even the Aces; the "Auto" button shoots them all up to the
+Foundations in one long riffle!
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:obijohn99@aol.com">John Stoneham</a> and is part of the
-official PySol distribution.</p>
-<p><i>Copyright (C) 1998 by <a href="mailto:obijohn99@aol.com">John
-Stoneham</a>. These rules are free; you can redistribute them
-and/or modify them under the terms of the GNU General Public
-License as published by the Free Software Foundation; either
-version 2 of the License, or (at your option) any later
-version.</i></p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:obijohn99@aol.com">John Stoneham</a>
+and is part of the official PySol distribution.
+<p>
+<i>Copyright (C) 1998 by <a href="mailto:obijohn99@aol.com">John Stoneham</a>.
+These rules are free; you can redistribute them and/or modify them under the
+terms of the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any later
+version.</i>

--- a/html-src/rules/saratoga.html
+++ b/html-src/rules/saratoga.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Saratoga</h1>
-<p>Klondike type. 1 deck. Unlimited redeal.</p>
+<p>
+Klondike type. 1 deck. Unlimited redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondikebythrees.html">Klondike by Threes</a>, but
-all the cards in the tableau visible.</p>
+<p>
+Like <a href="klondikebythrees.html">Klondike by Threes</a>,
+but all the cards in the tableau visible.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/scorpion.html
+++ b/html-src/rules/scorpion.html
@@ -1,33 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Scorpion</h1>
-<p>Spider type. 1 deck. No redeal.</p>
+<p>
+Spider type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Quick Description</h3>
-<p>Object is like in <a href="spiderette.html">Spiderette</a>, but
-the cards can be moved like in <a href=
-"russiansolitaire.html">Russian Solitaire</a>.</p>
+<p>
+Object is like in <a href="spiderette.html">Spiderette</a>,
+but the cards can be moved like in
+<a href="russiansolitaire.html">Russian Solitaire</a>.
+
 <h3>Rules</h3>
-<p>The object is to group the cards in sets of 13 cards, from King
-to Ace of the same suit. Such groups can be moved to the
-foundations.</p>
-<p>Cards in tableau are built down by suit. Groups of cards can be
-moved regardless of sequence. An empty pile in the tableau can be
-filled with a King or a group of cards with a King on the
-bottom.</p>
-<p>When no more moves are possible, click on the talon. Three more
-cards will be dealt.</p>
+<p>
+The object is to group the cards in sets of 13 cards, from King to Ace
+of the same suit. Such groups can be moved to the foundations.
+<p>
+Cards in tableau are built down by suit.
+Groups of cards can be moved regardless of sequence.
+An empty pile in the tableau can be filled with a King or a group
+of cards with a King on the bottom.
+<p>
+When no more moves are possible, click on the talon.
+Three more cards will be dealt.
+
 <h3>History</h3>
-<p>This is an interesting combination of <a href=
-"spider.html">Spider type</a> and <a href="yukon.html">Yukon
-type</a> game elements.</p>
-</body>
-</html>
+<p>
+This is an interesting combination of
+<a href="spider.html">Spider type</a> and
+<a href="yukon.html">Yukon type</a> game elements.

--- a/html-src/rules/scorpionhead.html
+++ b/html-src/rules/scorpionhead.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Scorpion Head</h1>
-<p>Spider type. 1 deck. No redeal.</p>
+<p>
+Spider type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="scorpion.html">Scorpion</a>, but with four extra
-free cells.</p>
+<p>
+Like <a href="scorpion.html">Scorpion</a>,
+but with four extra free cells.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/scorpiontail.html
+++ b/html-src/rules/scorpiontail.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Scorpion Tail</h1>
-<p>Spider type. 1 deck. No redeal.</p>
+<p>
+Spider type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="scorpion.html">Scorpion</a>, but the piles build
-down by alternate color.</p>
+<p>
+Like <a href="scorpion.html">Scorpion</a>,
+but the piles build down by alternate color.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/scotchpatience.html
+++ b/html-src/rules/scotchpatience.html
@@ -1,18 +1,15 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Scotch Patience</h1>
-<p>Fan game type. 1 deck. No redeal.</p>
+<p>
+Fan game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations <b>build up by alternate color</b>.</p>
-<p>The 18 piles build down by rank ignoring suit. Only one card can
-be moved at a time, and empty piles cannot be filled.</p>
-</body>
-</html>
+<p>
+The foundations <b>build up by alternate color</b>.
+<p>
+The 18 piles build down by rank ignoring suit.
+Only one card can be moved at a time, and
+empty piles cannot be filled.

--- a/html-src/rules/seahaventowers.html
+++ b/html-src/rules/seahaventowers.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Seahaven Towers</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="kingonlybakersgame.html">King Only Baker's
-Game</a>, but with 10 piles.</p>
+<p>
+Just like <a href="kingonlybakersgame.html">King Only Baker's Game</a>,
+but with 10 piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/serpent.html
+++ b/html-src/rules/serpent.html
@@ -1,23 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Serpent</h1>
-<p>FreeCell type. Two Tarock Decks. No redeal.</p>
+<p>
+FreeCell type.  Two Tarock Decks.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, using two 78 card Tarock
-decks and the number of cards you can move as a sequence is not
-restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+using two 78 card Tarock decks and the number of cards you can move as a
+sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-King or Skiz starting a new pile. Rows build down in rank by
-alternate color. The trumps will play as any color. Empty rows
-cannot be filled. The eight free cells will hold one card each.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each King or Skiz
+starting a new pile.  Rows build down in rank by alternate color.  The
+trumps will play as any color.  Empty rows cannot be filled.  The eight
+free cells will hold one card each.

--- a/html-src/rules/sevenbyfive.html
+++ b/html-src/rules/sevenbyfive.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Seven by Five</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="freecell.html">FreeCell</a>, but with only three
-free cells and seven playing piles.</p>
+<p>
+Like <a href="freecell.html">FreeCell</a>,
+but with only three free cells and seven playing piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/sevenbyfour.html
+++ b/html-src/rules/sevenbyfour.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Seven by Four</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="freecell.html">FreeCell</a>, but with seven
-playing piles.</p>
+<p>
+Like <a href="freecell.html">FreeCell</a>,
+but with seven playing piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/shamrocks.html
+++ b/html-src/rules/shamrocks.html
@@ -1,20 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Shamrocks</h1>
-<p>Fan game type. 1 deck. No redeal.</p>
+<p>
+Fan game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The 18 piles build up or down regardless of suit. Each pile can
-hold no more than three cards. Only one card can be moved at a
-time. Empty piles are not filled.</p>
+<p>
+The 18 piles build up or down regardless of suit.
+Each pile can hold no more than three cards.
+Only one card can be moved at a time.
+Empty piles are not filled.
+
 <h3>Strategy</h3>
-<p>Build evenly on to foundations.</p>
-</body>
-</html>
+<p>
+Build evenly on to foundations.

--- a/html-src/rules/shamsher.html
+++ b/html-src/rules/shamsher.html
@@ -1,26 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Shamsher</h1>
 Mughal Ganjifa type. One deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-The cards on the tableau build down by rank regardless of suit, no
-more than twelve to a row. Any card or movable pile may be played
-on an empty row.
+The cards on the tableau build down by rank regardless of suit, no more than
+twelve to a row.  Any card or movable pile may be played on an empty row.
+
 <h3>Rules</h3>
-All cards are dealt to the fourteen rows when the games begins.
-Cards on the tableau build down in descending rank order. The
-foundations build up by suit. Any card or movable pile may be
-played on an empty row.
+All cards are dealt to the fourteen rows when the games begins.  Cards
+on the tableau build down in descending rank order.  The foundations
+build up by suit.  Any card or movable pile may be played on an empty row.
+
 <h3>Strategy</h3>
-The first priority is to empty a row. Then don't fill it unless it
-or another row can be emptied by doing so.
-</body>
-</html>
+The first priority is to empty a row.  Then don't fill it
+unless it or another row can be emptied by doing so.

--- a/html-src/rules/shanka.html
+++ b/html-src/rules/shanka.html
@@ -1,24 +1,15 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Shanka</h1>
 Dashavatara Ganjifa type. One deck. No redeal.
 <h3>Object</h3>
 Move all cards to the foundations.
 <h3>Quick description</h3>
-The cards build down by rank only on the tableau, no more than
-twelve to a row. Only the Rajas may be played on an empty row.
+The cards build down by rank only on the tableau, no more
+than twelve to a row.  Only the Rajas may be played on an empty row.
 <h3>Rules</h3>
-All cards are dealt to the sixteen rows when the games begins.
-Cards on the tableau build down in rank only. The foundations build
-up by suit. Only a Raja or sequence may be played on an empty row.
-<p>Shanka is the conch incarnation of Vishnu.</p>
+All cards are dealt to the sixteen rows when the games begins.  Cards
+on the tableau build down in rank only.  The foundations build up by suit.
+Only a Raja or sequence may be played on an empty row.
+<p>
+Shanka is the conch incarnation of Vishnu.
 <h3>Strategy</h3>
 Try for an empty row.
-</body>
-</html>

--- a/html-src/rules/shisensho.html
+++ b/html-src/rules/shisensho.html
@@ -1,30 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Shisen-Sho</h1>
-<p>Shisen-Sho is a single-player-game similar to Mahjongg and uses
-the same set of tiles as Mahjongg.</p>
+<p>
+Shisen-Sho is a single-player-game similar to Mahjongg and uses the same
+set of tiles as Mahjongg.
+
 <h3>Object</h3>
-<p>The object of the game is to remove all tiles from the
-field.</p>
+<p>
+The object of the game is to remove all tiles from the field.
+
 <h3>Rules</h3>
-<p>The aim of the game is to remove all tiles from the board. Only
-two matching tiles can be removed at a time. Two tiles can only be
-removed if they can be connected with a maximum of three connected
-lines. Lines can be horizontal or vertical, but not diagonal.</p>
-<p>You don't have to draw the lines by yourself, the game does this
-for you. Just mark two matching tiles on the board, if they can be
-connected with a maximum of three lines, the lines will be drawn
-and the tiles are removed.</p>
-<p>Remember that lines only may cross the empty border. If you are
-stuck, you can use the Hint feature to find two tiles which may be
-removed. Clicking a tile with the right mouse button will show you
-all corresponding tiles, no matter if they are removable at the
-moment or not.</p>
-</body>
-</html>
+<p>
+The aim of the game is to remove all tiles from the board. Only two
+matching tiles can be removed at a time. Two tiles can only be removed if they
+can be connected with a maximum of three connected lines. Lines can be
+horizontal or vertical, but not diagonal.
+<p>
+You don't have to draw the lines by yourself, the game does this for
+you. Just mark two matching tiles on the board, if they can be connected with a
+maximum of three lines, the lines will be drawn and the tiles are
+removed.
+<p>
+Remember that lines only may cross the empty border. If you are stuck, you
+can use the Hint feature to find two tiles which may be removed. Clicking a
+tile with the right mouse button will show you all corresponding tiles, no
+matter if they are removable at the moment or not.

--- a/html-src/rules/siebenbisas.html
+++ b/html-src/rules/siebenbisas.html
@@ -1,32 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Sieben bis As</h1>
-<p>Montana type. 1 stripped deck. No redeal.</p>
+<p>
+Montana type. 1 stripped deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>This game is played with one stripped deck.</p>
-<p>This 32-card solitaire starts with the entire deck shuffled and
-dealt out in three rows and two extra reserves at the top. All
-Sevens from the rows are then dealt to the foundations thereby
-making initial free spaces.</p>
-<p>You may move to a space only the card that matches the neighbor
-in suit, and is one greater in rank than the left neighbour or one
-less in rank than the right neighbour. Aces are high, so no cards
-may be placed to their right (they create dead spaces).</p>
-<p>The foundations build up from Seven to King and then Ace. You
-may only move a card from the rows (and not from the reserves) to
+<p>
+This game is played with one stripped deck.
+<p>
+This 32-card solitaire starts with the entire deck shuffled and dealt
+out in three rows and two extra reserves at the top.
+All Sevens from the rows are then dealt to the foundations thereby
+making initial free spaces.
+<p>
+You may move to a space only the card that
+matches the neighbor in suit, and is one greater in rank than the left
+neighbour or one less in rank than the right neighbour. Aces are
+high, so no cards may be placed to their right (they create dead spaces).
+<p>
+The foundations build up from Seven to King and then Ace.
+You may only move a card from the rows (and not from the reserves) to
 the foundations if it has an empty left neightbour - this implies
-that you cannot drop a card from the leftmost column without moving
-it somewhere else first.</p>
+that you cannot drop a card from the leftmost column without
+moving it somewhere else first.
+
 <h3>Strategy</h3>
-<p>Don't drop cards to early - you should turn off <i>Autodrop</i>
-for this game.</p>
-</body>
-</html>
+<p>
+Don't drop cards to early - you should turn off <i>Autodrop</i> for this game.

--- a/html-src/rules/simplecarlo.html
+++ b/html-src/rules/simplecarlo.html
@@ -1,26 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Simple Carlo</h1>
-<p>Pairing game type. 1 deck. No redeal.</p>
+<p>
+Pairing game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Discard all pairs of cards of the same rank.</p>
+<p>
+Discard all pairs of cards of the same rank.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="montecarlo.html">Monte Carlo</a>, but
-<i>all</i> pairs of the same rank may be discarded.<br />
-Extremely easy.</p>
+<p>
+Just like <a href="montecarlo.html">Monte Carlo</a>,
+but <i>all</i> pairs of the same rank may be discarded.
+<br>Extremely easy.
+
 <h3>Rules</h3>
-<p>The object is to use up all the cards from the tableau by
-discarding pairs of cards of the same rank.</p>
-<p>Empty spaces are filled automatically by shifting cards up and
-dealing from the talon to the bottom piles.</p>
-<p>You win when the tableau piles are all gone.</p>
+<p>
+The object is to use up all the cards from the tableau by
+discarding pairs of cards of the same rank.
+<p>
+Empty spaces are filled automatically by shifting cards up and
+dealing from the talon to the bottom piles.
+<p>
+You win when the tableau piles are all gone.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/simplepairs.html
+++ b/html-src/rules/simplepairs.html
@@ -1,20 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Simple Pairs</h1>
-<p>Pairing game type. 1 deck. No redeal.</p>
+<p>
+Pairing game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Discard all pairs of cards of the same rank.</p>
+<p>
+Discard all pairs of cards of the same rank.
+
 <h3>Rules</h3>
-<p>The object is to use up all the cards from the tableau by
-discarding pairs of cards of the same rank.</p>
-<p>You win when the tableau piles are all gone.</p>
+<p>
+The object is to use up all the cards from the tableau by
+discarding pairs of cards of the same rank.
+<p>
+You win when the tableau piles are all gone.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/simplesimon.html
+++ b/html-src/rules/simplesimon.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Simple Simon</h1>
-<p>Spider type. 1 deck. No redeal.</p>
+<p>
+Spider type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="spiderette.html">Spiderette</a>, but all
-cards are dealt at the beginning to the 10 piles.</p>
+<p>
+Just like <a href="spiderette.html">Spiderette</a>,
+but all cards are dealt at the beginning to the 10 piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/singlerail.html
+++ b/html-src/rules/singlerail.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Single Rail</h1>
-<p>Forty Thieves type. 1 deck. No redeal.</p>
+<p>
+Forty Thieves type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="doublerail.html">Double Rail</a>, but with
-one deck and 4 piles.</p>
+<p>
+Just like <a href="doublerail.html">Double Rail</a>,
+but with one deck and 4 piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/sixsages.html
+++ b/html-src/rules/sixsages.html
@@ -1,18 +1,11 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Six Sages</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Rules</h3>
-Play is identical to <a href="japanesegarden.html">Japanese
-Garden</a> except there are six row stacks that will each hold up
-to nine cards and a reserve stack that will hold one card.
-</body>
-</html>
+Play is identical to
+<a href="japanesegarden.html">Japanese Garden</a>
+except there are six row stacks that will each hold up to nine
+cards and a reserve stack that will hold one card.

--- a/html-src/rules/sixtengus.html
+++ b/html-src/rules/sixtengus.html
@@ -1,23 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Six Tengus</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Rules</h3>
-Play is identical to <a href="japanesegarden.html">Japanese
-Garden</a> except there are six row stacks that will each hold up
-to nine cards. Two cards may be moved at a time if they are in rank
-order.
+Play is identical to
+<a href="japanesegarden.html">Japanese Garden</a>
+except there are six row stacks that will each hold up to nine cards.
+Two cards may be moved at a time if they are in rank order.
+
 <h3>Notes</h3>
-The Tengu is a mythical Japanese character of exceptional fighting
-skill. You will need great skill (and more than a little luck)
-yourself to over come six of them.
-</body>
-</html>
+The Tengu is a mythical Japanese character of exceptional fighting skill.
+You will need great skill (and more than a little luck) yourself to over
+come six of them.

--- a/html-src/rules/skiz.html
+++ b/html-src/rules/skiz.html
@@ -1,27 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Skiz</h1>
-<p>Tarock type. 1 deck. No redeal.</p>
+<p>
+Tarock type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>This is a Freecell type of game. Cards on the tableau build down
-in rank by suit. Cards build up in rank on the foundations. A stack
-can be moved if the cards are in decending rank order regardless of
-the suit. Only a King or the highest trump can be played on an
-empty row.</p>
+<p>
+This is a Freecell type of game.  Cards on the tableau build down in rank
+by suit.  Cards build up in rank on the foundations.
+A stack can be moved if the cards are in decending rank order
+regardless of the suit.  Only a King or the highest trump can be played
+on an empty row.
+
 <h3>Strategy</h3>
-<p>The foundations are less important early in the game than
-building movable stacks. Use the reserve stacks carefully.</p>
+<p>
+The foundations are less important early in the game than
+building movable stacks.  Use the reserve stacks carefully.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/smallharp.html
+++ b/html-src/rules/smallharp.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Small Harp (Die kleine Harfe)</h1>
-<p>Klondike type. 1 deck. Unlimited redeals.</p>
+<p>
+Klondike type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="klondike.html">Klondike</a>, only with a
-different layout.</p>
+<p>
+Just like <a href="klondike.html">Klondike</a>,
+only with a different layout.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>History</h3>
-<p><i>Small Harp</i> and <i>Big Harp</i> are the German ways of
-playing <i>Klondike</i> and <i>Double Klondike</i>.</p>
-</body>
-</html>
+<p>
+<i>Small Harp</i> and <i>Big Harp</i> are the German ways of playing
+<i>Klondike</i> and <i>Double Klondike</i>.

--- a/html-src/rules/snake.html
+++ b/html-src/rules/snake.html
@@ -1,31 +1,30 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Snake (Die Schlange)</h1>
-<p>FreeCell type. 2 decks. No redeal.</p>
+<p>
+FreeCell type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="freecell.html">FreeCell</a>, but with 2 decks, and
-empty rows are not filled.</p>
+<p>
+Like <a href="freecell.html">FreeCell</a>,
+but with 2 decks, and empty rows are not filled.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-King starting a new pile. To compensate for this there are 7 free
-cells which can hold any - and just one - card.</p>
-<p>Piles build down by alternate color, and an empty space cannot
-be filled.</p>
-<p>The number of cards you can move as a sequence is restricted by
+<p>
+All cards are dealt to 9 piles at the start of the game, each King
+starting a new pile.
+To compensate for this there are 7 free cells which can hold any
+- and just one - card.
+<p>
+Piles build down by alternate color, and an empty space cannot be filled.
+<p>
+The number of cards you can move as a sequence is restricted by
 the number of free cells - the number of free cells required is the
-same as if you would make an equivalent sequence of moves with
-single cards.</p>
+same as if you would make an equivalent sequence of moves with single cards.
+
 <h3>History</h3>
-<p>This is a <a href="freecell.html">FreeCell type game</a> of
-German origin. It is related to <a href="catstail.html">Cat's
-Tail</a>.</p>
-</body>
-</html>
+<p>
+This is a <a href="freecell.html">FreeCell type game</a> of German origin.
+It is related to <a href="catstail.html">Cat's Tail</a>.

--- a/html-src/rules/snakestone.html
+++ b/html-src/rules/snakestone.html
@@ -1,23 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Snakestone</h1>
-<p>FreeCell type. Two Hex A Decks. No redeal.</p>
+<p>
+FreeCell type.  Two Hex A Decks.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, with the Hex A Deck
-Variations and the number of cards you can move as a sequence is
-not restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+with the Hex A Deck Variations and the number of cards you can move as a
+sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-King or "Ten" (hexadecimal) starting a new pile. Rows build down in
-rank and suit. The Wizards will play as any color. Empty rows
-cannot be filled.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each King or "Ten"
+(hexadecimal) starting a new pile.  Rows build down in rank and suit.
+The Wizards will play as any color.  Empty rows cannot be filled.

--- a/html-src/rules/spaces.html
+++ b/html-src/rules/spaces.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Spaces</h1>
-<p>Montana type. 1 deck. 2 redeals.</p>
+<p>
+Montana type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 12 cards in acscending sequence
-by suit from Two to King.</p>
+<p>
+Group all the cards in sets of 12 cards in acscending sequence
+by suit from Two to King.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="montana.html">Montana</a>, but with random
-spaces after each redeal.</p>
+<p>
+Just like <a href="montana.html">Montana</a>,
+but with random spaces after each redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/spanishpatience.html
+++ b/html-src/rules/spanishpatience.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Spanish Patience</h1>
-<p>Baker's Dozen type. 1 deck. No redeal.</p>
+<p>
+Baker's Dozen type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="bakersdozen.html">Baker's Dozen</a>, but the
-<em>Foundations</em> build up in alternate color.</p>
+<p>
+Like <a href="bakersdozen.html">Baker's Dozen</a>,
+but the <em>Foundations</em> build up in alternate color.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/spider.html
+++ b/html-src/rules/spider.html
@@ -1,29 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Spider</h1>
-<p>Spider type. 2 decks. No redeal.</p>
+<p>
+Spider type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Rules</h3>
-<p>54 cards are dealt in 10 piles. Cards are built down, regardless
-of suit. However, sequences that are all of the same suit are
-preferred because these are available for further movement. A space
-can be filled by any card or legal group of cards.</p>
-<p>The object is to group the cards in sets of 13 cards, from King
-to Ace of the same suit. Such groups can be moved to the
-foundations.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles.</p>
-<p>You only may deal new cards if there are no empty spaces.</p>
+<p>
+54 cards are dealt in 10 piles. Cards are built down, regardless of suit.
+However, sequences that are all of the same suit are preferred because
+these are available for further movement.
+A space can be filled by any card or legal group of cards.
+<p>
+The object is to group the cards in sets of 13 cards, from King to Ace
+of the same suit. Such groups can be moved to the foundations.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each of the playing piles.
+<p>
+You only may deal new cards if there are no empty spaces.
+
 <h3>History</h3>
-<p>Spider is one of the classic solitaire card games. It offers a
-lot of decisions, so choose a good strategy.</p>
-</body>
-</html>
+<p>
+Spider is one of the classic solitaire card games.
+It offers a lot of decisions, so choose a good strategy.

--- a/html-src/rules/spiderette.html
+++ b/html-src/rules/spiderette.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Spiderette</h1>
-<p>Spider type. 1 deck. No redeal.</p>
+<p>
+Spider type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="spider.html">Spider</a>, but with one deck and 7
-piles. Very hard.</p>
+<p>
+Like <a href="spider.html">Spider</a>,
+but with one deck and 7 piles. Very hard.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/stalactites.html
+++ b/html-src/rules/stalactites.html
@@ -1,21 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Stalactites</h1>
-<p>FreeCell type. 1 deck. No redeal.</p>
+<p>
+FreeCell type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations build up by rank ignoring color and suit,
-wrapping around from King to Ace. The base rank is determined at
-initial dealing.</p>
-<p>There is no building on the tableau piles, and spaces are not
-filled. Only the top card can be moved.</p>
-<p>The two free cells can hold any - and just one - card.</p>
-</body>
-</html>
+<p>
+The foundations build up by rank ignoring color and suit, wrapping
+around from King to Ace.
+The base rank is determined at initial dealing.
+<p>
+There is no building on the tableau piles, and spaces
+are not filled.
+Only the top card can be moved.
+<p>
+The two free cells can hold any - and just one - card.

--- a/html-src/rules/steps.html
+++ b/html-src/rules/steps.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Steps</h1>
-<p>Klondike type. 2 decks. One redeal.</p>
+<p>
+Klondike type. 2 decks. One redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="doubleklondike.html">Double Klondike</a>, but
-seven piles, anything on an empty space, and one redeal.<br />
-Much like <a href="bigharp.html">Big Harp</a>.</p>
+<p>
+Like <a href="doubleklondike.html">Double Klondike</a>,
+but seven piles, anything on an empty space, and one redeal.
+<br>Much like <a href="bigharp.html">Big Harp</a>.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/storehouse.html
+++ b/html-src/rules/storehouse.html
@@ -1,22 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Storehouse</h1>
-<p>Canfield type. 1 deck. 2 redeals.</p>
+<p>
+Canfield type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="canfield.html">Canfield</a>, but the piles build
-down by suit, cards are dealt singly, and two redeals.</p>
+<p>
+Like <a href="canfield.html">Canfield</a>,
+but the piles build down by suit,
+cards are dealt singly, and two redeals.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>History</h3>
-<p>This game is also known under names such as <i>Straight
-Up</i>.</p>
-</body>
-</html>
+<p>
+This game is also known under names such as
+<i>Straight Up</i>.

--- a/html-src/rules/strategy.html
+++ b/html-src/rules/strategy.html
@@ -1,22 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Strategy</h1>
-<p>Numerica type. 1 deck. No redeal.</p>
+<p>
+Numerica type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>One card is flipped over at a time and moved onto the row
-stacks. There are no restrictions on which card may go where on the
-stacks. Once on a stack, a card can only be moved onto a
-foundation.</p>
-<p>The foundations build up in suit from Ace to King. You can only
-move cards to the foundations once all cards have been placed on
-the row stacks and the talon is empty.</p>
-</body>
-</html>
+<p>
+One card is flipped over at a time and moved onto the row stacks. There are no
+restrictions on which card may go where on the stacks. Once on a stack,
+a card can only be moved onto a foundation.
+<p>
+The foundations build up in suit from Ace to King. You can only move
+cards to the foundations once all cards have been placed on the
+row stacks and the talon is empty.

--- a/html-src/rules/streets.html
+++ b/html-src/rules/streets.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Streets</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the
-piles build down by alternate color.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the piles build down by alternate color.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/streetsandalleys.html
+++ b/html-src/rules/streetsandalleys.html
@@ -1,20 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Streets and Alleys</h1>
-<p>Beleaguered Castle type. 1 deck. No redeal.</p>
+<p>
+Beleaguered Castle type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="beleagueredcastle.html">Beleaguered
-Castle</a>, but the Aces are not dealt to the foundations at game
-start.</p>
+<p>
+Just like <a href="beleagueredcastle.html">Beleaguered Castle</a>,
+but the Aces are not dealt to the foundations at game start.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/stronghold.html
+++ b/html-src/rules/stronghold.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Stronghold</h1>
-<p>Beleaguered Castle type. 1 deck. No redeal.</p>
+<p>
+Beleaguered Castle type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="streetsandalleys.html">Streets and Alleys</a>, but
-with one free cell.</p>
+<p>
+Like <a href="streetsandalleys.html">Streets and Alleys</a>,
+but with one free cell.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/sumo.html
+++ b/html-src/rules/sumo.html
@@ -1,29 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Sumo</h1>
 Hanafuda type. 1 deck. No redeal.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="freecell.html">Free Cell</a>. Cards
-build from first to fourth rank on the tableau by suit and from
-fourth to first on the foundations. Only first rank cards may be
-played on an empty row.
-<h3>Rules</h3>
-Cards build down in rank on the rows and up in rank on the
-foundations. Third and fourth rank (trash) cards are not
-interchangeable. Only a first rank card or correctly ordered pile
+Play is similar to
+<a href="freecell.html">Free Cell</a>.
+Cards build from first to fourth rank on the tableau by suit and
+from fourth to first on the foundations.  Only first rank cards
 may be played on an empty row.
+
+<h3>Rules</h3>
+Cards build down in rank on the rows and up in rank on the foundations.
+Third and fourth rank (trash) cards are not interchangeable.  Only a first
+rank card or correctly ordered pile may be played on an empty row.
+
 <h3>Strategy</h3>
 Don't play cards on the reserves unless they can be removed.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/superflowergarden.html
+++ b/html-src/rules/superflowergarden.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Super Flower Garden</h1>
-<p>Fan game type. 1 deck. 2 redeals.</p>
+<p>
+Fan game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="labellelucie.html">La Belle Lucie</a>, but
-the piles build down by rank.</p>
+<p>
+Just like <a href="labellelucie.html">La Belle Lucie</a>,
+but the piles build down by rank.
+
 <h3>Rules</h3>
-<p>The 18 piles build down by rank. Only one card can be moved at a
-time. Empty piles are not filled.</p>
-<p>When no more moves are possible, click on the talon. All cards
-on the tableau will be re-shuffled.</p>
-</body>
-</html>
+<p>
+The 18 piles build down by rank.
+Only one card can be moved at a time.
+Empty piles are not filled.
+<p>
+When no more moves are possible, click on the talon.
+All cards on the tableau will be re-shuffled.

--- a/html-src/rules/superiorcanfield.html
+++ b/html-src/rules/superiorcanfield.html
@@ -1,19 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Superior Canfield</h1>
-<p>Canfield type. 1 deck. Unlimited redeals.</p>
+<p>
+Canfield type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="canfield.html">Canfield</a>, but the reserve is
-dealt face-up, and empty rows are not automatically filled.</p>
+<p>
+Like <a href="canfield.html">Canfield</a>,
+but the reserve is dealt face-up, and
+empty rows are not automatically filled.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/supersamuri.html
+++ b/html-src/rules/supersamuri.html
@@ -1,21 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Super Samuri</h1>
-<p>Hanafuda type. 4 decks. No redeal.</p>
+<p>
+Hanafuda type. 4 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-This is <a href="samuri.html">Samuri</a> played with four decks.
+This is
+<a href="samuri.html">Samuri</a>
+played with four decks.
+
 <h3>Strategy</h3>
 Try not to let the waste stack get too deep.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/surukh.html
+++ b/html-src/rules/surukh.html
@@ -1,28 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Surukh</h1>
 Dashavatara Ganjifa type. One deck. No redeal.
 <h3>Object</h3>
 Move all cards to the foundations.
 <h3>Quick description</h3>
-The cards build down by rank in alternating force on the tableau,
-no more than twelve to a row. Only the Rajas may be played on an
-empty row.
+The cards build down by rank in alternating force on the tableau, no more
+than twelve to a row.  Only the Rajas may be played on an empty row.
 <h3>Rules</h3>
-All cards are dealt to the sixteen rows when the games begins.
-Cards on the tableau build down in rank in alternating force. See
-the general <a href="../ganjifa.html">Ganjifa</a> rules for more
-information. The easy way to remember the force of a suit is that
-the foundations to the left are one force and the foundations to
-the right are the other. The foundations build up by suit. Any card
-or sequence may be played on an empty row.
+All cards are dealt to the sixteen rows when the games begins.  Cards
+on the tableau build down in rank in alternating force.  See the general
+<a href="../ganjifa.html">Ganjifa</a>
+rules for more information.  The easy way to remember the force of a suit
+is that the foundations to the left are one force and the foundations to the
+right are the other.  The foundations build up by suit.  Any card or sequence
+may be played on an empty row.
 <h3>Strategy</h3>
 Try for an empty row.
-</body>
-</html>

--- a/html-src/rules/tabbycat.html
+++ b/html-src/rules/tabbycat.html
@@ -1,23 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Tabby Cat</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundation.</p>
+<p>
+Move all cards to the foundation.
+
 <h3>Rules</h3>
-<p>Foundations are built up from Ace to King, regardless of suit.
-One must move an entire Ace-to-King sequence to a foundation as one
-move.</p>
-<p>The playing piles build down by rank, regardless of suit. A king
-may be played on an ace.. An empty pile can receive any card, or
-sequence.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles.</p>
-</body>
-</html>
+<p>
+Foundations are built up from Ace to King, regardless of suit. One
+must move an entire Ace-to-King sequence to a foundation as one move.
+<p>
+The playing piles build down by rank, regardless of suit. A king may
+be played on an ace.. An empty pile can receive any card, or
+sequence.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each of the playing piles.

--- a/html-src/rules/tamoshanter.html
+++ b/html-src/rules/tamoshanter.html
@@ -1,25 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Tam O'Shanter</h1>
-<p>Numerica type. 1 deck. No redeal.</p>
+<p>
+Numerica type. 1 deck. No redeal.
+
 <h3>Quick Description</h3>
-<p>Like <a href="auldlangsyne.html">Auld Lang Syne</a>, but do not
-deal the Aces at game start.</p>
+<p>
+Like <a href="auldlangsyne.html">Auld Lang Syne</a>,
+but do not deal the Aces at game start.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The foundations build up by rank ignoring suit.</p>
-<p>There is no building on the tableau piles - cards can only be
-moved to the foundations, and spaces are not filled.</p>
-<p>When no more moves are possible, click on the talon. One card
-will be added to each of the playing piles.</p>
+<p>
+The foundations build up by rank ignoring suit.
+<p>
+There is no building on the tableau piles - cards can only be
+moved to the foundations, and spaces are not filled.
+<p>
+When no more moves are possible, click on the talon. One card will be
+added to each of the playing piles.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/tenavatars.html
+++ b/html-src/rules/tenavatars.html
@@ -1,28 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Ten Avatars</h1>
 Dashavatara Ganjifa type. One deck. No redeal.
 <h3>Object</h3>
 Arrange all cards in suit and rank order on the tableau.
 <h3>Quick description</h3>
-The cards may be built down by rank only on the tableau. The twelve
-reserve stacks hold one card each. The game is won when all cards
-are on the tableau in suit and rank order.
+The cards may be built down by rank only on the tableau.  The twelve
+reserve stacks hold one card each.  The game is won when all cards are
+on the tableau in suit and rank order.
 <h3>Rules</h3>
-The game begins with five cards on each of the ten rows and the
-twelve reserve stacks empty. Cards are dealt from the talon ten at
-a time, one to each row. Rows can be built with cards of any suit
-in descending rank. Only Rajas can be played on an empty row. All
-ten suits must be in descending rank order for the game to be won.
+The game begins with five cards on each of the ten rows and the twelve
+reserve stacks empty.  Cards are dealt from the talon ten at a time, one
+to each row.  Rows can be built with cards of any suit in descending rank.
+Only Rajas can be played on an empty row.  All ten suits must be in
+descending rank order for the game to be won.
 <h3>Strategy</h3>
-Make as many plays as possible without filling too many reserves
-before taking another deal. Put a priority on getting the Rajas and
-Pradhans in place.
-</body>
-</html>
+Make as many plays as possible without filling too many reserves before taking
+another deal.  Put a priority on getting the Rajas and Pradhans in place.

--- a/html-src/rules/terrace.html
+++ b/html-src/rules/terrace.html
@@ -1,16 +1,11 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Terrace</h1>
-<p>Terrace type. 2 decks. No redeal.</p>
+<p>
+Terrace type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/thefamiliar.html
+++ b/html-src/rules/thefamiliar.html
@@ -1,31 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>The Familiar</h1>
 Klondike type. One deck. One redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-Similar to <a href="klondike.html">Klondike</a> with <a href=
-"../hexadeck.html">Hex A Deck</a> variations.
+Similar to <a href="klondike.html">Klondike</a>
+with <a href="../hexadeck.html">Hex A Deck</a>
+variations.
+
 <h3>Rules</h3>
-Game play is like Klondike. The rows build down in rank in
-alternate color. The color of the Wizards is the alternate of
-either red or black. Only the Tens (top rank cards) may be played
-on an empty row. There is one reserve stack that will hold up to
-three Wizards. No suit cards can be played there. The Wizards will
-also play in their proper rank position on the tableau. They play
-as the alternate of either red or black. Cards are dealt from the
-talon one at a time. Cards may be played from the foundations.
+Game play is like Klondike.  The rows build down in rank in alternate
+color.  The color of the Wizards is the alternate of either red or black.
+Only the Tens (top rank cards) may be played on an empty row.  There is
+one reserve stack that will hold up to three Wizards.  No suit cards can
+be played there.  The Wizards will also play in their proper rank position
+on the tableau.  They play as the alternate of either red or black.  Cards
+are dealt from the talon one at a time.  Cards may be played from the
+foundations.
+
 <h3>Strategy</h3>
-Use caution when playing the Wizards on the reserve stack. If you
-play a lower rank Wizard on top of a higher rank one, you will have
-to move it off before the high rank one will play to the
-foundation.
-</body>
-</html>
+Use caution when playing the Wizards on the reserve stack.  If you play a
+lower rank Wizard on top of a higher rank one, you will have to move it off
+before the high rank one will play to the foundation.

--- a/html-src/rules/thelastmonarch.html
+++ b/html-src/rules/thelastmonarch.html
@@ -1,23 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>The last Monarch (Der letzte Monarch)</h1>
-<p>One-Deck game type. 1 deck. No redeal.</p>
+<p>
+One-Deck game type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move 51 cards (all cards except the last King) to the
-foundations.</p>
+<p>
+Move 51 cards (all cards except the last King) to the foundations.
+
 <h3>Rules</h3>
-<p>Cards on the tableau must be captured by one of their left,
-right, top or bottom neighbour. The captured card is then moved to
-the foundations or Reserves, and the capturing card moves into
-place.</p>
-<p>Cards from the reserve can only be moved to the foundations.</p>
+<p>
+Cards on the tableau must be captured by one of their left, right, top or
+bottom neighbour. The captured card is then moved to the foundations or
+Reserves, and the capturing card moves into place.
+<p>
+Cards from the reserve can only be moved to the foundations.
+
 <h3>Notes</h3>
-<p><i>Quickplay</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Quickplay</i> is disabled for this game.

--- a/html-src/rules/threepeaks.html
+++ b/html-src/rules/threepeaks.html
@@ -1,45 +1,36 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Three Peaks</h1>
 Pairing type game. 1 deck. No redeal.
+
 <h3>Object</h3>
 Remove all cards from the tableau.
+
 <h3>Rules</h3>
 The object is to remove all the cards from the tableau by playing
-them to the waste stack. Cards from the tableau will play to the
+them to the waste stack.  Cards from the tableau will play to the
 waste if they are one rank higher or lower than the card at the top
-of the waste. A King will play on an Ace and vice versa. Cards are
-played to the waste by clicking on them. Points are made as
-follows:
+of the waste.  A King will play on an Ace and vice versa.  Cards are
+played to the waste by clicking on them.  Points are made as follows:
+
 <dl>
-<dd>When a hand is dealt 52 points are subtracted from the
-score.</dd>
-<dd>For each of the first four cards played from the tableau in a
-sequence one point is added.</dd>
-<dd>For each of the second four cards played from the tableau in a
-sequence two points are added.</dd>
-<dd>Then four points for the next four cards, eight for the next
-four, then sixteen etc.</dd>
-<dd>If one peak is empty the points added are doubled.</dd>
-<dd>If two peaks are empty the points added are quadrupled.</dd>
-<dd></dd>
-<dd>Ten points are added for emptying the first peak.</dd>
-<dd>Twenty points are added for the second peak.</dd>
-<dd>Forty points are added for emptying the last peak.</dd>
-<dd></dd>
-<dd>When all the cards are removed from the tableau ten points are
-added for each card remaining in the talon.</dd>
-<dd></dd>
-<dd>The highest possible score for a single hand is 2336
-points.</dd>
+    <dd>When a hand is dealt 52 points are subtracted from the score.
+    <dd>For each of the first four cards played from the tableau in a
+	sequence one point is added.
+    <dd>For each of the second four cards played from the tableau in a
+	sequence two points are added.
+    <dd>Then four points for the next four cards, eight for the next four,
+	then sixteen etc.
+    <dd>If one peak is empty the points added are doubled.
+    <dd>If two peaks are empty the points added are quadrupled.
+    <dd><p>
+    <dd>Ten points are added for emptying the first peak.
+    <dd>Twenty points are added for the second peak.
+    <dd>Forty points are added for emptying the last peak.
+    <dd><p>
+    <dd>When all the cards are removed from the tableau ten points are
+	added for each card remaining in the talon.
+    <dd><p>
+    <dd>The highest possible score for a single hand is 2336 points.
 </dl>
+
 <h3>Notes</h3>
 Undo is disabled in this game.
-</body>
-</html>

--- a/html-src/rules/threepeaksnonscoring.html
+++ b/html-src/rules/threepeaksnonscoring.html
@@ -1,17 +1,10 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Three Peaks Non-scoring</h1>
 Pairing type game. 1 deck. No redeal.
+
 <h3>Object</h3>
 Remove all cards from the tableau.
+
 <h3>Rules</h3>
-Play is identical to <a href="threepeaks.html">Three Peaks</a>
+Play is identical to
+<a href="threepeaks.html">Three Peaks</a>
 except no score is kept and plays can be undone.
-</body>
-</html>

--- a/html-src/rules/threeshufflesandadraw.html
+++ b/html-src/rules/threeshufflesandadraw.html
@@ -1,25 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Three Shuffles and a Draw</h1>
-<p>Fan game type. 1 deck. 2 redeals.</p>
+<p>
+Fan game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="labellelucie.html">La Belle Lucie</a>, but
-with an additional draw.</p>
+<p>
+Just like <a href="labellelucie.html">La Belle Lucie</a>,
+but with an additional draw.
+
 <h3>Rules</h3>
-<p>The 18 piles build down by suit. Only one card can be moved at a
-time. Empty piles are not filled.</p>
-<p>When no more moves are possible, click on the talon. All cards
-on the tableau will be re-shuffled.</p>
-<p>Once during the game, any one card below the top of a fan may be
-drawn out and used on foundations or fan builds. Do this by moving
-the top card of the fan to the Draw pile.</p>
-</body>
-</html>
+<p>
+The 18 piles build down by suit.
+Only one card can be moved at a time.
+Empty piles are not filled.
+<p>
+When no more moves are possible, click on the talon.
+All cards on the tableau will be re-shuffled.
+<p>
+Once during the game, any one card below the top of a fan may
+be drawn out and used on foundations or fan builds.
+Do this by moving the top card of the fan to the Draw pile.

--- a/html-src/rules/thumbandpouch.html
+++ b/html-src/rules/thumbandpouch.html
@@ -1,19 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Thumb and Pouch</h1>
-<p>Klondike type. 1 deck. No redeal.</p>
+<p>
+Klondike type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but piles build down
-by any suit but own, anything on an empty space, and no redeal.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but piles build down by any suit but own, anything on an empty space,
+and no redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/tipati.html
+++ b/html-src/rules/tipati.html
@@ -1,30 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Tipati</h1>
 Mughal Ganjifa type. One deck. No redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank regardless of suit.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank regardless of suit.
+
 <h3>Rules</h3>
-The cards on the tableau build down by rank. The foundations build
-up in rank by suit starting with the Ace. Only the Mirs (Kings) may
-be played on an empty row. Cards are dealt from the talon one at a
-time. There are no redeals. Cards may not be played from the
+The cards on the tableau build down by rank.  The foundations build
+up in rank by suit starting with the Ace.  Only the Mirs (Kings) may
+be played on an empty row.  Cards are dealt from the talon one at
+a time.  There are no redeals.  Cards may not be played from the
 foundations.
-<p>This game is one of a series of games that have names ending in
-"pati" which transliterates as "lord of". Tipati means "Lord
-(Highest/Queen) of Women". The names are the names of the suits in
-a twelve suit Ganjifa deck.</p>
+<p>
+This game is one of a series of games that have names ending in "pati"
+which transliterates as "lord of".  Tipati means "Lord (Highest/Queen) of
+Women".  The names are the names of the suits in a twelve suit Ganjifa deck.
+
 <h3>Strategy</h3>
 Move cards back and forth on the rows to make every play possible.
 Don't let the waste stack get too deep.
-</body>
-</html>

--- a/html-src/rules/towerofhanoy.html
+++ b/html-src/rules/towerofhanoy.html
@@ -1,21 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Tower of Hanoy</h1>
-<p>Puzzle game type. 9 cards. No redeal.</p>
+<p>
+Puzzle game type. 9 cards. No redeal.
+
 <h3>Object</h3>
-<p>Build a pile containing all 9 cards.</p>
+<p>
+Build a pile containing all 9 cards.
+
 <h3>Rules</h3>
-<p>A card may only be placed onto another card that is of higher
-rank.</p>
-<p>Only the top card may be moved, and spaces may be filled with
-any single card.</p>
+<p>
+A card may only be placed onto another card that is of higher rank.
+<p>
+Only the top card may be moved, and spaces may be filled
+with any single card.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/trefoil.html
+++ b/html-src/rules/trefoil.html
@@ -1,22 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Trefoil</h1>
-<p>Fan game type. 1 deck. 2 redeals.</p>
+<p>
+Fan game type. 1 deck. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="labellelucie.html">La Belle Lucie</a>, but 16
-piles, and the Aces are moved to the foundations at game start.</p>
+<p>
+Like <a href="labellelucie.html">La Belle Lucie</a>,
+but 16 piles, and the Aces are moved to the foundations at game start.
+
 <h3>Rules</h3>
-<p>The 16 piles build down by suit. Only one card can be moved at a
-time. Empty piles are not filled.</p>
-<p>When no more moves are possible, click on the talon. All cards
-on the tableau will be re-shuffled.</p>
-</body>
-</html>
+<p>
+The 16 piles build down by suit.
+Only one card can be moved at a time.
+Empty piles are not filled.
+<p>
+When no more moves are possible, click on the talon.
+All cards on the tableau will be re-shuffled.

--- a/html-src/rules/tripeaks.html
+++ b/html-src/rules/tripeaks.html
@@ -1,34 +1,39 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Tri Peaks</h1>
-<p>Golf type. 1 deck. No redeal.</p>
+<p>
+Golf type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the waste stack.</p>
+<p>
+Move all cards to the waste stack.
+
 <h3>Quick Description</h3>
-<p>Much like <a href="relaxedgolf.html">Relaxed Golf</a>, only with
-a <a href="pyramid.html">Pyramid</a> related layout.</p>
+<p>
+Much like <a href="relaxedgolf.html">Relaxed Golf</a>,
+only with a <a href="pyramid.html">Pyramid</a>
+related layout.
+
 <h3>Rules</h3>
-<p>Build singly on the waste stack up or down regardless of
-suit.</p>
-<p>Only the top card is available for play. When no more moves are
-possible, click on the talon to deal a new card.</p>
-<p>Sequences wrap around, i.e. Twos and Kings may be placed on Aces
-and Queens and Aces may be placed on Kings.</p>
+<p>
+Build singly on the waste stack up or down regardless of suit.
+<p>
+Only the top card is available for play. When no more moves are
+possible, click on the talon to deal a new card.
+<p>
+Sequences wrap around,
+i.e. Twos and Kings may be placed on Aces
+and Queens and Aces may be placed on Kings.
+
 <h3>Notes</h3>
-<p>There is a simple scoring system here - you debit $120 for each
-game ($5 for each of the 24 cards in the talon) and for every card
-you bear off, you get $1, $2, $3,... credit, depending on the
-length of your current streak.<br />
-Each cleared peak gains $15 bonus, and there's an additional $30 if
-you manage to clear all three peaks.<br />
-Your balance is reset whenever you select a different game. Loaded
-games and manually entered game numbers don't count.</p>
-<p><i>Autodrop</i> is disabled for this game.</p>
-</body>
-</html>
+<p>
+There is a simple scoring system here - you debit $120 for each game
+($5 for each of the 24 cards in the talon) and for every card you
+bear off, you get $1, $2, $3,... credit, depending on the length
+of your current streak.
+<br>
+Each cleared peak gains $15 bonus, and there's an
+additional $30 if you manage to clear all three peaks.
+<br>
+Your balance is reset whenever you select a different game.
+Loaded games and manually entered game numbers don't count.
+<p>
+<i>Autodrop</i> is disabled for this game.

--- a/html-src/rules/tripleklondike.html
+++ b/html-src/rules/tripleklondike.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Triple Klondike</h1>
-<p>Klondike type. 3 decks. Unlimited redeals.</p>
+<p>
+Klondike type. 3 decks. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but with three decks
-and 13 playing piles.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but with three decks and 13 playing piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/tripleklondikebythrees.html
+++ b/html-src/rules/tripleklondikebythrees.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Triple Klondike by Threes</h1>
-<p>Klondike type. 3 decks. Unlimited redeals.</p>
+<p>
+Klondike type. 3 decks. Unlimited redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="tripleklondike.html">Triple Klondike</a>, but deal
-three cards.</p>
+<p>
+Like <a href="tripleklondike.html">Triple Klondike</a>,
+but deal three cards.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/tripleline.html
+++ b/html-src/rules/tripleline.html
@@ -1,20 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Triple Line</h1>
-<p>Forty Thieves type. 2 decks. One redeal.</p>
+<p>
+Forty Thieves type. 2 decks. One redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the Foundations.</p>
+<p>
+Move all cards to the Foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the 12
-piles build down by alternate color, empty rows are automatically
-filled from the Waste or Talon, and sequences can be moved.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the 12 piles build down by alternate color,
+empty rows are automatically filled from the Waste or Talon,
+and sequences can be moved.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/twofamiliars.html
+++ b/html-src/rules/twofamiliars.html
@@ -1,31 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Two Familiars</h1>
 Klondike type. Two decks. One redeal.
+
 <h3>Object</h3>
 Move all cards to the Foundations.
+
 <h3>Quick description</h3>
-This is a two deck version of <a href="thefamiliar.html">The
-Familiar</a>.
+This is a two deck version of <a href="thefamiliar.html">The Familiar</a>.
+
 <h3>Rules</h3>
-Game play is like Klondike. The rows build down in rank in
-alternate color. The color of the Wizards is the alternate of
-either red or black. Only the Tens (top rank cards) may be played
-on an empty row. There is one reserve stack that will hold up to
-three Wizards. No suit cards can be played there. The Wizards will
-also play in their proper rank position on the tableau. They play
-as the alternate of either red or black. Cards are dealt from the
-talon one at a time. Cards may be played from the foundations.
+Game play is like Klondike.  The rows build down in rank in alternate
+color.  The color of the Wizards is the alternate of either red or black.
+Only the Tens (top rank cards) may be played on an empty row.  There is
+one reserve stack that will hold up to three Wizards.  No suit cards can
+be played there.  The Wizards will also play in their proper rank position
+on the tableau.  They play as the alternate of either red or black.  Cards
+are dealt from the talon one at a time.  Cards may be played from the
+foundations.
+
 <h3>Strategy</h3>
-Use caution when playing the Wizards on the reserve stack. If you
-play a lower rank Wizard on top of a higher rank one, you will have
-to move it off before the high rank one will play to the
-foundation.
-</body>
-</html>
+Use caution when playing the Wizards on the reserve stack.  If you play a
+lower rank Wizard on top of a higher rank one, you will have to move it off
+before the high rank one will play to the foundation.

--- a/html-src/rules/unionsquare.html
+++ b/html-src/rules/unionsquare.html
@@ -1,30 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Union Square</h1>
-<p>Two-Deck game type. 2 decks. No redeal.</p>
+<p>
+Two-Deck game type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards in tableau can be built either up or down in suit.
-However, each pile must follow only one of these rules. For
-example, if a tableau pile has a three of clubs over a two of
-clubs, one can only play a four of clubs on this pile. Any
-available card can be played on to an empty tableau pile.</p>
-<p>Foundation piles are to be built in suit from Ace to King,
-followed by another King, then back down to Ace, giving 26 cards
-per pile when game is won. Cards in foundation piles are no longer
-in play.</p>
-<p>Cards can be flipped singly from the talon to the waste. Top
-card of waste is available for play. There is no redeal.</p>
+<p>
+Cards in tableau can be built either up or down in suit. However, each pile must follow only one of
+these rules. For example, if a tableau pile has a three of clubs over a two of clubs, one can only
+play a four of clubs on this pile. Any available card can be played on to an empty tableau pile.
+<p>
+Foundation piles are to be built in suit from Ace to King, followed by another King, then back down
+to Ace, giving 26 cards per pile when game is won. Cards in foundation piles are no longer in play.
+<p>
+Cards can be flipped singly from the talon to the waste.
+Top card of waste is available for play.
+There is no redeal.
+
 <h3>Strategy</h3>
-<p>A string of beads can be added to from both ends, and so should
-your piles. Make good use of any empty slots to append cards. With
-a little perseverance, this game can be a lot of fun!</p>
-</body>
-</html>
+<p>
+A string of beads can be added to from both ends, and so should your piles.
+Make good use of any empty slots to append cards.
+With a little perseverance, this game can be a lot of fun!

--- a/html-src/rules/vajra.html
+++ b/html-src/rules/vajra.html
@@ -1,23 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Vajra</h1>
-<p>FreeCell type. One Moghul Ganjifa Deck. No redeal.</p>
+<p>
+FreeCell type.  One Moghul Ganjifa Deck.  No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, using the eight suit Moghul
-Ganjifa deck and the number of cards you can move as a sequence is
-not restricted.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+using the eight suit Moghul Ganjifa deck and the number of cards you can move
+as a sequence is not restricted.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-Raja or King starting a new pile. Rows build down in rank
-regardless of suit. Empty rows cannot be filled. The eight free
-cells will hold one card each.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each Raja or King
+starting a new pile.  Rows build down in rank regardless of suit.
+Empty rows cannot be filled. The eight free cells will hold one card each.

--- a/html-src/rules/vamana.html
+++ b/html-src/rules/vamana.html
@@ -1,30 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Vamana</h1>
 Dashavatara Ganjifa type. One deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down by rank in "alternate" colors.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down by rank in "alternate" colors.
+
 <h3>Rules</h3>
-The cards on the tableau build down in rank in alternate colors.
-The Dashavatara Ganjifa deck has ten suits and each suit has it's
-own color. This makes it a bit problematic at times knowing which
-colors are alternate. If a card of one suit doesn't play in a spot,
-try a different card of the same rank. The foundations build up in
-rank by suit starting with the Ace. The cards are dealt from the
-talon three at a time. There are unlimited redeals. Only Mirs
-(Kings) may be played on an empty row. Cards may not be played from
+The cards on the tableau build down in rank in alternate colors.  The
+Dashavatara Ganjifa deck has ten suits and each suit has it's own color.
+This makes it a bit problematic at times knowing which colors are alternate.
+If a card of one suit doesn't play in a spot, try a different card of the
+same rank.  The foundations build up in rank by suit starting with the Ace.
+The cards are dealt from the talon three at a time.  There are unlimited redeals.
+Only Mirs (Kings) may be played on an empty row.  Cards may not be played from
 the foundations.
+
 <h3>Strategy</h3>
-The waste stack will be the biggest problem area. Move cards on the
-tableau to free up spots for cards on the waste stack.
-</body>
-</html>
+The waste stack will be the biggest problem area.  Move cards on the tableau
+to free up spots for cards on the waste stack.

--- a/html-src/rules/varaha.html
+++ b/html-src/rules/varaha.html
@@ -1,25 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Varaha</h1>
 Dashavatara Ganjifa type. One deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-Play is similar to <a href="klondike.html">Klondike</a>. The rows
-build down in rank by suit.
+Play is similar to
+<a href="klondike.html">Klondike</a>.
+The rows build down in rank by suit.
+
 <h3>Rules</h3>
-The cards on the tableau build down in rank by suit. The
-foundations build up in rank by suit starting with the Ace. The
-cards are dealt from the talon three at a time. There are unlimited
-redeals. Any card or movable pile may be played on an empty row.
-Cards may not be played from the foundations.
+The cards on the tableau build down in rank by suit.  The foundations build up
+in rank by suit starting with the Ace.  The cards are dealt from the talon three
+at a time.  There are unlimited redeals.  Any card or movable pile may be played
+on an empty row.  Cards may not be played from the foundations.
+
 <h3>Strategy</h3>
 The odds against winning this game are high.
-</body>
-</html>

--- a/html-src/rules/variegatedcanfield.html
+++ b/html-src/rules/variegatedcanfield.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Variegated Canfield</h1>
-<p>Canfield type. 2 decks. 2 redeals.</p>
+<p>
+Canfield type. 2 decks. 2 redeals.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="doublecanfield.html">Double Canfield</a>, but the
-reserve is dealt face-up, and two redeals.</p>
+<p>
+Like <a href="doublecanfield.html">Double Canfield</a>,
+but the reserve is dealt face-up, and two redeals.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/vegasklondike.html
+++ b/html-src/rules/vegasklondike.html
@@ -1,24 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Vegas Klondike</h1>
-<p>Klondike type. 1 deck. No redeal.</p>
+<p>
+Klondike type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="klondike.html">Klondike</a>, but no
-redeal.</p>
+<p>
+Just like <a href="klondike.html">Klondike</a>,
+but no redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>Notes</h3>
-<p>There is a simple casino scoring system here - you debit $52 for
-each game and for every card you bear off, you get $5 credit. Your
-balance is reset whenever you select a different game. Loaded games
-and manually entered game numbers don't count.</p>
-</body>
-</html>
+<p>
+There is a simple casino scoring system here - you debit $52 for each game
+and for every card you bear off, you get $5 credit.
+Your balance is reset whenever you select a different game.
+Loaded games and manually entered game numbers don't count.

--- a/html-src/rules/waningmoon.html
+++ b/html-src/rules/waningmoon.html
@@ -1,19 +1,16 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Waning Moon</h1>
-<p>Forty Thieves type. 2 decks. No redeal.</p>
+<p>
+Forty Thieves type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but with 13
-piles.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but with 13 piles.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/wasp.html
+++ b/html-src/rules/wasp.html
@@ -1,20 +1,17 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Wasp</h1>
-<p>Spider type. 1 deck. No redeal.</p>
+<p>
+Spider type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Quick Description</h3>
-<p>Just like <a href="scorpion.html">Scorpion</a>, but anything on
-an empty space.</p>
+<p>
+Just like <a href="scorpion.html">Scorpion</a>,
+but anything on an empty space.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/westcliff.html
+++ b/html-src/rules/westcliff.html
@@ -1,26 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Westcliff</h1>
-<p>Klondike type. 1 deck. No redeal.</p>
+<p>
+Klondike type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but 10 piles,
-anything on an empty space, and no redeal.<br />
-Very easy.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but 10 piles, anything on an empty space, and no redeal.
+<br>Very easy.
+
 <h3>Rules</h3>
-<p>Piles build down by alternate color, and an empty space can be
-filled with any card or sequence.</p>
-<p>Cards from the talon are turned over to the waste pile, one at a
-time. You can move the top card to the playing piles or the
-foundations. There is no redeal.</p>
-<p>You are <em>not</em> permitted to move cards back out of the
-foundations.</p>
-</body>
-</html>
+<p>
+Piles build down by alternate color, and an empty space can be filled
+with any card or sequence.
+<p>
+Cards from the talon are turned over to the waste pile, one at a time.
+You can move the top card to the playing piles or the foundations.
+There is no redeal.
+<p>
+You are <em>not</em> permitted to move cards back out of the foundations.

--- a/html-src/rules/wheeloffortune.html
+++ b/html-src/rules/wheeloffortune.html
@@ -1,30 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Wheel of Fortune</h1>
-<p>Tarock type. 1 deck. No redeal.</p>
+<p>
+Tarock type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards on the tableau build down by suit. Only two cards can be
-placed on a row stack. Only one card can be moved at a time. Any
-card can be played on an empty row stack. The foundations build up
-in rank from the Ace by suit. Cards are dealt from the talon two at
-a time.</p>
+<p>
+Cards on the tableau build down by suit.  Only two cards
+can be placed on a row stack.  Only one card can be moved at a
+time.  Any card can be played on an empty row stack.
+The foundations build up in rank from the Ace by suit.
+Cards are dealt from the talon two at a time.
+
 <h3>Strategy</h3>
-<p>Keeping one or more open row stacks is critical in the early
-stages of the game since the cards are dealt two at a time. It's
-also important not to let low ranked cards get buried too deep in
-the waste stack. Do all you can to place as many cards as possible
-on the row stacks.</p>
+<p>
+Keeping one or more open row stacks is critical in the early
+stages of the game since the cards are dealt two at a time.
+It's also important not to let low ranked cards get buried
+too deep in the waste stack.  Do all you can to place as
+many cards as possible on the row stacks.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a> and is part of the
-official PySol distribution.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>
+and is part of the official PySol distribution.

--- a/html-src/rules/whitehead.html
+++ b/html-src/rules/whitehead.html
@@ -1,20 +1,18 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Whitehead</h1>
-<p>Klondike type. 1 deck. No redeal.</p>
+<p>
+Klondike type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="klondike.html">Klondike</a>, but piles build down
-by same color (sequences can be moved only if they build down by
-same suit), anything on an empty space, and no redeal.</p>
+<p>
+Like <a href="klondike.html">Klondike</a>,
+but piles build down by same color
+(sequences can be moved only if they build down by same suit),
+anything on an empty space, and no redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules/wicked.html
+++ b/html-src/rules/wicked.html
@@ -1,25 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Wicked</h1>
 Tarock type. 1 deck. Unlimited redeals.
+
 <h3>Object</h3>
 Move all cards to the foundations.
+
 <h3>Quick description</h3>
-This game is similar to <a href="cruel.html">Cruel</a> played with
-the 78 card Tarock deck. Piles build down in rank in by suit. Only
-one card may be moved at a time.
+This game is similar to
+<a href="cruel.html">Cruel</a>
+played with the 78 card Tarock deck.  Piles build down in rank in
+by suit.  Only one card may be moved at a time.
+
 <h3>Rules</h3>
-Rows build down in rank by suit. Only one card may be moved at a
-time. An empty row can not be filled. When no more moves can be
-made click the talon for a redeal.
+Rows build down in rank by suit.  Only one card may be moved at a time.
+An empty row can not be filled.  When no more moves can be made click
+the talon for a redeal.
+
 <h3>Author</h3>
-<p>This game and documentation has been written by <a href=
-"mailto:grania@mailcity.com">T. Kirk</a>.</p>
-</body>
-</html>
+<p>
+This game and documentation has been written by
+<a href="mailto:grania@mailcity.com">T. Kirk</a>.

--- a/html-src/rules/willothewisp.html
+++ b/html-src/rules/willothewisp.html
@@ -1,23 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Will o' the Wisp</h1>
-<p>Spider type. 1 deck. No redeal.</p>
+<p>
+Spider type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Group all the cards in sets of 13 cards in descending sequence
-by suit from King to Ace and move such sets to the foundations.</p>
+<p>
+Group all the cards in sets of 13 cards in descending sequence
+by suit from King to Ace and move such sets to the foundations.
+
 <h3>Quick Description</h3>
-<p>Exactly like <a href="spiderette.html">Spiderette</a>, but a
-little bit easier due to the different layout.</p>
+<p>
+Exactly like <a href="spiderette.html">Spiderette</a>,
+but a little bit easier due to the different layout.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
+<p>
+<i>[To be written]</i>
+
 <h3>History</h3>
-<p>This game was invented by Albert H. Morehead and Geoffrey
-Mott-Smith.</p>
-</body>
-</html>
+<p>
+This game was invented by Albert H. Morehead and Geoffrey Mott-Smith.

--- a/html-src/rules/windmill.html
+++ b/html-src/rules/windmill.html
@@ -1,26 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Windmill</h1>
-<p>Two-Deck game type. 2 decks. No redeal.</p>
+<p>
+Two-Deck game type. 2 decks. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>The 4 foundations in the corners build down by rank from King to
-Ace.</p>
-<p>The foundation in the center builds up by rank from Ace to King,
-four times wrapping around until it contains 52 cards.</p>
-<p>The 8 reserve piles can hold a single card and are automatically
-filled from the waste or talon.</p>
-<p>Cards can be flipped singly from the talon to the waste. There
-is no redeal.</p>
+<p>
+The 4 foundations in the corners build down by rank from King to Ace.
+<p>
+The foundation in the center builds up by rank from Ace to King,
+four times wrapping around until it contains 52 cards.
+<p>
+The 8 reserve piles can hold a single card and are
+automatically filled from the waste or talon.
+<p>
+Cards can be flipped singly from the talon to the waste.
+There is no redeal.
+
 <h3>Notes</h3>
-<p><i>Autodrop</i> and <i>Quickplay</i> are disabled for this
-game.</p>
-</body>
-</html>
+<p>
+<i>Autodrop</i> and <i>Quickplay</i> are disabled for this game.

--- a/html-src/rules/wisteria.html
+++ b/html-src/rules/wisteria.html
@@ -1,23 +1,20 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Wisteria</h1>
-<p>Hanafuda FreeCell type. No redeal.</p>
+<p>
+Hanafuda FreeCell type. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="snake.html">Snake</a>, with the Hanafuda deck but
-the number of cards you can move as a sequence is not restricted
-and there are no "free" cells.</p>
+<p>
+Like <a href="snake.html">Snake</a>,
+with the Hanafuda deck but the number of cards you can move as a sequence is
+not restricted and there are no "free" cells.
+
 <h3>Rules</h3>
-<p>All cards are dealt to 9 piles at the start of the game, each
-first rank card starting a new pile.</p>
-<p>Piles build from first rank to fourth, and an empty space cannot
-be filled.</p>
-</body>
-</html>
+<p>
+All cards are dealt to 9 piles at the start of the game, each first rank card
+starting a new pile.
+<p>
+Piles build from first rank to fourth, and an empty space cannot be filled.

--- a/html-src/rules/yukon.html
+++ b/html-src/rules/yukon.html
@@ -1,23 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Yukon</h1>
-<p>Yukon type. 1 deck. No redeal.</p>
+<p>
+Yukon type. 1 deck. No redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Rules</h3>
-<p>Cards in tableau are built down by alternate color. Groups of
-cards can be moved regardless of sequence. An empty pile in the
-tableau can be filled with a King or a group of cards with a King
-on the bottom.</p>
-<p>Foundations are built up in suit from Ace to King. Cards in
-foundations are no longer in play.</p>
+<p>
+Cards in tableau are built down by alternate color.
+Groups of cards can be moved regardless of sequence.
+An empty pile in the tableau can be filled with a King or a group
+of cards with a King on the bottom.
+<p>
+Foundations are built up in suit from Ace to King.
+Cards in foundations are no longer in play.
+
 <h3>History</h3>
-<p>Yukon is one of the classic solitaire card games.</p>
-</body>
-</html>
+<p>
+Yukon is one of the classic solitaire card games.

--- a/html-src/rules/zebra.html
+++ b/html-src/rules/zebra.html
@@ -1,21 +1,19 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Zebra</h1>
-<p>Forty Thieves type. 2 decks. 1 redeal.</p>
+<p>
+Forty Thieves type. 2 decks. 1 redeal.
+
 <h3>Object</h3>
-<p>Move all cards to the foundations.</p>
+<p>
+Move all cards to the foundations.
+
 <h3>Quick Description</h3>
-<p>Like <a href="fortythieves.html">Forty Thieves</a>, but the 8
-piles build down by alternate color, the foundations <b>build up by
-alternate color</b>, empty piles are automatically filled from the
-waste or talon, and one redeal.</p>
+<p>
+Like <a href="fortythieves.html">Forty Thieves</a>,
+but the 8 piles build down by alternate color,
+the foundations <b>build up by alternate color</b>,
+empty piles are automatically filled from the waste or talon,
+and one redeal.
+
 <h3>Rules</h3>
-<p><i>[To be written]</i></p>
-</body>
-</html>
+<p>
+<i>[To be written]</i>

--- a/html-src/rules_alternate.html
+++ b/html-src/rules_alternate.html
@@ -1,11 +1,2 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h2>Alternate Names</h2>
-</body>
-</html>
+<ul>

--- a/html-src/wikipedia/accordion.html
+++ b/html-src/wikipedia/accordion.html
@@ -1,49 +1,43 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Accordion</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Accordion is a solitaire game using one deck of playing cards.
-The object is to compress the entire deck into one pile like an
-accordion.</p>
-<p>There are two variants of the game in terms of how the game
-begins.</p>
-<p>In one variant, the cards are laid out one by one and are
-immediately put into play if possible. The number of cards to be
-laid out range from just one card to how many cards the width of
-the table can allow (usually a second or third row is constructed
-in the process). While practical, it also allows an element of
-surprise as the player does not know the next card to be dealt
-until all possible plays are exhausted.</p>
-<p>In another variant, the cards are spread out in one line. While
-this variant allows for some tactics to be applied, it can prove to
-be cumbersome when played with a real deck. This variant of the
-game is implemented in BVS Solitaire Collection and Patience
-Pack.</p>
-<p>No matter the layout variant, the game is the same. A pile can
-be moved on top of another pile immediately to its left or
-separated to its left by two piles if the top cards of each pile
-have the same suit or rank. Gaps left behind are filled by moving
-piles to the left.</p>
-<p>Here's an example: <b>5</b><img src="../images/s.gif" />
-<b>6</b><img src="../images/s.gif" /> <b>10</b><img src=
-"../images/d.gif" /> <b>5</b><img src="../images/h.gif" />
-<b>K</b><img src="../images/c.gif" /></p>
-<p>According to this example, either <b>6</b><img src=
-"../images/s.gif" /> or <b>5</b><img src="../images/h.gif" /> can
-be placed over <b>5</b><img src="../images/s.gif" />. These are the
-only allowable moves.</p>
-<p>The game is won when all cards are compressed into one pile. But
-since achieving this is next to impossible under these rigid rules,
-Alfred Sheinwold mentions in his book <i>101 Best Family Card
-Games</i> (ISBN 0806986352) that it is considered a win when there
-are five piles or less at the end of the game.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Accordion_%28solitaire%29">http://en.wikipedia.org/wiki/Accordion_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Accordion is a solitaire game using one deck of playing cards. The object is
+to compress the entire deck into one pile like an accordion.
+<p>
+There are two variants of the game in terms of how the game begins.
+<p>
+In one variant, the cards are laid out one by one and are immediately put into
+play if possible. The number of cards to be laid out range from just one card
+to how many cards the width of the table can allow (usually a second or third
+row is constructed in the process). While practical, it also allows an element
+of surprise as the player does not know the next card to be dealt until all
+possible plays are exhausted.
+<p>
+In another variant, the cards are spread out in one line. While this variant
+allows for some tactics to be applied, it can prove to be cumbersome when
+played with a real deck. This variant of the game is implemented in BVS
+Solitaire Collection and Patience Pack.
+<p>
+No matter the layout variant, the game is the same. A pile can be moved on top
+of another pile immediately to its left or separated to its left by two piles
+if the top cards of each pile have the same suit or rank. Gaps left behind are
+filled by moving piles to the left.
+<p>
+Here's an example:
+<b>5</b><img src="../images/s.gif">
+<b>6</b><img src="../images/s.gif">
+<b>10</b><img src="../images/d.gif">
+<b>5</b><img src="../images/h.gif">
+<b>K</b><img src="../images/c.gif">
+<p>
+According to this example, either <b>6</b><img src="../images/s.gif"> or
+<b>5</b><img src="../images/h.gif"> can be placed over <b>5</b><img
+src="../images/s.gif">. These are the only allowable moves.
+<p>
+The game is won when all cards are compressed into one pile. But since
+achieving this is next to impossible under these rigid rules, Alfred Sheinwold
+mentions in his book <i>101 Best Family Card Games</i> (ISBN 0806986352) that
+it is considered a win when there are five piles or less at the end of the
+game.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Accordion_%28solitaire%29">http://en.wikipedia.org/wiki/Accordion_(solitaire)</a>)</i>

--- a/html-src/wikipedia/agnes.html
+++ b/html-src/wikipedia/agnes.html
@@ -1,49 +1,39 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Agnes</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Agnes is a solitaire card game which is a variant of the very
-popular game Klondike. It is similar to the latter except on how
-the stock is dealt.</p>
-<p>Dealing the first 28 cards onto the tableau is a lot like in
-Klondike. Then a card is placed in the first of the four
-foundations. This card will be the first card of that foundation
-and all other cards with the same rank should be placed at the
-other three foundations.</p>
-<p>Seven cards are then dealt in a row either above or below the
-tableau. This will act as the reserve. The cards in the reserve are
-available for play.</p>
-<p>Playing the game is a lot like Klondike except that any gaps are
-filled in by a card a rank lower than the first card of the
-foundation. For instance, if the first card of each foundation is a
-10, gaps are only filled by 9s. Foundations are built up by suit,
-while the columns on the tableau are built down in alternating
-colors, wrapping from Ace to King if necessary. When play is no
-longer possible on the tableau, any card on the reserve can be used
-to continue the game. Gaps in the reserve are not filled until a
-new set is dealt.</p>
-<p>If the game cannot continue even from the reserve, a new set of
-seven cards is dealt from the stock to the reserve. The stock is
-good for two deals on the reserve with two cards left over. So
-after the third new deal and no more moves possible, the two left
-over cards are dealt as if they each have a reserve pile on their
-own.</p>
-<p>The game is won when all cards have made their way to the
-foundations.</p>
-<p>There are two versions of the game of Agnes. The one described
-above is called Agnes Bernauer. In another version called Agnes
-Sorel (no connection to the woman with the same name), the game is
-played the same way except the cards in the tableau are built down
-by color, i.e. Red suits on red, black suits on black. Furthermore,
-in Agnes Sorel, spaces are not filled. David Parlett is said to
-have given these two versions their separate names.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Agnes">http://en.wikipedia.org/wiki/Agnes</a>)</i></p>
-</body>
-</html>
+<p>
+Agnes is a solitaire card game which is a variant of the very popular game
+Klondike. It is similar to the latter except on how the stock is dealt.
+<p>
+Dealing the first 28 cards onto the tableau is a lot like in Klondike. Then a
+card is placed in the first of the four foundations. This card will be the
+first card of that foundation and all other cards with the same rank should be
+placed at the other three foundations.
+<p>
+Seven cards are then dealt in a row either above or below the tableau. This
+will act as the reserve. The cards in the reserve are available for play.
+<p>
+Playing the game is a lot like Klondike except that any gaps are filled in by
+a card a rank lower than the first card of the foundation. For instance, if
+the first card of each foundation is a 10, gaps are only filled by 9s.
+Foundations are built up by suit, while the columns on the tableau are built
+down in alternating colors, wrapping from Ace to King if necessary. When play
+is no longer possible on the tableau, any card on the reserve can be used to
+continue the game. Gaps in the reserve are not filled until a new set is
+dealt.
+<p>
+If the game cannot continue even from the reserve, a new set of seven cards is
+dealt from the stock to the reserve. The stock is good for two deals on the
+reserve with two cards left over. So after the third new deal and no more
+moves possible, the two left over cards are dealt as if they each have a
+reserve pile on their own.
+<p>
+The game is won when all cards have made their way to the foundations.
+<p>
+There are two versions of the game of Agnes. The one described above is called
+Agnes Bernauer. In another version called Agnes Sorel (no connection to the
+woman with the same name), the game is played the same way except the cards in
+the tableau are built down by color, i.e. Red suits on red, black suits on
+black. Furthermore, in Agnes Sorel, spaces are not filled. David Parlett is
+said to have given these two versions their separate names.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Agnes">http://en.wikipedia.org/wiki/Agnes</a>)</i>

--- a/html-src/wikipedia/alhambra.html
+++ b/html-src/wikipedia/alhambra.html
@@ -1,36 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Alhambra</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Alhambra is a solitaire card game which is played using two
-decks of playing cards. Its unusual feature is akin to that of
-Crazy Quilt: the cards in the reserve are built either on the
-foundations or on a waste pile.</p>
-<p>First, one King and one Ace is removed from the shuffled decks
-and placed in a row as foundations. Right below them, eight piles
-of four cards are dealt; these piles serve as the reserve.</p>
-<p>The King foundations are built down by suit while the Ace
-foundations are built up, also by suit.</p>
-<p>The top cards of the reserve piles are available only to be
-built on the foundation; there is no building. When there are no
-more moves possible, the stock is dealt, one card at a time, on the
-waste pile, the top card of which is available. The cards on the
-wastepile can be built on the foundations, while it can be built
-upon by cards from the reserve piles.</p>
-<p>When the stock is exhausted, the waste pile (which by then
-already includes cards from the reserve) is picked up and turned
-over to become the new stock. This can be done twice in the entire
-game.</p>
-<p>The game finishes soon after the stock is exhausted the third
-time. The game is won when all cards are built into the
-foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Alhambra_%28solitaire%29">http://en.wikipedia.org/wiki/Alhambra_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Alhambra is a solitaire card game which is played using two decks of playing
+cards. Its unusual feature is akin to that of Crazy Quilt: the cards in the
+reserve are built either on the foundations or on a waste pile.
+<p>
+First, one King and one Ace is removed from the shuffled decks and placed in a
+row as foundations. Right below them, eight piles of four cards are dealt;
+these piles serve as the reserve.
+<p>
+The King foundations are built down by suit while the Ace foundations are
+built up, also by suit.
+<p>
+The top cards of the reserve piles are available only to be built on the
+foundation; there is no building. When there are no more moves possible, the
+stock is dealt, one card at a time, on the waste pile, the top card of which
+is available. The cards on the wastepile can be built on the foundations,
+while it can be built upon by cards from the reserve piles.
+<p>
+When the stock is exhausted, the waste pile (which by then already includes
+cards from the reserve) is picked up and turned over to become the new stock.
+This can be done twice in the entire game.
+<p>
+The game finishes soon after the stock is exhausted the third time. The game
+is won when all cards are built into the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Alhambra_%28solitaire%29">http://en.wikipedia.org/wiki/Alhambra_(solitaire)</a>)</i>

--- a/html-src/wikipedia/alternation.html
+++ b/html-src/wikipedia/alternation.html
@@ -1,34 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Alternation</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Alternation is a solitaire card game which is played using two
-decks of playing cards. Its tableau (or playing area) is similar to
-that of another solitaire game <i>Stonewall</i>.</p>
-<p>Forty-nine cards are set up into seven columns of seven cards
-each. Keep in mind that in each column, the top card, as well as
-the third, fifth cards from the top and the bottom card, are face
-up, while the second, fourth, and sixth cards from the top are face
-down, much like the pattern OXOXOXO.</p>
-<p>The object of the game is to release the Aces as they become
-available and built each of them by suit.</p>
-<p>The top cards of each column are the only ones available for
-play, to be built up by suit on the foundations, or on each other
-down by alternating colors. A sequence or part of a sequence can be
-moved as a unit.</p>
-<p>When no more cards can be moved, the stock (the remaining cards)
-is dealt one card at a time. A card that cannot be built on the
-tableau or on the foundations is placed on the waste pile, the top
-card of which is available for play.</p>
-<p>The game ends soon after the entire stock has run out. The game
-is won when all cards are built onto the foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Alternation">http://en.wikipedia.org/wiki/Alternation</a>)</i></p>
-</body>
-</html>
+<p>
+Alternation is a solitaire card game which is played using two decks of
+playing cards. Its tableau (or playing area) is similar to that of another
+solitaire game <i>Stonewall</i>.
+<p>
+Forty-nine cards are set up into seven columns of seven cards each. Keep in
+mind that in each column, the top card, as well as the third, fifth cards from
+the top and the bottom card, are face up, while the second, fourth, and sixth
+cards from the top are face down, much like the pattern OXOXOXO.
+<p>
+The object of the game is to release the Aces as they become available and
+built each of them by suit.
+<p>
+The top cards of each column are the only ones available for play, to be built
+up by suit on the foundations, or on each other down by alternating colors. A
+sequence or part of a sequence can be moved as a unit.
+<p>
+When no more cards can be moved, the stock (the remaining cards) is dealt one
+card at a time. A card that cannot be built on the tableau or on the
+foundations is placed on the waste pile, the top card of which is available
+for play.
+<p>
+The game ends soon after the entire stock has run out. The game is won when
+all cards are built onto the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Alternation">http://en.wikipedia.org/wiki/Alternation</a>)</i>

--- a/html-src/wikipedia/amazons.html
+++ b/html-src/wikipedia/amazons.html
@@ -1,40 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Amazons</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Amazons is a solitaire card game which is played with a deck of
-playing cards. What is interesting about this game is that it is
-played with a stripped deck, i.e. one that has its deuces, treys,
-fours, fives, and sixes removed. This game is so named because if
-the game is won, all queens are shown on full view, so all kings
-are removed as well.</p>
-<p>First, four cards are dealt. They would be the reserve. Above it
-is a space for the foundations. Once an ace is available, it is
-placed on the foundations and each ace should be placed in order on
-which they become available.</p>
-<p>The first four cards dealt are the bases of the reserve piles,
-the top card of each being available only to the foundation
-immediately above it. The exception to this rule is a queen can be
-moved to its foundation from any pile. The order of placing is
-<b>A-7-8-9-10-J-Q</b>.</p>
-<p>When play goes on a standstill, four more cards are then dealt,
-one on each reserve pile, and stop to see if any of the cards dealt
-can be placed on the foundations. Spaces are not filled until the
-next deal. This process is repeated until the stock runs out. When
-it does, a new stock is formed by placing each pile over its
-right-hand neighbor, turn them face down and deal; this should be
-done without reshuffling. The process of dealing the cards,
-building to the foundations, and redealing, is repeated without
-limits until the game is won or lost.</p>
-<p>The game is won when all cards are built onto the foundations,
-with the queens at the top.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Amazons_%28solitaire%29">http://en.wikipedia.org/wiki/Amazons_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Amazons is a solitaire card game which is played with a deck of playing cards.
+What is interesting about this game is that it is played with a stripped deck,
+i.e. one that has its deuces, treys, fours, fives, and sixes removed. This
+game is so named because if the game is won, all queens are shown on full
+view, so all kings are removed as well.
+<p>
+First, four cards are dealt. They would be the reserve. Above it is a space
+for the foundations. Once an ace is available, it is placed on the foundations
+and each ace should be placed in order on which they become available.
+<p>
+The first four cards dealt are the bases of the reserve piles, the top card of
+each being available only to the foundation immediately above it. The
+exception to this rule is a queen can be moved to its foundation from any
+pile. The order of placing is <b>A-7-8-9-10-J-Q</b>.
+<p>
+When play goes on a standstill, four more cards are then dealt, one on each
+reserve pile, and stop to see if any of the cards dealt can be placed on the
+foundations. Spaces are not filled until the next deal. This process is
+repeated until the stock runs out. When it does, a new stock is formed by
+placing each pile over its right-hand neighbor, turn them face down and deal;
+this should be done without reshuffling. The process of dealing the cards,
+building to the foundations, and redealing, is repeated without limits until
+the game is won or lost.
+<p>
+The game is won when all cards are built onto the foundations, with the queens
+at the top.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Amazons_%28solitaire%29">http://en.wikipedia.org/wiki/Amazons_(solitaire)</a>)</i>

--- a/html-src/wikipedia/baroness.html
+++ b/html-src/wikipedia/baroness.html
@@ -1,44 +1,37 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Baroness</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Baroness is a solitaire card game that is played with a deck of
-52 playing cards. Also known as <b>Five Piles</b> and
-<b>Thirteens</b>, it is a game that has an arrangement that is
-almost like that of Aces Up but with the game play of Pyramid.</p>
-<p>Five cards are dealt in a row; they will form the bases of the
-five piles, the top cards of which are available for play.</p>
-<p>In order to win, one has to remove Kings and pairs of cards that
-total 13. In this game, spot cards are taken at face value, Jacks
-value at 11, Queens 12, and Kings 13. So the following combinations
-of cards are discarded:</p>
+<p>
+Baroness is a solitaire card game that is played with a deck of 52 playing
+cards. Also known as <b>Five Piles</b> and <b>Thirteens</b>, it is a game that
+has an arrangement that is almost like that of Aces Up but with the game play
+of Pyramid.
+<p>
+Five cards are dealt in a row; they will form the bases of the five piles, the
+top cards of which are available for play.
+<p>
+In order to win, one has to remove Kings and pairs of cards that total 13. In
+this game, spot cards are taken at face value, Jacks value at 11, Queens 12,
+and Kings 13. So the following combinations of cards are discarded:
 <ul>
-<li>Queen and Ace</li>
-<li>Jack and 2</li>
-<li>10 and 3</li>
-<li>9 and 4</li>
-<li>8 and 5</li>
-<li>7 and 6</li>
-<li>Kings on their own.</li>
+<li>Queen and Ace
+<li>Jack and 2
+<li>10 and 3
+<li>9 and 4
+<li>8 and 5
+<li>7 and 6
+<li>Kings on their own.
 </ul>
-<p>When gaps occur, they are filled by the top cards of the other
-piles; but when there are not enough cards to do this (less than
-five), cards from the stock are used.</p>
-<p>When gaps are filled and no kings and/or pairs of cards
-totalling 13 are present, five new cards are dealt from the stock,
-one onto each pile. Game play then continues, with the top cards of
-each pile, as mentioned above, are available. This cycle of
-discarding and dealing of new cards goes on until the stock has
-been used up.</p>
-<p>The game is successfully won when all cards have been
-discarded.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Baroness_%28solitaire%29">http://en.wikipedia.org/wiki/Baroness_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+When gaps occur, they are filled by the top cards of the other piles; but when
+there are not enough cards to do this (less than five), cards from the stock
+are used.
+<p>
+When gaps are filled and no kings and/or pairs of cards totalling 13 are
+present, five new cards are dealt from the stock, one onto each pile. Game
+play then continues, with the top cards of each pile, as mentioned above, are
+available. This cycle of discarding and dealing of new cards goes on until the
+stock has been used up.
+<p>
+The game is successfully won when all cards have been discarded.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Baroness_%28solitaire%29">http://en.wikipedia.org/wiki/Baroness_(solitaire)</a>)</li>

--- a/html-src/wikipedia/bigben.html
+++ b/html-src/wikipedia/bigben.html
@@ -1,75 +1,64 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Big Ben</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Big Ben (or known in other solitaire brands as Clock) is a
-solitaire card game which uses two decks of playing cards mixed
-together. It is basically a large-scale, two-deck version of
-<a href="grandfathersclock.html">Grandfather's Clock</a> and is
-probably named after Big Ben, the colloquially used nickname for
-the clock face at the tower of the Palace of Westminster in
-London.</p>
-<p>Before the start of the game, the following cards are separated
-from the decks: 2<img src="../images/c.gif" />, 3<img src=
-"../images/h.gif" />, 4<img src="../images/s.gif" />, 5<img src=
-"../images/d.gif" />, 6<img src="../images/c.gif" />, 7<img src=
-"../images/h.gif" />, 8<img src="../images/s.gif" />, 9<img src=
-"../images/d.gif" />, 10<img src="../images/c.gif" />, J<img src=
-"../images/h.gif" />, Q<img src="../images/s.gif" />, K<img src=
-"../images/d.gif" />. These cards to form a circle arranged like
-numbers on a clock face with the 2<img src="../images/c.gif" /> on
-the "9 o' clock" position, the 5<img src="../images/d.gif" /> at
-the "12 o' clock" position, and the K<img src="../images/d.gif" />
-at the "8 o' clock." This will be the foundations, or the "inner
-circle" (otherwise known as the "clock").</p>
-<p>Twelves piles of three cards are then dealt around the inner
-circle. These piles form the tableau, or the "outer circle." The
-top cards of the outer circle are available for play to the inner
-circle or around the outer circle. Building on the outer circle is
-down by suit, while the foundations in the inner circle are built
-up by suit until the last card corresponds to the its position on
-the clock (i.e. the Q<img src="../images/s.gif" /> should be built
-up to 7<img src="../images/s.gif" />, for instance). Building is
-also continuous, with Aces placed over Kings in the inner circle
-and vice versa in the outer circle.</p>
-<p>It should be noted that the minimum number of cards in each pile
-in the outer circle is three. A pile containing less than three
-cards is said to have gaps; an empty pile has three "gaps," a pile
-having one card has two "gaps," and a pile with two cards has one
-"gap." As cards are built, "gaps" are formed and the only way these
-are "filled" is by dealing cards from the stock. Building on a pile
-having cards less than three is like "filling a gap" from the
-tableau and is therefore not allowed.</p>
-<p>It is the player's discretion when to fill the "gaps," but when
-the player decides to do so, one has to fill all "gaps," i. e.
-replenish all piles with less than three cards so each of them
-contains three cards once again. For example, two piles are empty,
-one pile has one card left, and two piles have two cards left. So
-the player has to fill a total of 10 gaps. He does this by dealing
-cards one card per pile at a time clockwise starting from the pile
-above the "12 o' clock" foundation. No building is done until this
-process is complete. The player can do this as long as there are
-"gaps."</p>
-<p>Sometimes, the player cannot make any moves even when all piles
-contain three cards each. So the player can deal cards from the
-stock one at a time. Cards that cannot be built either onto the
-inner or outer circles are placed on the wastepile (as a
-suggestion, one can place the wastepile at the center of the inner
-circle for convenience). Again, cards at the wastepile cannot be
-used to fill "gaps." But once the stock is exhausted, there are no
-redeals; the game ends sooner after this or later.</p>
-<p>The game is successfully won when all foundations show cards
-corresponding to their positions in the clock (J<img src=
-"../images/s.gif" /> on "11 o' clock," Q<img src=
-"../images/d.gif" /> on "12 o' clock," A<img src=
-"../images/c.gif" /> on "1 o' clock," and so on.)</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Big_Ben_%28solitaire%29">http://en.wikipedia.org/wiki/Big_Ben_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Big Ben (or known in other solitaire brands as Clock) is a solitaire card game
+which uses two decks of playing cards mixed together. It is basically a
+large-scale, two-deck version of <a
+href="grandfathersclock.html">Grandfather's Clock</a> and is probably named
+after Big Ben, the colloquially used nickname for the clock face at the tower
+of the Palace of Westminster in London.
+<p>
+Before the start of the game, the following cards are separated from the
+decks: 2<img src="../images/c.gif">, 3<img src="../images/h.gif">, 4<img
+src="../images/s.gif">, 5<img src="../images/d.gif">, 6<img
+src="../images/c.gif">, 7<img src="../images/h.gif">, 8<img
+src="../images/s.gif">, 9<img src="../images/d.gif">, 10<img
+src="../images/c.gif">, J<img src="../images/h.gif">, Q<img
+src="../images/s.gif">, K<img src="../images/d.gif">. These cards to form a
+circle arranged like numbers on a clock face with the 2<img
+src="../images/c.gif"> on the "9 o' clock" position, the 5<img
+src="../images/d.gif"> at the "12 o' clock" position, and the K<img
+src="../images/d.gif"> at the "8 o' clock." This will be the foundations, or
+the "inner circle" (otherwise known as the "clock").
+<p>
+Twelves piles of three cards are then dealt around the inner circle. These
+piles form the tableau, or the "outer circle." The top cards of the outer
+circle are available for play to the inner circle or around the outer circle.
+Building on the outer circle is down by suit, while the foundations in the
+inner circle are built up by suit until the last card corresponds to the its
+position on the clock (i.e. the Q<img src="../images/s.gif"> should be built
+up to 7<img src="../images/s.gif">, for instance). Building is also
+continuous, with Aces placed over Kings in the inner circle and vice versa in
+the outer circle.
+<p>
+It should be noted that the minimum number of cards in each pile in the outer
+circle is three. A pile containing less than three cards is said to have gaps;
+an empty pile has three "gaps," a pile having one card has two "gaps," and a
+pile with two cards has one "gap." As cards are built, "gaps" are formed and
+the only way these are "filled" is by dealing cards from the stock. Building
+on a pile having cards less than three is like "filling a gap" from the
+tableau and is therefore not allowed.
+<p>
+It is the player's discretion when to fill the "gaps," but when the player
+decides to do so, one has to fill all "gaps," i. e. replenish all piles with
+less than three cards so each of them contains three cards once again. For
+example, two piles are empty, one pile has one card left, and two piles have
+two cards left. So the player has to fill a total of 10 gaps. He does this by
+dealing cards one card per pile at a time clockwise starting from the pile
+above the "12 o' clock" foundation. No building is done until this process is
+complete. The player can do this as long as there are "gaps."
+<p>
+Sometimes, the player cannot make any moves even when all piles contain three
+cards each. So the player can deal cards from the stock one at a time. Cards
+that cannot be built either onto the inner or outer circles are placed on the
+wastepile (as a suggestion, one can place the wastepile at the center of the
+inner circle for convenience). Again, cards at the wastepile cannot be used to
+fill "gaps." But once the stock is exhausted, there are no redeals; the game
+ends sooner after this or later.
+<p>
+The game is successfully won when all foundations show cards corresponding to
+their positions in the clock (J<img src="../images/s.gif"> on "11 o' clock,"
+Q<img src="../images/d.gif"> on "12 o' clock," A<img src="../images/c.gif"> on
+"1 o' clock," and so on.)
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Big_Ben_%28solitaire%29">http://en.wikipedia.org/wiki/Big_Ben_(solitaire)</a>)</i>

--- a/html-src/wikipedia/bisley.html
+++ b/html-src/wikipedia/bisley.html
@@ -1,61 +1,47 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Bisley</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Bisley is a solitaire card game which uses a deck of 52 playing
-cards. It is one of the few one-deck games in which the player has
-options on which foundation a card can be placed.</p>
-<p>First the four aces are taken out and laid on the tableau to
-start the foundations. Then four columns of three cards are placed
-overlapping each other separately under the aces. After that, nine
-columns of four cards, also overlapping each other, are dealt to
-the right of the aces and first four columns. If the player decides
-to lay out all of the cards, he must make sure that there are four
-rows of thirteen cards and the first four cards on the first row
-should be the four aces.</p>
-<p>Here is the method of game play:</p>
+<p>
+Bisley is a solitaire card game which uses a deck of 52 playing cards. It is
+one of the few one-deck games in which the player has options on which
+foundation a card can be placed.
+<p>
+First the four aces are taken out and laid on the tableau to start the
+foundations. Then four columns of three cards are placed overlapping each
+other separately under the aces. After that, nine columns of four cards, also
+overlapping each other, are dealt to the right of the aces and first four
+columns. If the player decides to lay out all of the cards, he must make sure
+that there are four rows of thirteen cards and the first four cards on the
+first row should be the four aces.
+<p>
+Here is the method of game play:
 <ul>
-<li>Only the bottom cards are available for play. Thus, if the
-cards are overlapping, it is the exposed card of each column; if
-the cards are laid out, it is the card at the bottom each
-column.</li>
-<li>Only one card can be moved at a time.</li>
-<li>The cards on the tableau can be built either up or down by
-suit.</li>
-<li>Whenever a column becomes empty, it stays empty for the rest of
-the game.</li>
-<li>The foundations (the four aces) are built up by suit. However,
-whenever a King is released and becomes available, it becomes a
-foundation and is placed above its counterpart ace foundation to be
-built down, also by suit. The same thing can be done for the three
-other kings. This rule also gives the player an opportunity to
-place a card on one of the foundations of the same suit if it can
-be placed on either of them.</li>
+<li>Only the bottom cards are available for play. Thus, if the cards are
+overlapping, it is the exposed card of each column; if the cards are laid out,
+it is the card at the bottom each column.
+<li>Only one card can be moved at a time.
+<li>The cards on the tableau can be built either up or down by suit.
+<li>Whenever a column becomes empty, it stays empty for the rest of the game.
+<li>The foundations (the four aces) are built up by suit. However, whenever a
+King is released and becomes available, it becomes a foundation and is placed
+above its counterpart ace foundation to be built down, also by suit. The same
+thing can be done for the three other kings. This rule also gives the player
+an opportunity to place a card on one of the foundations of the same suit if
+it can be placed on either of them.
 </ul>
-<p>The game is won when all cards end up in the foundations. It
-actually does not matter where the ace and king foundations of each
-suit would meet and how many cards the ace and king foundations of
-each suit will have. At the end of one game for example, the
-<b>K</b><img src="../images/s.gif" /> is the only one on its
-foundation while the rest of spade cards are built on the
-<b>A</b><img src="../images/s.gif" />; the <b>A</b><img src=
-"../images/c.gif" /> remains unbuilt because all club cards are
-built on the <b>K</b><img src="../images/c.gif" />; the
-<b>A</b><img src="../images/h.gif" /> is built up to
-<b>4</b><img src="../images/h.gif" /> while the <b>K</b><img src=
-"../images/h.gif" /> is built down to <b>5</b><img src=
-"../images/h.gif" />; and the <b>A</b><img src="../images/d.gif" />
-is built up to <b>8</b><img src="../images/d.gif" /> while the
-<b>K</b><img src="../images/d.gif" /> is built down to
-<b>9</b><img src="../images/d.gif" />. In fact, the ace and king
-foundation of a suit can meet anywhere.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Bisley_%28solitaire%29">http://en.wikipedia.org/wiki/Bisley_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+The game is won when all cards end up in the foundations. It actually does not
+matter where the ace and king foundations of each suit would meet and how many
+cards the ace and king foundations of each suit will have. At the end of one
+game for example, the <b>K</b><img src="../images/s.gif"> is the only one on
+its foundation while the rest of spade cards are built on the <b>A</b><img
+src="../images/s.gif">; the <b>A</b><img src="../images/c.gif"> remains
+unbuilt because all club cards are built on the <b>K</b><img
+src="../images/c.gif">; the <b>A</b><img src="../images/h.gif"> is built up to
+<b>4</b><img src="../images/h.gif"> while the <b>K</b><img
+src="../images/h.gif"> is built down to <b>5</b><img src="../images/h.gif">;
+and the <b>A</b><img src="../images/d.gif"> is built up to
+<b>8</b><img src="../images/d.gif"> while the <b>K</b><img
+src="../images/d.gif"> is built down to <b>9</b><img src="../images/d.gif">.
+In fact, the ace and king foundation of a suit can meet anywhere.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Bisley_%28solitaire%29">http://en.wikipedia.org/wiki/Bisley_(solitaire)</a>)</i>

--- a/html-src/wikipedia/blockade.html
+++ b/html-src/wikipedia/blockade.html
@@ -1,31 +1,21 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Blockade</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Blockade is a solitaire card game which uses two decks of 52
-playing cards each. Akin to solitaire games like Klondike and
-Gargantua, the object of the game is play the cards into the eight
-foundations.</p>
-<p>The game starts with twelve piles, each containing a card (the
-rest form the stock). Cards are built down by suit (e.g., 7-6-5-4)
-and cards or groups of cards can be moved from one pile to another
-or to the foundations. The foundations are built up also by suit,
-starting from the ace. An empty pile will be filled up immediately
-by a card from the stock.</p>
-<p>When all possible moves are done without success, a card is
-dealt onto each pile, even with those that have sequences. This and
-the placing of cards on empty piles is done until the stock runs
-out. After that, any card or group of cards can be placed on any
-empty space.</p>
-<p>The game is won when all 104 cards are successfully moved to the
-foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Blockade_%28solitaire%29">http://en.wikipedia.org/wiki/Blockade_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Blockade is a solitaire card game which uses two decks of 52 playing cards
+each. Akin to solitaire games like Klondike and Gargantua, the object of the
+game is play the cards into the eight foundations.
+<p>
+The game starts with twelve piles, each containing a card (the rest form the
+stock). Cards are built down by suit (e.g., 7-6-5-4) and cards or groups of
+cards can be moved from one pile to another or to the foundations. The
+foundations are built up also by suit, starting from the ace. An empty pile
+will be filled up immediately by a card from the stock.
+<p>
+When all possible moves are done without success, a card is dealt onto each
+pile, even with those that have sequences. This and the placing of cards on
+empty piles is done until the stock runs out. After that, any card or group of
+cards can be placed on any empty space.
+<p>
+The game is won when all 104 cards are successfully moved to the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Blockade_%28solitaire%29">http://en.wikipedia.org/wiki/Blockade_(solitaire)</a>)</i>

--- a/html-src/wikipedia/britishconstitution.html
+++ b/html-src/wikipedia/britishconstitution.html
@@ -1,50 +1,41 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>British Constitution</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>British Constitution (or simply Constitution) is a solitaire
-card game which is played with two decks of playing cards. It is a
-card game with a high chance in winning.</p>
-<p>First, the kings, queens, and aces are removed from the stock.
-The kings and queens are discarded, while the aces are placed in a
-row to form the "Government" or the foundations, which are built up
-by suit to jacks.</p>
-<p>Below the aces, four rows of eight cards each are dealt. This
-forms the tableau (also known as the "Constitution").</p>
-<p>The cards available for building in the foundations should come
-from Row 1 (also known as the "Privy Council") only. Furthermore,
-cards in Row 1 can be built down by alternating colors. Available
-for building in Row 1 are the top cards of the piles in Row 1
-(initially containing only one card per pile) and the cards from
-Row 2. Only one card can be moved at a time.</p>
-<p>When a card leaves from either Row 1 or 2, the space it leaves
-behind must be filled with any card from the row immediately below
-it, not necessarily the one immediately below the space. The space,
-in essence, is pushed downwards until it reaches Row 4 (the "People
-Row"), where it is filled with a card from the stock. This is the
-only way cards from the stock enter the game. Furthermore, cards
-from the stock cannot be played directly to the foundations. If no
-more spaces appear in Row 4 with cards still undealt from the
-stock, the game is lost.</p>
-<p>The game is won when all cards are built in the foundations up
-to jacks.</p>
-<p>Lady Cadogan's rule set specified that as the tableau is being
-set up, one Queen of Diamonds and the eight kings are put above the
-foundations; the <b>Q</b><img src="../images/d.gif" /> being "The
-Sovereign," the black Kings being the "Bishops," and the red Kings
-the "Judges," all placed above the foundation. The other Queens are
-discarded. Since these nine cards clearly play a purely decorative
-role in this game, most modern rule sets bypass this, which
-explains the reason the kings and queens are discarded completely
-as mentioned above.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/British_Constitution_%28solitaire%29">
-http://en.wikipedia.org/wiki/British_Constitution_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+British Constitution (or simply Constitution) is a solitaire card game which
+is played with two decks of playing cards. It is a card game with a high
+chance in winning.
+<p>
+First, the kings, queens, and aces are removed from the stock. The kings and
+queens are discarded, while the aces are placed in a row to form the
+"Government" or the foundations, which are built up by suit to jacks.
+<p>
+Below the aces, four rows of eight cards each are dealt. This forms the
+tableau (also known as the "Constitution").
+<p>
+The cards available for building in the foundations should come from Row 1
+(also known as the "Privy Council") only. Furthermore, cards in Row 1 can be
+built down by alternating colors. Available for building in Row 1 are the top
+cards of the piles in Row 1 (initially containing only one card per pile) and
+the cards from Row 2. Only one card can be moved at a time.
+<p>
+When a card leaves from either Row 1 or 2, the space it leaves behind must be
+filled with any card from the row immediately below it, not necessarily the
+one immediately below the space. The space, in essence, is pushed downwards
+until it reaches Row 4 (the "People Row"), where it is filled with a card from
+the stock. This is the only way cards from the stock enter the game.
+Furthermore, cards from the stock cannot be played directly to the
+foundations. If no more spaces appear in Row 4 with cards still undealt from
+the stock, the game is lost.
+<p>
+The game is won when all cards are built in the foundations up to jacks.
+<p>
+Lady Cadogan's rule set specified that as the tableau is being set up, one
+Queen of Diamonds and the eight kings are put above the foundations; the
+<b>Q</b><img src="../images/d.gif"> being "The Sovereign," the black Kings
+being the "Bishops," and the red Kings the "Judges," all placed above the
+foundation. The other Queens are discarded. Since these nine cards clearly
+play a purely decorative role in this game, most modern rule sets bypass this,
+which explains the reason the kings and queens are discarded completely as
+mentioned above.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/British_Constitution_%28solitaire%29">http://en.wikipedia.org/wiki/British_Constitution_(solitaire)</a>)</i>

--- a/html-src/wikipedia/capricieuse.html
+++ b/html-src/wikipedia/capricieuse.html
@@ -1,37 +1,31 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Capricieuse</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Capricieuse (or Capricious) is a solitaire card game which is
-played using two decks of playing cards.</p>
-<p>The entire deck must be dealt into twelve piles of cards. Any
-arrangement will do, but for convenience, two rows of six piles
-each will be form. During dealing, one Ace and one King of each
-suit is removed, all of which will form the foundations. The Aces
-are built up while the Kings are built down, all by suit.</p>
-<p>During the process of dealing the twelve piles, cards that can
-be built on a foundation must be built. Also, none of the twelve
-piles should be left out, i.e. when a card is immediately built on
-a foundation, the next card is dealt on the pile the previous card
-left.</p>
-<p>No building is done during the process of dealing until all
-cards are dealt. Afterwards, the top cards of each pile are built
-on the foundations or on each other's piles. The cards on the piles
-are built on each other either up or down by suit. Building can go
-on both directions, but a King cannot be placed over an Ace and
-vice versa. Only one card can be moved at a time, and any empty
-pile can be filled with any card.</p>
-<p>After the player has made all the moves he can make, the piles
-are collected in the reverse order the piles are dealt and the
-process is repeated. This redeal can be done twice in the game.</p>
-<p>The game is won when all cards end up in the foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Capricieuse">http://en.wikipedia.org/wiki/Capricieuse</a>)</i></p>
-</body>
-</html>
+<p>
+Capricieuse (or Capricious) is a solitaire card game which is played using two
+decks of playing cards.
+<p>
+The entire deck must be dealt into twelve piles of cards. Any arrangement will
+do, but for convenience, two rows of six piles each will be form. During
+dealing, one Ace and one King of each suit is removed, all of which will form
+the foundations. The Aces are built up while the Kings are built down, all by
+suit.
+<p>
+During the process of dealing the twelve piles, cards that can be built on a
+foundation must be built. Also, none of the twelve piles should be left out,
+i.e. when a card is immediately built on a foundation, the next card is dealt
+on the pile the previous card left.
+<p>
+No building is done during the process of dealing until all cards are dealt.
+Afterwards, the top cards of each pile are built on the foundations or on each
+other's piles. The cards on the piles are built on each other either up or
+down by suit. Building can go on both directions, but a King cannot be placed
+over an Ace and vice versa. Only one card can be moved at a time, and any
+empty pile can be filled with any card.
+<p>
+After the player has made all the moves he can make, the piles are collected
+in the reverse order the piles are dealt and the process is repeated. This
+redeal can be done twice in the game.
+<p>
+The game is won when all cards end up in the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Capricieuse">http://en.wikipedia.org/wiki/Capricieuse</a>)</i>

--- a/html-src/wikipedia/captivequeens.html
+++ b/html-src/wikipedia/captivequeens.html
@@ -1,44 +1,37 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Captive Queens</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Captive Queens is a solitaire card game using a deck of 52
-playing cards. The game is so named because the queens are being
-"enclosed" as the foundations are built.</p>
-<p>There are two ways that the queens are played in this game:
-either they are laid in the center of the tableau immediately or
-shuffled into the deck and laid out later. Either way, their role
-is just purely decorative and have no further part in the game.</p>
-<p>The game starts by laying the cards from the stock one at a time
-into a wastepile in search for fives or sixes. Once any of these
-cards are found, it becomes a foundation and can be placed on a
-circle surrounding the area where queens are placed; it can be
-built upon immediately. The foundations' places in this circle are
-irrelevant.</p>
-<p>The fives are built down and the sixes are built up, all by
-suit. Here's the chart of which cards are placed on these
-cards:</p>
+<p>
+Captive Queens is a solitaire card game using a deck of 52 playing cards. The
+game is so named because the queens are being "enclosed" as the foundations
+are built.
+<p>
+There are two ways that the queens are played in this game: either they are
+laid in the center of the tableau immediately or shuffled into the deck and
+laid out later. Either way, their role is just purely decorative and have no
+further part in the game.
+<p>
+The game starts by laying the cards from the stock one at a time into a
+wastepile in search for fives or sixes. Once any of these cards are found, it
+becomes a foundation and can be placed on a circle surrounding the area where
+queens are placed; it can be built upon immediately. The foundations' places
+in this circle are irrelevant.
+<p>
+The fives are built down and the sixes are built up, all by suit. Here's the
+chart of which cards are placed on these cards:
 <pre>
 5  4  3  2  A  K
 6  7  8  9 10  J
 </pre>
-<p>After the foundation cards are found, the rest of the stock is
-dealt to look for cards that can be built in to the foundations. In
-case the queens are shuffled into the deck, when a queen is found,
-it is placed on the center.</p>
-<p>Once the stock runs out, the cards are gathered from the
-wastepile and become the new stock from which cards are to be
-dealt. This can only be done twice in the whole game.</p>
-<p>The game is won when all the cards are in the foundations with
-the face cards (kings and jacks) are at the top of each
-foundation.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Captive_Queens">http://en.wikipedia.org/wiki/Captive_Queens</a>)</i></p>
-</body>
-</html>
+<p>
+After the foundation cards are found, the rest of the stock is dealt to look
+for cards that can be built in to the foundations. In case the queens are
+shuffled into the deck, when a queen is found, it is placed on the center.
+<p>
+Once the stock runs out, the cards are gathered from the wastepile and become
+the new stock from which cards are to be dealt. This can only be done twice in
+the whole game.
+<p>
+The game is won when all the cards are in the foundations with the face cards
+(kings and jacks) are at the top of each foundation.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Captive_Queens">http://en.wikipedia.org/wiki/Captive_Queens</a>)</i>

--- a/html-src/wikipedia/colorado.html
+++ b/html-src/wikipedia/colorado.html
@@ -1,43 +1,35 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Colorado</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Colorado is a solitaire card game which is played using two
-decks of playing cards. It is a game of card-building which belongs
-to the same family as <i>Strategy</i>, <i>Sir Tommy</i>,
-<i>Calculation</i> and <i>Sly Fox</i>.</p>
-<p>First, twenty cards are dealt in any arrangement the player
-desires; it is suggested that cards should be two rows of ten cards
-each.</p>
-<p>Then the player searches for an Ace and a King of each suit.
-These cards should go to the foundations whenever they become
-available for play. The foundations that start with the Aces are
-built up by suit, while those that start with Kings are built down
-by suit. The spaces that they left behind are immediately filled
-with cards from the stock.</p>
-<p>The stock is then dealt one card at a time, and any card that
-cannot be built yet to the foundations is placed on one of the 20
-cards which are in fact bases for waste piles. When placing cards
-onto a wastepile, they do not have to follow suit or rank. However,
-there is no building; when a card is placed on a waste pile, the
-only place it would go is to a foundation.</p>
-<p>After each deal, the player will determine if any of the cards
-on the waste piles can be built onto the foundations.</p>
-<p>Again, whenever a waste pile becomes empty, no matter how many
-cards it previously had, it is filled with a card from the
-wastepile. This is the only way an empty pile is refilled because
-when the stock runs out, spaces are no longer filled.</p>
-<p>The game ends soon after the stock has run out. The game is won
-when all cards are built into the foundations; but when there are
-still cards that are stuck and cannot be possibly released, the
-game is lost.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Colorado_%28solitaire%29">http://en.wikipedia.org/wiki/Colorado_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Colorado is a solitaire card game which is played using two decks of playing
+cards. It is a game of card-building which belongs to the same family as
+<i>Strategy</i>, <i>Sir Tommy</i>, <i>Calculation</i> and <i>Sly Fox</i>.
+<p>
+First, twenty cards are dealt in any arrangement the player desires; it is
+suggested that cards should be two rows of ten cards each.
+<p>
+Then the player searches for an Ace and a King of each suit. These cards
+should go to the foundations whenever they become available for play. The
+foundations that start with the Aces are built up by suit, while those that
+start with Kings are built down by suit. The spaces that they left behind are
+immediately filled with cards from the stock.
+<p>
+The stock is then dealt one card at a time, and any card that cannot be built
+yet to the foundations is placed on one of the 20 cards which are in fact
+bases for waste piles. When placing cards onto a wastepile, they do not have
+to follow suit or rank. However, there is no building; when a card is placed
+on a waste pile, the only place it would go is to a foundation.
+<p>
+After each deal, the player will determine if any of the cards on the waste
+piles can be built onto the foundations.
+<p>
+Again, whenever a waste pile becomes empty, no matter how many cards it
+previously had, it is filled with a card from the wastepile. This is the only
+way an empty pile is refilled because when the stock runs out, spaces are no
+longer filled.
+<p>
+The game ends soon after the stock has run out. The game is won when all cards
+are built into the foundations; but when there are still cards that are stuck
+and cannot be possibly released, the game is lost.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Colorado_%28solitaire%29">http://en.wikipedia.org/wiki/Colorado_(solitaire)</a>)</i>

--- a/html-src/wikipedia/contradance.html
+++ b/html-src/wikipedia/contradance.html
@@ -1,30 +1,22 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Contradance</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Contradance (also known as Cotillion) is a solitaire card game
-which is played with two decks of playing cards. It is probably so
-called because when the game is won, it shows the king and the
-queen of each suit about to do a dance. It should not be confused
-with another solitaire game of Royal Cotillion.</p>
-<p>Before the game starts, all fives and sixes are separated from
-the shuffled decks and placed on the table. These sixteen cards are
-the foundations; the fives are built down to aces, then kings,
-while the sixes are built up to queens, all by suit.</p>
-<p>The stock is dealt one at a time, and cards that cannot be built
-yet on the foundations are placed on a wastepile, the top card of
-which is available for play on the foundations. The predominant
-rule sets allow only one redeal. To do this, the unplayed cards on
-the wastepile are picked up and turned face down to make the new
-stock.</p>
-<p>The game is won when all cards are built on the foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Contradance_%28solitaire%29">http://en.wikipedia.org/wiki/Contradance_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Contradance (also known as Cotillion) is a solitaire card game which is played
+with two decks of playing cards. It is probably so called because when the
+game is won, it shows the king and the queen of each suit about to do a dance.
+It should not be confused with another solitaire game of Royal Cotillion.
+<p>
+Before the game starts, all fives and sixes are separated from the shuffled
+decks and placed on the table. These sixteen cards are the foundations; the
+fives are built down to aces, then kings, while the sixes are built up to
+queens, all by suit.
+<p>
+The stock is dealt one at a time, and cards that cannot be built yet on the
+foundations are placed on a wastepile, the top card of which is available for
+play on the foundations. The predominant rule sets allow only one redeal. To
+do this, the unplayed cards on the wastepile are picked up and turned face
+down to make the new stock.
+<p>
+The game is won when all cards are built on the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Contradance_%28solitaire%29">http://en.wikipedia.org/wiki/Contradance_(solitaire)</a>)</i>

--- a/html-src/wikipedia/curdsandwhey.html
+++ b/html-src/wikipedia/curdsandwhey.html
@@ -1,44 +1,39 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Curds and Whey</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Curds and Whey is a solitaire card game which uses a deck of 52
-playing cards. Invented by David Parlett, this game belongs to the
-family of solitaire games that includes Spider and Scorpion.</p>
-<p>The cards are dealt into 13 piles (or columns) of four cards
-each. The top card of each pile is available for play.</p>
-<p>There are no foundations in this game; the object is to form
-four suit sequences each running from King down to Ace.</p>
-<p>A card can be built in only two ways:</p>
+<p>
+Curds and Whey is a solitaire card game which uses a deck of 52 playing cards.
+Invented by David Parlett, this game belongs to the family of solitaire games
+that includes Spider and Scorpion.
+<p>
+The cards are dealt into 13 piles (or columns) of four cards each. The top
+card of each pile is available for play.
+<p>
+There are no foundations in this game; the object is to form four suit
+sequences each running from King down to Ace.
+<p>
+A card can be built in only two ways:
 <ul>
-<li>Over a card that is of the same suit and of a higher rank,
-or</li>
-<li>Over a card that is of the same rank but of a different
-suit.</li>
+<li>Over a card that is of the same suit and of a higher rank, or
+<li>Over a card that is of the same rank but of a different suit.
 </ul>
-<p>For example, the 8 of spades can be built over the 9 of spades
-or any other 8 (such as the 8 of clubs).</p>
-<p>One card can be moved at a time unless a sequence has been made.
-If a sequence of cards follows either one of the following two
-guidelines:</p>
+<p>
+For example, the 8 of spades can be built over the 9 of spades or any other 8
+(such as the 8 of clubs).
+<p>
+One card can be moved at a time unless a sequence has been made. If a sequence
+of cards follows either one of the following two guidelines:
 <ul>
-<li>Sequences that are built down by suit</li>
-<li>Sequences of cards with the same rank</li>
+<li>Sequences that are built down by suit
+<li>Sequences of cards with the same rank
 </ul>
-...it can be moved as a unit in part or in whole. However, a
-sequence that follows both guidelines at once must be rearranged to
-follow only one guideline before moving as a unit.
-<p>When a column becomes empty, it can only be filled by a King or
-a sequence starting with a King.</p>
-<p>The game is won when the object above is fulfilled, forming four
-suit sequences each running from King down to Ace.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Curds_and_Whey">http://en.wikipedia.org/wiki/Curds_and_Whey</a>)</i></p>
-</body>
-</html>
+...it can be moved as a unit in part or in whole. However, a sequence that
+follows both guidelines at once must be rearranged to follow only one
+guideline before moving as a unit.
+<p>
+When a column becomes empty, it can only be filled by a King or a sequence
+starting with a King.
+<p>
+The game is won when the object above is fulfilled, forming four suit
+sequences each running from King down to Ace.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Curds_and_Whey">http://en.wikipedia.org/wiki/Curds_and_Whey</a>)</i>

--- a/html-src/wikipedia/emperor.html
+++ b/html-src/wikipedia/emperor.html
@@ -1,41 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Emperor</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Emperor (or The Emperor) is a solitaire card game which is
-played using two decks of playing cards. Its rules are not so
-clearly explained that it has at least two versions, one of which
-is exactly like Rank and File, a variant of Forty Thieves. But it
-also one card game that lends itself to "forethough and much
-integrity," according to author Peter Arnold.</p>
-<p>The set-up of the tableau is not clearly defined either. The
-prevalent version prescribes that forty cards are set up into ten
-columns of four cards each. Each column should have its bottom
-three cards face down and its top card face up. The three face down
-cards are collectively known as a "sealed" packet.</p>
-<p>The goal of this game is to put the aces in the foundations as
-soon as they are available and build each of them up to kings.</p>
-<p>All the exposed (face-up) cards are available for play, to be
-built on the foundations or on other exposed cards on the tableau,
-and when an face-down card becomes fully exposed, it is turned
-face-up. Building in the tableau is down by alternating color. Some
-rule sets (like that of Solsuite) allow moving of packed sequences
-as a single unit, making it like Rank and File, while other rule
-sets (such as that of Pretty Good Solitaire) don't allow moving of
-sequences.</p>
-<p>When all possible moves are made, the stock is dealt one at a
-time. A card that cannot be played yet onto tableau or on the
-foundations is placed on the waste pile, the top card of which is
-available for play.</p>
-<p>The game ends soon after the stock has run out. The game is won
-when all cards are built onto the foundations.</p>
-<p><i>(Retrieved From <a href=
-"http://en.wikipedia.org/wiki/Emperor_%28solitaire%29">http://en.wikipedia.org/wiki/Emperor_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Emperor (or The Emperor) is a solitaire card game which is played using two
+decks of playing cards. Its rules are not so clearly explained that it has at
+least two versions, one of which is exactly like Rank and File, a variant of
+Forty Thieves. But it also one card game that lends itself to "forethough and
+much integrity," according to author Peter Arnold.
+<p>
+The set-up of the tableau is not clearly defined either. The prevalent version
+prescribes that forty cards are set up into ten columns of four cards each.
+Each column should have its bottom three cards face down and its top card face
+up. The three face down cards are collectively known as a "sealed" packet.
+<p>
+The goal of this game is to put the aces in the foundations as soon as they
+are available and build each of them up to kings.
+<p>
+All the exposed (face-up) cards are available for play, to be built on the
+foundations or on other exposed cards on the tableau, and when an face-down
+card becomes fully exposed, it is turned face-up. Building in the tableau is
+down by alternating color. Some rule sets (like that of Solsuite) allow moving
+of packed sequences as a single unit, making it like Rank and File, while
+other rule sets (such as that of Pretty Good Solitaire) don't allow moving of
+sequences.
+<p>
+When all possible moves are made, the stock is dealt one at a time. A card
+that cannot be played yet onto tableau or on the foundations is placed on the
+waste pile, the top card of which is available for play.
+<p>
+The game ends soon after the stock has run out. The game is won when all cards
+are built onto the foundations.
+<p>
+<i>(Retrieved From <a href="http://en.wikipedia.org/wiki/Emperor_%28solitaire%29">http://en.wikipedia.org/wiki/Emperor_(solitaire)</a>)</i>

--- a/html-src/wikipedia/flowergarden.html
+++ b/html-src/wikipedia/flowergarden.html
@@ -1,33 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Flower Garden</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Flower Garden is a solitaire card game using a deck of 52
-playing cards. It is not known why the game is called such, but the
-terms used in this game do have a relation to those in gardening
-and it takes merit that some skill is needed. It is also known
-under the names <i>The Bouquet</i> and <i>The Garden</i>.</p>
-<p>Thirty-six cards are dealt in to six columns, each containing
-six cards. The columns are called the "flower beds" and the entire
-tableau is sometimes called "the garden." The sixteen leftover
-cards become the reserve, or "the bouquet."</p>
-<p>The top cards of each flower-bed and all of the cards in the
-bouquet are available for play. Cards can only be moved one at a
-time and can be built either on the foundations or on the other
-flower beds. The foundations are built up by suit, from Ace to King
-(a general idea of the game is to release the aces first). The
-cards in the garden, on the other hand, can be built down
-regardless of suit and any empty flower bed can be filled with any
-card. The cards in the bouquet can be used to aid in building, be
-put into the foundations, or fill an empty flower bed.</p>
-<p>The game is won when all cards end up in the foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Flower_Garden_%28solitaire%29">http://en.wikipedia.org/wiki/Flower_Garden_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Flower Garden is a solitaire card game using a deck of 52 playing cards. It is
+not known why the game is called such, but the terms used in this game do have
+a relation to those in gardening and it takes merit that some skill is needed.
+It is also known under the names <i>The Bouquet</i> and <i>The Garden</i>.
+<p>
+Thirty-six cards are dealt in to six columns, each containing six cards. The
+columns are called the "flower beds" and the entire tableau is sometimes
+called "the garden." The sixteen leftover cards become the reserve, or "the
+bouquet."
+<p>
+The top cards of each flower-bed and all of the cards in the bouquet are
+available for play. Cards can only be moved one at a time and can be built
+either on the foundations or on the other flower beds. The foundations are
+built up by suit, from Ace to King (a general idea of the game is to release
+the aces first). The cards in the garden, on the other hand, can be built down
+regardless of suit and any empty flower bed can be filled with any card. The
+cards in the bouquet can be used to aid in building, be put into the
+foundations, or fill an empty flower bed.
+<p>
+The game is won when all cards end up in the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Flower_Garden_%28solitaire%29">http://en.wikipedia.org/wiki/Flower_Garden_(solitaire)</a>)</i>

--- a/html-src/wikipedia/fortunesfavor.html
+++ b/html-src/wikipedia/fortunesfavor.html
@@ -1,33 +1,24 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Fortune's Favor</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Fortune's Favor is a solitaire card game which is playing with a
-deck of 52 playing cards. It is so-called probably because the
-chances of winning are completely on the player's side.</p>
-<p>First, the four aces are removed from the deck and placed in a
-row to form the bases of the foundations. These foundations are
-built up by suit to kings.</p>
-<p>Below the foundations, two rows of six cards each (or any
-preferred arrangement of twelve cards) are dealt. These form the
-bases of the twelve tableau piles. The top cards on the tableau
-piles are available for building on the foundations and on the
-tableau. Building in the tableau is down by suit and spaces which
-result in moving a card is filled from the wastepile or, if there
-is none, the stock. Only one card can be moved at a time.</p>
-<p>The stock, when play goes on a standstill, is dealt one card at
-a time onto a wastepile, the top card of which is available for
-play on the tableau or foundations.</p>
-<p>The game is won when all cards are built onto the
-foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Fortune%27s_Favor">http://en.wikipedia.org/wiki/Fortune's
-Favor</a>)</i></p>
-</body>
-</html>
+<p>
+Fortune's Favor is a solitaire card game which is playing with a deck of 52
+playing cards. It is so-called probably because the chances of winning are
+completely on the player's side.
+<p>
+First, the four aces are removed from the deck and placed in a row to form the
+bases of the foundations. These foundations are built up by suit to kings.
+<p>
+Below the foundations, two rows of six cards each (or any preferred
+arrangement of twelve cards) are dealt. These form the bases of the twelve
+tableau piles. The top cards on the tableau piles are available for building
+on the foundations and on the tableau. Building in the tableau is down by suit
+and spaces which result in moving a card is filled from the wastepile or, if
+there is none, the stock. Only one card can be moved at a time.
+<p>
+The stock, when play goes on a standstill, is dealt one card at a time onto a
+wastepile, the top card of which is available for play on the tableau or
+foundations.
+<p>
+The game is won when all cards are built onto the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Fortune%27s_Favor">http://en.wikipedia.org/wiki/Fortune's Favor</a>)</i>

--- a/html-src/wikipedia/fourseasons.html
+++ b/html-src/wikipedia/fourseasons.html
@@ -1,58 +1,48 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Four Seasons</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Four Seasons is a solitaire card game which is played with a
-deck of playing cards. It is given the more appropriate alternate
-names of <b>Corner Card</b> and <b>Vanishing Cross</b> because of
-where the foundations are placed and the arrangement of the tableau
-respectively.</p>
-<p>First, five cards are dealt in form of a cross: three cards are
-placed in a row, then two cards are each placed above and below the
-middle of the three cards. A sixth card is dealt in the upper left
-corner of the cross. This card will be the base for the first of
-four foundations. The three cards of the same rank are placed in
-the other three corners of the cross to become the foundations
-themselves.</p>
-<p>The foundations are built up in suit and building is
-round-the-corner, i.e. aces are placed above kings, except when
-aces are the foundation bases.</p>
-<p>Cards in the cross are built down regardless of suit and any
-space in the cross is filled with any available card, whether it is
-the top card of a pile within the cross, the top card of the
-wastepile, or a card from the stock. Like the foundations, building
-in the cross is round-the-corner, i.e. kings are placed over aces,
-unless aces are the foundations. Only one card can be moved at a
-time.</p>
-<p>Whenever the game goes on a standstill, the stock is dealt one
-card at a time into the wastepile, the top card of which is
-available for play on the cross or on the foundations. There is no
-redeal.</p>
-<p>The game ends when goes on another standstill after the stock
-has run out. The game is won when all cards end up in the
-foundations.</p>
+<p>
+Four Seasons is a solitaire card game which is played with a deck of playing
+cards. It is given the more appropriate alternate names of <b>Corner Card</b>
+and <b>Vanishing Cross</b> because of where the foundations are placed and the
+arrangement of the tableau respectively.
+<p>
+First, five cards are dealt in form of a cross: three cards are placed in a
+row, then two cards are each placed above and below the middle of the three
+cards. A sixth card is dealt in the upper left corner of the cross. This card
+will be the base for the first of four foundations. The three cards of the
+same rank are placed in the other three corners of the cross to become the
+foundations themselves.
+<p>
+The foundations are built up in suit and building is round-the-corner, i.e.
+aces are placed above kings, except when aces are the foundation bases.
+<p>
+Cards in the cross are built down regardless of suit and any space in the
+cross is filled with any available card, whether it is the top card of a pile
+within the cross, the top card of the wastepile, or a card from the stock.
+Like the foundations, building in the cross is round-the-corner, i.e. kings
+are placed over aces, unless aces are the foundations. Only one card can be
+moved at a time.
+<p>
+Whenever the game goes on a standstill, the stock is dealt one card at a time
+into the wastepile, the top card of which is available for play on the cross
+or on the foundations. There is no redeal.
+<p>
+The game ends when goes on another standstill after the stock has run out. The
+game is won when all cards end up in the foundations.
+<p>
 <h3>Variations</h3>
-<p>Below are the variations of Four Seasons:</p>
+<p>
+Below are the variations of Four Seasons:
 <ul>
-<li>In <b>Czarina</b>, any space in the cross is immediately filled
-only from the stock.</li>
-<li>In <b>Corners</b>, the cross is in fact a reserve, not a
-tableau, and each space is a cell, which should have room for only
-one card. Empty cells in this game are filled immediately from the
-stock.</li>
-<li><b>Simplicity</b> is played like Four Seasons. The only
-exception is that the tableau (instead of a cross) contains twelve
-cards dealt into two rows of six. The thirteenth card deal becomes
-the base of the first formation. Also, building in the tableau is
-down by alternating colors.</li>
+<li>In <b>Czarina</b>, any space in the cross is immediately filled only from
+the stock.
+<li>In <b>Corners</b>, the cross is in fact a reserve, not a tableau, and each
+space is a cell, which should have room for only one card. Empty cells in this
+game are filled immediately from the stock.
+<li><b>Simplicity</b> is played like Four Seasons. The only exception is that
+the tableau (instead of a cross) contains twelve cards dealt into two rows of
+six. The thirteenth card deal becomes the base of the first formation. Also,
+building in the tableau is down by alternating colors.
 </ul>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Four_Seasons_%28solitaire%29">http://en.wikipedia.org/wiki/Four_Seasons_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Four_Seasons_%28solitaire%29">http://en.wikipedia.org/wiki/Four_Seasons_(solitaire)</a>)</i>

--- a/html-src/wikipedia/frog.html
+++ b/html-src/wikipedia/frog.html
@@ -1,48 +1,42 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Frog</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Frog (also known as Toad) is a solitaire card game which is
-played with two decks of playing cards. Because of its gameplay, it
-belongs to the same family of solitaire games as Strategy, Sir
-Tommy, Calculation, and Puss in the Corner.</p>
-<p>Thirteen cards are dealt face up to become the reserve, also
-known as the "Frog." Any aces that are about to be dealt are
-separated and placed in the foundations; they are not counted in
-the reserve count. Once the reserve is formed, it is then squared
-up (i. e. arranged to become one neat pile) and placed on the
-tableau face up. The aces that are separated in making the reserve
-are placed next to the reserve. If case there is no ace segregated
-in making the reserve, an ace is removed from the stock to become
-the first foundation.</p>
-<p>The foundations are built up regardless of suit up to kings. The
-aces already in the foundations can be built immediately while any
-ace that becomes available in the game is placed in the
-foundations.</p>
-<p>The cards are dealt one at a time onto one of five wastepiles.
-It is the player's discretion where each pile is placed as long as
-it is placed in one of only five wastepiles. The top cards of each
-wastepile is available for play to the foundations. The same goes
-for the top card of the reserve. However, once a card is in a
-wastepile, it stays there until it can be built on the foundations.
-Also, there is no redeal.</p>
-<p>The game ends long after the stock runs out. The game is won
-when all cards are built in the foundations.</p>
-<p>As in the other games mentioned above, it is a good idea to
-reserve a wastepile for both kings and queens and to build
-downwards whenever possible in order to win.</p>
+<p>
+Frog (also known as Toad) is a solitaire card game which is played with two
+decks of playing cards. Because of its gameplay, it belongs to the same family
+of solitaire games as Strategy, Sir Tommy, Calculation, and Puss in the
+Corner.
+<p>
+Thirteen cards are dealt face up to become the reserve, also known as the
+"Frog." Any aces that are about to be dealt are separated and placed in the
+foundations; they are not counted in the reserve count. Once the reserve is
+formed, it is then squared up (i. e. arranged to become one neat pile) and
+placed on the tableau face up. The aces that are separated in making the
+reserve are placed next to the reserve. If case there is no ace segregated in
+making the reserve, an ace is removed from the stock to become the first
+foundation.
+<p>
+The foundations are built up regardless of suit up to kings. The aces already
+in the foundations can be built immediately while any ace that becomes
+available in the game is placed in the foundations.
+<p>
+The cards are dealt one at a time onto one of five wastepiles. It is the
+player's discretion where each pile is placed as long as it is placed in one
+of only five wastepiles. The top cards of each wastepile is available for play
+to the foundations. The same goes for the top card of the reserve. However,
+once a card is in a wastepile, it stays there until it can be built on the
+foundations. Also, there is no redeal.
+<p>
+The game ends long after the stock runs out. The game is won when all cards
+are built in the foundations.
+<p>
+As in the other games mentioned above, it is a good idea to reserve a
+wastepile for both kings and queens and to build downwards whenever possible
+in order to win.
+
 <h3>Fly</h3>
-<p>Fly is a solitaire card game which is played the same way as
-Frog. The difference is that the Aces are removed and placed in the
-foundations before the game begins. In this game, the reserve is
-called the "Fly."</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Frog_%28game%29">http://en.wikipedia.org/wiki/Frog_(game)</a>)</i></p>
-</body>
-</html>
+<p>
+Fly is a solitaire card game which is played the same way as Frog. The
+difference is that the Aces are removed and placed in the foundations before
+the game begins. In this game, the reserve is called the "Fly."
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Frog_%28game%29">http://en.wikipedia.org/wiki/Frog_(game)</a>)</i>

--- a/html-src/wikipedia/gate.html
+++ b/html-src/wikipedia/gate.html
@@ -1,45 +1,39 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Gate</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Gate is a solitaire card game which is playing using a deck of
-52 playing cards. It is called such because the cards are laid own
-in such a way that they form a gate.</p>
-<p>First, two columns of five cards are laid out face-up with their
-faces showing. These act as the reserve or "gate posts." Then,
-between these columns, two rows of four cards are dealt, again
-face-up. These compose the "rails" or the tableau. The spaces for
-the foundations are allotted over the first row of cards.</p>
-<p>The object of the game, like solitaire games, is to find the
-aces, place then onto the foundations, and build each of them up by
-suit to kings.</p>
-<p>The cards in the rails are available for play, to be placed on
-the foundations or onto other cards in the rail. The cards in the
-rails are built down by alternating color (a card with a red suit
-over a one with a black suit, and vice versa). Spaces in the rails
-are filled using cards from the gate posts. If the cards in the
-gate posts are used up, the top card of the wastepile, or the next
-card in the stock if there is no wastepile, can be used to fill
-spaces. The gate posts are never replenished.</p>
-<p>Generally, one card can be moved at a time. The most prevalent
-rule regarding moves of sequences is that sequences can be moved as
-a whole. However, there is a rule set which does not allow moving
-groups of cards, effectively making the game harder (mentioned in
-<i>Card Games Made Easy</i> by Marks and Harrod, ISBN
-1-899606-17-3).</p>
-<p>The stock can be dealt one card at a time to a wastepile. The
-top card of which is available for play, either to placed in on the
-foundations or on the rails, or to fill a gap on the rails.
-However, once the stock runs out, there are no redeals.</p>
-<p>The game ends soon after the stock runs out. The game is won
-when all cards are played to the foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Gate_%28solitaire%29">http://en.wikipedia.org/wiki/Gate_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Gate is a solitaire card game which is playing using a deck of 52 playing
+cards. It is called such because the cards are laid own in such a way that
+they form a gate.
+<p>
+First, two columns of five cards are laid out face-up with their faces
+showing. These act as the reserve or "gate posts." Then, between these
+columns, two rows of four cards are dealt, again face-up. These compose the
+"rails" or the tableau. The spaces for the foundations are allotted over the
+first row of cards.
+<p>
+The object of the game, like solitaire games, is to find the aces, place then
+onto the foundations, and build each of them up by suit to kings.
+<p>
+The cards in the rails are available for play, to be placed on the foundations
+or onto other cards in the rail. The cards in the rails are built down by
+alternating color (a card with a red suit over a one with a black suit, and
+vice versa). Spaces in the rails are filled using cards from the gate posts.
+If the cards in the gate posts are used up, the top card of the wastepile, or
+the next card in the stock if there is no wastepile, can be used to fill
+spaces. The gate posts are never replenished.
+<p>
+Generally, one card can be moved at a time. The most prevalent rule regarding
+moves of sequences is that sequences can be moved as a whole. However, there
+is a rule set which does not allow moving groups of cards, effectively making
+the game harder (mentioned in <i>Card Games Made Easy</i> by Marks and Harrod,
+ISBN 1-899606-17-3).
+<p>
+The stock can be dealt one card at a time to a wastepile. The top card of
+which is available for play, either to placed in on the foundations or on the
+rails, or to fill a gap on the rails. However, once the stock runs out, there
+are no redeals.
+<p>
+The game ends soon after the stock runs out. The game is won when all cards
+are played to the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Gate_%28solitaire%29">http://en.wikipedia.org/wiki/Gate_(solitaire)</a>)</i>

--- a/html-src/wikipedia/germanpatience.html
+++ b/html-src/wikipedia/germanpatience.html
@@ -1,37 +1,28 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>German Patience</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>German Patience is a solitaire card game which is played with
-two decks of playing cards shuffled together. It is an unusual game
-because building in the tableau or playing area is up, as opposed
-to building down in many others. Despite its name, it is not known
-if this game originated from Germany.</p>
-<p>The object of this game is to form eight columns of thirteen
-cards each. Each column starts with any card and ends with the card
-a rank lower than the first. In this game, building is
-round-the-corner, i.e. an Ace can be built over a King and a Deuce
-(or Two card) can be placed over an Ace.</p>
-<p>At the start of the game, each column in the tableau starts with
-one card. The cards in the tableau are built up regardless of suit.
-Only the top card of each column is available for play and cards
-are moved one at a time. Spaces can be filled with any card.</p>
-<p>When there are no more moves that can be make, the stock is
-dealt one a time. Any card that cannot be placed onto the tableau
-yet is placed on the waste pile, the top card of which is available
-for play.</p>
-<p>The game ends soon after the stock has run out (although some
-rule sets allow a redeal by picking up the waste pile and turning
-it face down to make a new stock). The game is won when all cards
-are built onto the tableau. It actually does not matter which card
-starts each column.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/German_Patience">http://en.wikipedia.org/wiki/German_Patience</a>)</i></p>
-</body>
-</html>
+<p>
+German Patience is a solitaire card game which is played with two decks of
+playing cards shuffled together. It is an unusual game because building in the
+tableau or playing area is up, as opposed to building down in many others.
+Despite its name, it is not known if this game originated from Germany.
+<p>
+The object of this game is to form eight columns of thirteen cards each. Each
+column starts with any card and ends with the card a rank lower than the
+first. In this game, building is round-the-corner, i.e. an Ace can be built
+over a King and a Deuce (or Two card) can be placed over an Ace.
+<p>
+At the start of the game, each column in the tableau starts with one card. The
+cards in the tableau are built up regardless of suit. Only the top card of
+each column is available for play and cards are moved one at a time. Spaces
+can be filled with any card.
+<p>
+When there are no more moves that can be make, the stock is dealt one a time.
+Any card that cannot be placed onto the tableau yet is placed on the waste
+pile, the top card of which is available for play.
+<p>
+The game ends soon after the stock has run out (although some rule sets allow
+a redeal by picking up the waste pile and turning it face down to make a new
+stock). The game is won when all cards are built onto the tableau. It actually
+does not matter which card starts each column.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/German_Patience">http://en.wikipedia.org/wiki/German_Patience</a>)</i>

--- a/html-src/wikipedia/grandduchess.html
+++ b/html-src/wikipedia/grandduchess.html
@@ -1,55 +1,49 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Grand Duchess</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Grand Duchess (also known as Duchess de Luynes) is a solitaire
-card game which is played with two decks of playing cards. One
-unique feature of this game is the building of the reserve, which
-is not used until the entire stock runs out.</p>
-<p>First, four cards are dealt face-up, one onto each tableau pile,
-and two more cards are dealt face-down on the reserve to be used
-later. After each deal of six cards, the player pauses to see if
-any cards are playable. Available for play to the foundations
-(which are above the four tableau piles) are the top cards of each
-tableau pile.</p>
-<p>As they become available, one ace and one king of each suit are
-placed in the foundations. The aces are built up to kings while the
-kings are built down to aces, all by suit. Furthermore, once a
-foundation card is set, any can be built upon it at any time.</p>
-<p>Once the player builds the necessary cards one could, another
-set of six is dealt: one on each of the four tableau piles and two
-face-down ones set aside on the reserve. Afterwards, the plays
-builds more cards and the process is repeated until the stock runs
-out. Once this occurs, the entire reserve is turned face-up. All
-cards in that reserve become available to built on the foundations,
-along with the top cards of each reserve pile.</p>
-<p>When play goes on a stand still (when the tableau and the
-reserve no longer yields playable cards), the player is then
-entitled to three redeals. To do a redeal, the player picks up
-first tableau pile and places it over the second pile, picks up
-that newly formed pile and puts in over the third pile, and these
-three piles are then laid over the fourth pile. Then, the piles are
-turned face-down to form the new stock, and the remaining reserve
-piles are placed under it. On the first two redeals, the process of
-dealing one card on each of the four tableau piles and two more on
-the reserve faced down, stopping each time to make any play, and
-using the reserve when the stock runs out is repeated. But on the
-last redeal, there is no more reserve; all cards are dealt four at
-a time, one on each tableau pile.</p>
-<p>The game ends soon after the stock runs out in the last redeal.
-The game is won when all cards end up in the foundations.</p>
+<p>
+Grand Duchess (also known as Duchess de Luynes) is a solitaire card game which
+is played with two decks of playing cards. One unique feature of this game is
+the building of the reserve, which is not used until the entire stock runs
+out.
+<p>
+First, four cards are dealt face-up, one onto each tableau pile, and two more
+cards are dealt face-down on the reserve to be used later. After each deal of
+six cards, the player pauses to see if any cards are playable. Available for
+play to the foundations (which are above the four tableau piles) are the top
+cards of each tableau pile.
+<p>
+As they become available, one ace and one king of each suit are placed in the
+foundations. The aces are built up to kings while the kings are built down to
+aces, all by suit. Furthermore, once a foundation card is set, any can be
+built upon it at any time.
+<p>
+Once the player builds the necessary cards one could, another set of six is
+dealt: one on each of the four tableau piles and two face-down ones set aside
+on the reserve. Afterwards, the plays builds more cards and the process is
+repeated until the stock runs out. Once this occurs, the entire reserve is
+turned face-up. All cards in that reserve become available to built on the
+foundations, along with the top cards of each reserve pile.
+<p>
+When play goes on a stand still (when the tableau and the reserve no longer
+yields playable cards), the player is then entitled to three redeals. To do a
+redeal, the player picks up first tableau pile and places it over the second
+pile, picks up that newly formed pile and puts in over the third pile, and
+these three piles are then laid over the fourth pile. Then, the piles are
+turned face-down to form the new stock, and the remaining reserve piles are
+placed under it. On the first two redeals, the process of dealing one card on
+each of the four tableau piles and two more on the reserve faced down,
+stopping each time to make any play, and using the reserve when the stock runs
+out is repeated. But on the last redeal, there is no more reserve; all cards
+are dealt four at a time, one on each tableau pile.
+<p>
+The game ends soon after the stock runs out in the last redeal. The game is
+won when all cards end up in the foundations.
+<p>
 <h3>Parisienne</h3>
-<p>Parisienne (also known as La Parisienne or Parisian) is a
-variant of Grand Duchess. The game is played like Grand Duchess
-except the before the game starts, one ace and one king of each
-suit is removed from the deck and placed on the foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Grand_Duchess_%28solitaire%29">http://en.wikipedia.org/wiki/Grand_Duchess_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Parisienne (also known as La Parisienne or Parisian) is a variant of Grand
+Duchess. The game is played like Grand Duchess except the before the game
+starts, one ace and one king of each suit is removed from the deck and placed
+on the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Grand_Duchess_%28solitaire%29">http://en.wikipedia.org/wiki/Grand_Duchess_(solitaire)</a>)</i>

--- a/html-src/wikipedia/headsandtails.html
+++ b/html-src/wikipedia/headsandtails.html
@@ -1,39 +1,32 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Heads And Tails</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Heads and Tails is a solitaire card game which uses two decks of
-playing cards. It is mostly based on luck.</p>
-<p>First, a row of eight cards are dealt; this is the "Heads" row.
-Then 8 piles of 11 cards are dealt; this is reserve. Below them is
-another row of eight cards, the "Tails" row.</p>
-<p>The object of the game is to free one Ace and one King of each
-suit and built each of them by suit; the Aces are built up to Kings
-while the Kings are built down to Aces.</p>
-<p>Only the cards on the Heads and Tails rows are available to play
-on the foundations or on either the Heads or Tails row; the eight
-piles are used only to fill gaps. The cards on the Heads or Tails
-rows can be built either up or down by suit; building can change
-direction, but Aces cannot be built onto Kings and vice versa.</p>
-<p>When a gap occurs on either the Heads or the Tails row, it is
-filled by the top card of the reserve pile immediately below or
-above it (depending on which row the gap is). But when a gap occurs
-above or below an empty pile, two different rule sets say the gap
-is filled with:</p>
+<p>
+Heads and Tails is a solitaire card game which uses two decks of playing
+cards. It is mostly based on luck.
+<p>
+First, a row of eight cards are dealt; this is the "Heads" row. Then 8 piles
+of 11 cards are dealt; this is reserve. Below them is another row of eight
+cards, the "Tails" row.
+<p>
+The object of the game is to free one Ace and one King of each suit and built
+each of them by suit; the Aces are built up to Kings while the Kings are built
+down to Aces.
+<p>
+Only the cards on the Heads and Tails rows are available to play on the
+foundations or on either the Heads or Tails row; the eight piles are used only
+to fill gaps. The cards on the Heads or Tails rows can be built either up or
+down by suit; building can change direction, but Aces cannot be built onto
+Kings and vice versa.
+<p>
+When a gap occurs on either the Heads or the Tails row, it is filled by the
+top card of the reserve pile immediately below or above it (depending on which
+row the gap is). But when a gap occurs above or below an empty pile, two
+different rule sets say the gap is filled with:
 <ul>
-<li>The top card of the pile to the immediate left of the empty
-pile (Solsuite)</li>
-<li>The top card of any other pile. (Pretty Good Solitaire)</li>
+<li>The top card of the pile to the immediate left of the empty pile (Solsuite)
+<li>The top card of any other pile. (Pretty Good Solitaire)
 </ul>
-<p>The game is won when all cards are built onto the
-foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Heads_And_Tails">http://en.wikipedia.org/wiki/Heads_And_Tails</a>)</i></p>
-</body>
-</html>
+<p>
+The game is won when all cards are built onto the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Heads_And_Tails">http://en.wikipedia.org/wiki/Heads_And_Tails</a>)</i>

--- a/html-src/wikipedia/houseinthewood.html
+++ b/html-src/wikipedia/houseinthewood.html
@@ -1,40 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>House in the Woods</h1>
+
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>House in the Woods is a solitaire card game with uses two decks
-of 52 playing cards each. The game is basically a two-deck version
-of La Belle Lucie, but it borrows two things from its cousin
-Shamrocks. The object of the game is to place all the cards into
-eight foundations.</p>
-<p>The cards are dealt in sets of three, resulting in 34 piles,
-with two cards left over as a thirty-fifth. The top card of each
-pile is available for play.</p>
-<p>The cards on the tableau are built either up or down by suit;
-the player can have the cards go both directions at the same pile.
-However, an ace cannot be placed on a king and vice versa; an ace
-should be transferred to the foundations. Furthermore, when a pile
-becomes empty, it cannot be filled. All eight foundations are built
-up in suit starting from aces.</p>
-<p>The game is won when all 104 card end up in the foundations.</p>
-<p>As already mentioned, it is basically a two-deck version of La
-Belle Lucie. But the two things that make this game also similar to
-Shamrocks is the building the cards up or down and the fact that
-there are no redeals.</p>
+<p>
+House in the Woods is a solitaire card game with uses two decks of 52 playing
+cards each. The game is basically a two-deck version of La Belle Lucie, but it
+borrows two things from its cousin Shamrocks. The object of the game is to
+place all the cards into eight foundations.
+<p>
+The cards are dealt in sets of three, resulting in 34 piles, with two cards
+left over as a thirty-fifth. The top card of each pile is available for play.
+<p>
+The cards on the tableau are built either up or down by suit; the player can
+have the cards go both directions at the same pile. However, an ace cannot be
+placed on a king and vice versa; an ace should be transferred to the
+foundations. Furthermore, when a pile becomes empty, it cannot be filled. All
+eight foundations are built up in suit starting from aces.
+<p>
+The game is won when all 104 card end up in the foundations.
+<p>
+As already mentioned, it is basically a two-deck version of La Belle Lucie.
+But the two things that make this game also similar to Shamrocks is the
+building the cards up or down and the fact that there are no redeals.
+<p>
 <h3>House on the Hill</h3>
-<p>House on the Hill is another solitaire card game using two
-decks. It is played with the same rules as those of House in the
-Woods except that while the aces, one of each suit, must occupy
-four of the eight foundations, the kings, also one of each suit,
-must occupy the other four. The aces are built up by suit up to
-kings, the kings are built down by suit to aces.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/House_in_the_Woods">http://en.wikipedia.org/wiki/House_in_the_Woods</a>)</i></p>
-</body>
-</html>
+<p>
+House on the Hill is another solitaire card game using two decks. It is played
+with the same rules as those of House in the Woods except that while the aces,
+one of each suit, must occupy four of the eight foundations, the kings, also
+one of each suit, must occupy the other four. The aces are built up by suit up
+to kings, the kings are built down by suit to aces.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/House_in_the_Woods">http://en.wikipedia.org/wiki/House_in_the_Woods</a>)</i>

--- a/html-src/wikipedia/intelligence.html
+++ b/html-src/wikipedia/intelligence.html
@@ -1,45 +1,37 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Intelligence</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Intelligence is a solitaire card game which uses two decks of
-playing cards mixed together. It is basically a two-deck version of
-another solitaire game La Belle Lucie and its game play is somewhat
-closer to the parent game than its cousins House in the Wood and
-House on the Hill.</p>
-<p>First, 18 piles (or fans) of three cards are dealt. During this
-deal any ace encountered regardless of where it would end up in the
-pile will be moved to a foundation and be replaced with another
-card. As they become available, the other aces are placed on the
-foundations, which are all built up by suit.</p>
-<p>The top cards of the piles are available to be built on the
-foundations or on each other's piles on the tableau. When building
-on the tableau, the cards are built either up or down by suit. Aces
-cannot be placed over kings, however, and vice versa.</p>
-<p>When a gap occurs, it is immediately filled by three new cards
-from the stock. This is the only way cards from the stock are
-introduced from the game and the only way spaces are refilled. As
-in the original deal, any ace that comes up is immediately placed
-on the foundations.</p>
-<p>When all moves have been made and become stuck, even if there
-are still cards in the stock, the stock and all the cards in the
-tableau are gathered, reshuffled, and 18 piles of three cards each
-are redealt, or as many piles of three cards as the remaining ones
-can allow. This can be done twice and during both redeals as in the
-original deal, any aces the player encounters are immediately
-placed onto the foundations.</p>
-<p>The game is won when all cards end up in the foundations.</p>
-<p>Sloane Lee and Gabriel Packard's version of the game (in the
-book <i>100 Best Solitaire Games</i>) slightly increased the number
-of tableau piles to 19 because they think this improves the
-game.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Intelligence_%28solitaire%29">http://en.wikipedia.org/wiki/Intelligence_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Intelligence is a solitaire card game which uses two decks of playing cards
+mixed together. It is basically a two-deck version of another solitaire game
+La Belle Lucie and its game play is somewhat closer to the parent game than
+its cousins House in the Wood and House on the Hill.
+<p>
+First, 18 piles (or fans) of three cards are dealt. During this deal any ace
+encountered regardless of where it would end up in the pile will be moved to a
+foundation and be replaced with another card. As they become available, the
+other aces are placed on the foundations, which are all built up by suit.
+<p>
+The top cards of the piles are available to be built on the foundations or on
+each other's piles on the tableau. When building on the tableau, the cards are
+built either up or down by suit. Aces cannot be placed over kings, however,
+and vice versa.
+<p>
+When a gap occurs, it is immediately filled by three new cards from the stock.
+This is the only way cards from the stock are introduced from the game and the
+only way spaces are refilled. As in the original deal, any ace that comes up
+is immediately placed on the foundations.
+<p>
+When all moves have been made and become stuck, even if there are still cards
+in the stock, the stock and all the cards in the tableau are gathered,
+reshuffled, and 18 piles of three cards each are redealt, or as many piles of
+three cards as the remaining ones can allow. This can be done twice and during
+both redeals as in the original deal, any aces the player encounters are
+immediately placed onto the foundations.
+<p>
+The game is won when all cards end up in the foundations.
+<p>
+Sloane Lee and Gabriel Packard's version of the game (in the book <i>100 Best
+Solitaire Games</i>) slightly increased the number of tableau piles to 19
+because they think this improves the game.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Intelligence_%28solitaire%29">http://en.wikipedia.org/wiki/Intelligence_(solitaire)</a>)</i>

--- a/html-src/wikipedia/intrigue.html
+++ b/html-src/wikipedia/intrigue.html
@@ -1,50 +1,46 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Intrigue</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Intrigue is a solitaire card game which is played using two
-decks of playing cards. It is similar to another solitaire game of
-<a href="saliclaw.html">Salic Law</a>, but it also involves the
-queens and building in the foundations goes both ways.</p>
-<p>First, one queen is removed from the rest of the deck is placed
-on the layout as the base for the first tableau column.</p>
-<p>As they become available, all fives and sixes are placed at the
-foundations above the queens. The fives are built down to Aces,
-then to Kings while the sixes are built up to Jacks, all regardless
-of suit.</p>
-<p>Over the first queen, the cards are dealt over it until another
-queen appears. This new queen becomes the base for a new tableau
-column and cards are dealt over it. This is repeated until all
-eight queens are uncovered and all cards are deal.</p>
-<p>During the dealing, all fives and sixes are immediately placed
-in the foundations and any card that be built on the foundations
-must be placed there.</p>
-<p>Once all cards are dealt and all those that can be built in the
-foundations make their way there, building continues. The top cards
-of each column is available for play on the foundations. A column
-containing only a queen is considered empty and any card can be
-placed on it. There is no building in the tableau.</p>
-<p>The game is won when all cards are build on the foundations with
-the face cards on top.</p>
+<p>
+Intrigue is a solitaire card game which is played using two decks of playing
+cards. It is similar to another solitaire game of
+<a href="saliclaw.html">Salic Law</a>, but it also involves the queens and
+building in the foundations goes both ways.
+<p>
+First, one queen is removed from the rest of the deck is placed on the layout
+as the base for the first tableau column.
+<p>
+As they become available, all fives and sixes are placed at the foundations
+above the queens. The fives are built down to Aces, then to Kings while the
+sixes are built up to Jacks, all regardless of suit.
+<p>
+Over the first queen, the cards are dealt over it until another queen appears.
+This new queen becomes the base for a new tableau column and cards are dealt
+over it. This is repeated until all eight queens are uncovered and all cards
+are deal.
+<p>
+During the dealing, all fives and sixes are immediately placed in the
+foundations and any card that be built on the foundations must be placed
+there.
+<p>
+Once all cards are dealt and all those that can be built in the foundations
+make their way there, building continues. The top cards of each column is
+available for play on the foundations. A column containing only a queen is
+considered empty and any card can be placed on it. There is no building in the
+tableau.
+<p>
+The game is won when all cards are build on the foundations with the face
+cards on top.
+<p>
 <h3>Variations</h3>
-<p>Below are harder variations of Intrigue:</p>
+<p>
+Below are harder variations of Intrigue:
 <ul>
-<li>In <b>Laggard Lady</b>, the fives and sixes may not be moved
-faster then the queens. Therefore, for example, if there are five
-queens dealt so far, a sixth five or a sixth six must be dealt to
-the tableau.</li>
-<li>In <b>Glencoe</b>, each five and six must be placed over the
-queen of its respective suit. If the appropriate queen is not yet
-available at a time a five or six appears, that five or six must be
-dealt to the tableau.</li>
+<li>In <b>Laggard Lady</b>, the fives and sixes may not be moved faster then
+the queens. Therefore, for example, if there are five queens dealt so far, a
+sixth five or a sixth six must be dealt to the tableau.
+<li>In <b>Glencoe</b>, each five and six must be placed over the queen of its
+respective suit. If the appropriate queen is not yet available at a time a
+five or six appears, that five or six must be dealt to the tableau.
 </ul>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Intrigue_%28solitaire%29">http://en.wikipedia.org/wiki/Intrigue_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Intrigue_%28solitaire%29">http://en.wikipedia.org/wiki/Intrigue_(solitaire)</a>)</i>

--- a/html-src/wikipedia/kingalbert.html
+++ b/html-src/wikipedia/kingalbert.html
@@ -1,35 +1,29 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>King Albert</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>King Albert is a solitaire card game using a deck of 52 playing
-cards. It is said to be named after King Albert of Belgium the
-first. It is also the best known of the three games that are each
-called Idiot's Delight because of the low chance of winning the
-game (the other two are Aces Up and Perpetual Motion).</p>
-<p>The aim of the game, like many solitaire games, is to release
-the aces to the foundations and built each of them up by suit to
-Kings.</p>
-<p>First, the cards are deal into nine columns in such a way that
-the first column contains nine cards, the second having eight
-cards, the third seven, and so on until the ninth column having a
-single card. The seven left over cards form the reserve, sometimes
-known as "the Belgian Reserve."</p>
-<p>Building on the tableau is down by alternating colors and only
-one card can be moved at a time. Only the top card of each column
-and all cards in the reserve are available for play. Furthermore,
-an empty column can be filled with any available card.</p>
-<p>Once an ace is released, it can be built upon immediately.</p>
-<p>The game is won when all cards end up in the foundations. But
-achieveing this is difficult as one in only ten games can be won,
-hence the alternate name of <i>Idiot's Delight</i>.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/King_Albert_%28solitaire%29">http://en.wikipedia.org/wiki/King_Albert_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+King Albert is a solitaire card game using a deck of 52 playing cards. It is
+said to be named after King Albert of Belgium the first. It is also the best
+known of the three games that are each called Idiot's Delight because of the
+low chance of winning the game (the other two are Aces Up and Perpetual
+Motion).
+<p>
+The aim of the game, like many solitaire games, is to release the aces to the
+foundations and built each of them up by suit to Kings.
+<p>
+First, the cards are deal into nine columns in such a way that the first
+column contains nine cards, the second having eight cards, the third seven,
+and so on until the ninth column having a single card. The seven left over
+cards form the reserve, sometimes known as "the Belgian Reserve."
+<p>
+Building on the tableau is down by alternating colors and only one card can be
+moved at a time. Only the top card of each column and all cards in the reserve
+are available for play. Furthermore, an empty column can be filled with any
+available card.
+<p>
+Once an ace is released, it can be built upon immediately.
+<p>
+The game is won when all cards end up in the foundations. But achieveing this
+is difficult as one in only ten games can be won, hence the alternate name
+of <i>Idiot's Delight</i>.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/King_Albert_%28solitaire%29">http://en.wikipedia.org/wiki/King_Albert_(solitaire)</a>)</i>

--- a/html-src/wikipedia/lanivernaise.html
+++ b/html-src/wikipedia/lanivernaise.html
@@ -1,20 +1,10 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>La Nivernaise</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>La Nivernaise or just Nivernaise (also known as Napoleon's
-Flank) is an older version of <a href=
-"tournament.html">Tournament</a>. It is played exactly as
-Tournament except the six columns of four cards each are just piles
-with only their top cards exposed. Here, the reserve is the "flank"
-while the piles are the "line."</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Tournament_%28solitaire%29">http://en.wikipedia.org/wiki/Tournament_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+La Nivernaise or just Nivernaise (also known as Napoleon's Flank) is an older
+version of <a href="tournament.html">Tournament</a>. It is played exactly as
+Tournament except the six columns of four cards each are just piles with only
+their top cards exposed. Here, the reserve is the "flank" while the piles are
+the "line."
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Tournament_%28solitaire%29">http://en.wikipedia.org/wiki/Tournament_(solitaire)</a>)</i>

--- a/html-src/wikipedia/mountolympus.html
+++ b/html-src/wikipedia/mountolympus.html
@@ -1,46 +1,37 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Mount Olympus</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Mount Olympus is a solitaire card game using two decks of 52
-playing cards each. It is probably named because of the tableau's
-mountain shape and shows all the Kings and Queens in the end, if
-won successfully, like the Greek gods and goddesses who are said to
-be residing on the mountain with the same name.</p>
-<p>First, all aces and deuces, or twos (16 cards in all), are
-removed from the two decks. Then the remaining 88 cards are
-shuffled and nine of them are laid out on the tableau in an
-inverted "V" formation. Although this is one of the two bases
-mentioned above that gives the game its name, the player can opt to
-just lay the nine cards in a straight line. These nine cards start
-each of the nine piles in the tableau.</p>
-<p>Building on the 16 foundations is up by suit in intervals of
-two. Therefore, building should be like this:<br />
-On the aces: 3-5-7-9-J-K<br />
-On the deuces: 4-6-8-10-Q</p>
-<p>Building on the tableau is down, also by suit in intervals of
-two (i.e. the <b>5</b><img src="../images/s.gif" /> must be placed
-over the <b>7</b><img src="../images/s.gif" />). A card can be
-placed over an applicable card and any gap must be filled
-immediately with a card from the stock. A sequence of cards (such
-as <b>6-8-10</b><img src="../images/c.gif" />) can be moved as one
-unit. Any card can be placed on the foundation at any appropriate
-time.</p>
-<p>Once all possible moves have been made or the player has done
-all moves he wanted to make, a new set of nine cards are dealt, one
-for each pile. Moving, filling gaps with new cards, and dealing a
-new set of nine cards continue until the stock has been used up.
-After this has happened, building continues, but spaces left behind
-are not filled.</p>
-<p>The game is successfully won when all cards are built with the
-Kings and Queens at front.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Mount_Olympus_%28solitaire%29">http://en.wikipedia.org/wiki/Mount_Olympus_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Mount Olympus is a solitaire card game using two decks of 52 playing cards
+each. It is probably named because of the tableau's mountain shape and shows
+all the Kings and Queens in the end, if won successfully, like the Greek gods
+and goddesses who are said to be residing on the mountain with the same name.
+<p>
+First, all aces and deuces, or twos (16 cards in all), are removed from the
+two decks. Then the remaining 88 cards are shuffled and nine of them are laid
+out on the tableau in an inverted "V" formation. Although this is one of the
+two bases mentioned above that gives the game its name, the player can opt to
+just lay the nine cards in a straight line. These nine cards start each of the
+nine piles in the tableau.
+<p>
+Building on the 16 foundations is up by suit in intervals of two. Therefore,
+building should be like this:<br>
+On the aces: 3-5-7-9-J-K<br>
+On the deuces: 4-6-8-10-Q
+<p>
+Building on the tableau is down, also by suit in intervals of two (i.e. the
+<b>5</b><img src="../images/s.gif"> must be placed over the <b>7</b><img
+src="../images/s.gif">). A card can be placed over an applicable card and any
+gap must be filled immediately with a card from the stock. A sequence of cards
+(such as <b>6-8-10</b><img src="../images/c.gif">) can be moved as one unit.
+Any card can be placed on the foundation at any appropriate time.
+<p>
+Once all possible moves have been made or the player has done all moves he
+wanted to make, a new set of nine cards are dealt, one for each pile. Moving,
+filling gaps with new cards, and dealing a new set of nine cards continue
+until the stock has been used up. After this has happened, building continues,
+but spaces left behind are not filled.
+<p>
+The game is successfully won when all cards are built with the Kings and
+Queens at front.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Mount_Olympus_%28solitaire%29">http://en.wikipedia.org/wiki/Mount_Olympus_(solitaire)</a>)</i>

--- a/html-src/wikipedia/mrsmop.html
+++ b/html-src/wikipedia/mrsmop.html
@@ -1,34 +1,26 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Mrs. Mop</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Mrs. Mop is a solitaire card game which is played using two
-decks of playing cards. Invented by Charles Jewell, it is a distant
-relative of another solitaire card game Spider where all of the
-cards are dealt. The game seems easy at first, but when played,
-chances of winning are low.</p>
-<p>First the cards are dealt into thirteen columns of eight cards
-each. The player will then aim to form eight full suit sequences of
-13 cards each. Every sequence should run from King down to Ace.</p>
-<p>To achieve this, the cards are built down regardless of suit.
-One card can be moved at a time, unless there are two or more cards
-of the same suit forming a sequence (such as 7-6-5-4 of spades) at
-which case they are moved as a single unit.</p>
-<p>When a suit sequence is formed on the same column, running from
-King down to Ace (such as K-Q-J-10-9-8-7-6-5-4-3-2-A of clubs), the
-sequence is discarded. This game is won when all eight such
-sequences are removed.</p>
-<p>Like in Spider, it is generally a good idea for the player to
-built down in suit whenever possible because the earlier this is
-done, the sooner a sequence is removed, giving the player more
-space to maneuver.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Mrs._Mop">http://en.wikipedia.org/wiki/Mrs._Mop</a>)</i></p>
-</body>
-</html>
+<p>
+Mrs. Mop is a solitaire card game which is played using two decks of playing
+cards. Invented by Charles Jewell, it is a distant relative of another
+solitaire card game Spider where all of the cards are dealt. The game seems
+easy at first, but when played, chances of winning are low.
+<p>
+First the cards are dealt into thirteen columns of eight cards each. The
+player will then aim to form eight full suit sequences of 13 cards each. Every
+sequence should run from King down to Ace.
+<p>
+To achieve this, the cards are built down regardless of suit. One card can be
+moved at a time, unless there are two or more cards of the same suit forming a
+sequence (such as 7-6-5-4 of spades) at which case they are moved as a single
+unit.
+<p>
+When a suit sequence is formed on the same column, running from King down to
+Ace (such as K-Q-J-10-9-8-7-6-5-4-3-2-A of clubs), the sequence is discarded.
+This game is won when all eight such sequences are removed.
+<p>
+Like in Spider, it is generally a good idea for the player to built down in
+suit whenever possible because the earlier this is done, the sooner a sequence
+is removed, giving the player more space to maneuver.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Mrs._Mop">http://en.wikipedia.org/wiki/Mrs._Mop</a>)</i>

--- a/html-src/wikipedia/napoleonssquare.html
+++ b/html-src/wikipedia/napoleonssquare.html
@@ -1,39 +1,30 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Napoleon's Square</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Napoleon's Square is a solitaire card game which uses two decks
-of playing cards. First described by Lady Adelaide Cadogan in the
-early 1900s, it is an easy variation of Forty Thieves. It is not
-determined if Napoleon actually played this game, or any solitaire
-game named after him.</p>
-<p>First, forty-eight cards are dealt into twelve piles of four
-cards each, forming three sides of a square. The rest of the deck
-consist the stock. Fourth "side" of the square is left to be
-occupied by the foundations.</p>
-<p>The object of this game is to place the Aces as they become
-available and build each of them up to kings.</p>
-<p>The top card of each pile is available for play, to be built on
-the foundations or on another pile. Cards on the tableau are built
-down in suit and sequences can be moved as a unit. (Solsuite's
-version of the game, however, does not allow moving sequences as a
-unit) Spaces, whenever they occur, can be filled with any available
-card or sequence.</p>
-<p>When there are no more plays on the tableau that can be made,
-the stock is dealt one at a time, and any card that cannot be built
-on the foundations or on the tableau can be placed on a waste pile,
-the top card of which is available for play. The stock can only be
-dealt once.</p>
-<p>The game ends soon after the stock has run out. The game is won
-(which is very likely) when all cards are built onto the
-foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Napoleon%27s_Square">http://en.wikipedia.org/wiki/Napoleon's_Square</a>)</i></p>
-</body>
-</html>
+<p>
+Napoleon's Square is a solitaire card game which uses two decks of playing
+cards. First described by Lady Adelaide Cadogan in the early 1900s, it is an
+easy variation of Forty Thieves. It is not determined if Napoleon actually
+played this game, or any solitaire game named after him.
+<p>
+First, forty-eight cards are dealt into twelve piles of four cards each,
+forming three sides of a square. The rest of the deck consist the stock.
+Fourth "side" of the square is left to be occupied by the foundations.
+<p>
+The object of this game is to place the Aces as they become available and
+build each of them up to kings.
+<p>
+The top card of each pile is available for play, to be built on the
+foundations or on another pile. Cards on the tableau are built down in suit
+and sequences can be moved as a unit. (Solsuite's version of the game,
+however, does not allow moving sequences as a unit) Spaces, whenever they
+occur, can be filled with any available card or sequence.
+<p>
+When there are no more plays on the tableau that can be made, the stock is
+dealt one at a time, and any card that cannot be built on the foundations or
+on the tableau can be placed on a waste pile, the top card of which is
+available for play. The stock can only be dealt once.
+<p>
+The game ends soon after the stock has run out. The game is won (which is very
+likely) when all cards are built onto the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Napoleon%27s_Square">http://en.wikipedia.org/wiki/Napoleon's_Square</a>)</i>

--- a/html-src/wikipedia/nestor.html
+++ b/html-src/wikipedia/nestor.html
@@ -1,30 +1,23 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Nestor</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Nestor is a solitaire card game where the object is the removal
-of pairs.</p>
-<p>Cards are dealt into eight columns of six cards. They are dealt
-in such a way that no two cards in the same column have the same
-rank. If it is about to be the case, the card about to dealt is
-placed at the bottom of the deck and a new one is dealt as long as
-its rank doesn't match with any of the cards already in that
-column.</p>
-<p>Once the eight columns are dealt, the four remaining cards are
-placed either face-up or face-down in a row above or below the
-columns. These four cards will be the reserve.</p>
-<p>Play is composed of removing pairs of cards with the same rank
-(such as two kings or two 7s). All cards in the reserve and the top
-card of each column are available for play. Once a pair has been
-removed, new cards become exposed and available for play.</p>
-<p>The game is won once all cards are discarded.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Nestor_%28solitaire%29">http://en.wikipedia.org/wiki/Nestor_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Nestor is a solitaire card game where the object is the removal of pairs.
+<p>
+Cards are dealt into eight columns of six cards. They are dealt in such a way
+that no two cards in the same column have the same rank. If it is about to be
+the case, the card about to dealt is placed at the bottom of the deck and a
+new one is dealt as long as its rank doesn't match with any of the cards
+already in that column.
+<p>
+Once the eight columns are dealt, the four remaining cards are placed either
+face-up or face-down in a row above or below the columns. These four cards
+will be the reserve.
+<p>
+Play is composed of removing pairs of cards with the same rank (such as two
+kings or two 7s). All cards in the reserve and the top card of each column are
+available for play. Once a pair has been removed, new cards become exposed and
+available for play.
+<p>
+The game is won once all cards are discarded.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Nestor_%28solitaire%29">http://en.wikipedia.org/wiki/Nestor_(solitaire)</a>)</i>

--- a/html-src/wikipedia/parallels.html
+++ b/html-src/wikipedia/parallels.html
@@ -1,55 +1,46 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Parallels</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Parallels is a solitaire card game which is played with two
-decks of playing cards. It is so called because the cards are lined
-up in rows parallel to each other, so to speak.</p>
-<p>First, one king and one ace of each suit is removed and the aces
-and kings are each lined into columns to form the foundations. The
-aces are built up while the kings are built down all by suit.</p>
-<p>Between the two foundation columns, the player deals a row of
-ten cards, forming the tableau. All of these cards are available
-for play on the foundations and the spaces they leave behind are
-immediately filled from the stock.</p>
-<p>When play comes to a stand still, a second row of ten cards is
-dealt below the first row. All cards are still available for play
-and the spaces left behind are immediately filled from the
-stock.</p>
-<p>When play comes to a stand still a second time, a third row of
-ten cards is dealt. At this point onwards, the following rules
-apply:</p>
+<p>
+Parallels is a solitaire card game which is played with two decks of playing
+cards. It is so called because the cards are lined up in rows parallel to each
+other, so to speak.
+<p>
+First, one king and one ace of each suit is removed and the aces and kings are
+each lined into columns to form the foundations. The aces are built up while
+the kings are built down all by suit.
+<p>
+Between the two foundation columns, the player deals a row of ten cards,
+forming the tableau. All of these cards are available for play on the
+foundations and the spaces they leave behind are immediately filled from the
+stock.
+<p>
+When play comes to a stand still, a second row of ten cards is dealt below the
+first row. All cards are still available for play and the spaces left behind
+are immediately filled from the stock.
+<p>
+When play comes to a stand still a second time, a third row of ten cards is
+dealt. At this point onwards, the following rules apply:
 <ul>
-<li>A card is available to be built to the foundations if at least
-one of its narrower edges is free. Therefore, the cards at the top
-and bottom rows are available for play and card in the middle rows
-becomes available after a card immediately above or below it is
-played.</li>
-<li>There is no compulsion in filling spaces in the tableau. As
-long as there are moves available for player to make, spaces can be
-filled later.</li>
-<li>All spaces in the tableau must be filled when play goes on a
-standstill. The order is from left to right, top to bottom. There
-is no building at this point.</li>
-<li>Only when the existing spaces in the tableau are filled is the
-time another row of ten card is dealt at the bottom of the existing
-rows.</li>
-<li>Peeking on the next card in the stock is absolutely not
-allowed; doing so will force that card dealt to the tableau.</li>
+<li>A card is available to be built to the foundations if at least one of its
+narrower edges is free. Therefore, the cards at the top and bottom rows are
+available for play and card in the middle rows becomes available after a card
+immediately above or below it is played.
+<li>There is no compulsion in filling spaces in the tableau. As long as there
+are moves available for player to make, spaces can be filled later.
+<li>All spaces in the tableau must be filled when play goes on a standstill.
+The order is from left to right, top to bottom. There is no building at this
+point.
+<li>Only when the existing spaces in the tableau are filled is the time
+another row of ten card is dealt at the bottom of the existing rows.
+<li>Peeking on the next card in the stock is absolutely not allowed; doing so
+will force that card dealt to the tableau.
 </ul>
-<p>Also, reversals are allowed in the game, i.e. when the two
-foundations of the same suit meet at one point, the player can move
-the cards from one foundation to the other except the base cards
-(ace and king) of the foundations.</p>
-<p>The game ends when play stops after the stock has run out. The
-game is won when all cards are built into the foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Parallels_%28solitaire%29">http://en.wikipedia.org/wiki/Parallels_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Also, reversals are allowed in the game, i.e. when the two foundations of the
+same suit meet at one point, the player can move the cards from one foundation
+to the other except the base cards (ace and king) of the foundations.
+<p>
+The game ends when play stops after the stock has run out. The game is won
+when all cards are built into the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Parallels_%28solitaire%29">http://en.wikipedia.org/wiki/Parallels_(solitaire)</a>)</i>

--- a/html-src/wikipedia/patriarchs.html
+++ b/html-src/wikipedia/patriarchs.html
@@ -1,50 +1,44 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Patriarchs</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Patriarchs is a solitaire card game which is played with two
-decks of playing cards. It is similar in reserve layout to <a href=
-"oddandeven.html">Odd and Even</a> but with different game
-play.</p>
-<p>First, one king and one ace are removed from the deck and placed
-in two columns: one with all aces and the other with all kings. In
-between these two columns is a space for the reserve, which is
-composed of nine cards arranged in three rows of three cards
-each.</p>
-<p>Ace and King columns are the foundations. The ace foundations
-are built up to Kings while the king foundations are built down to
-aces, all by suit. When the top cards of the ace and king
-foundations of the same suit are in sequence, a reversal can be
-done, i.e. cards can be moved one at a time from one foundation to
-the other, except the base aces and kings.</p>
-<p>The nine reserve cards are available for play on the foundations
-(not on each other). When a card leaves the reserve, the space it
-leaves behind is filled with the top card of the waste pile (or the
-stock if there is no waste pile yet).</p>
-<p>If play comes to a standstill in the reserve, the stock is dealt
-one card at a time, and if a card is unplayable, it is placed on
-the waste pile, the top card of which is available for building on
-the foundations or filling a space on the reserve. Only one redeal
-is allowed; to do this the unused cards in the waste pile is picked
-up and turned face down to be used as the new stock.</p>
-<p>The game is won when all cards end up in the foundations.</p>
+<p>
+Patriarchs is a solitaire card game which is played with two decks of playing
+cards. It is similar in reserve layout to <a href="oddandeven.html">Odd and
+Even</a> but with different game play.
+<p>
+First, one king and one ace are removed from the deck and placed in two
+columns: one with all aces and the other with all kings. In between these two
+columns is a space for the reserve, which is composed of nine cards arranged
+in three rows of three cards each.
+<p>
+Ace and King columns are the foundations. The ace foundations are built up to
+Kings while the king foundations are built down to aces, all by suit. When the
+top cards of the ace and king foundations of the same suit are in sequence, a
+reversal can be done, i.e. cards can be moved one at a time from one
+foundation to the other, except the base aces and kings.
+<p>
+The nine reserve cards are available for play on the foundations (not on each
+other). When a card leaves the reserve, the space it leaves behind is filled
+with the top card of the waste pile (or the stock if there is no waste pile
+yet).
+<p>
+If play comes to a standstill in the reserve, the stock is dealt one card at a
+time, and if a card is unplayable, it is placed on the waste pile, the top
+card of which is available for building on the foundations or filling a space
+on the reserve. Only one redeal is allowed; to do this the unused cards in the
+waste pile is picked up and turned face down to be used as the new stock.
+<p>
+The game is won when all cards end up in the foundations.
+
 <h3>Picture Patience</h3>
-<p>Picture Patience is a solitaire game which is played exactly
-like Patriarchs except for the following:</p>
+<p>
+Picture Patience is a solitaire game which is played exactly like Patriarchs
+except for the following:
 <ul>
-<li>At the onset, no card is placed in the foundations; aces and
-kings needed are mixed in the deck.</li>
-<li>Reversals are not allowed.</li>
-<li>SolSuite's version of the game allows one redeal while Pretty
-Good Solitaire's version doesn't allow any redeal.</li>
+<li>At the onset, no card is placed in the foundations; aces and kings needed
+are mixed in the deck.
+<li>Reversals are not allowed.
+<li>SolSuite's version of the game allows one redeal while Pretty Good
+Solitaire's version doesn't allow any redeal.
 </ul>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Patriarchs_%28solitaire%29">http://en.wikipedia.org/wiki/Patriarchs_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Patriarchs_%28solitaire%29">http://en.wikipedia.org/wiki/Patriarchs_(solitaire)</a>)</i>

--- a/html-src/wikipedia/perseverance.html
+++ b/html-src/wikipedia/perseverance.html
@@ -1,41 +1,34 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Perseverance</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Perseverance is a solitaire card game played with a deck of 52
-playing cards. The reason is not known for the name is not known,
-but probably, the player must play this game with perseverance to
-succeed.</p>
-<p>First, the four aces are taken out of the deck. These form the
-four foundations.</p>
-<p>Then the rest are shuffled and dealt into twelve piles of four
-cards each. One can distribute one card at a time for each pile or
-deal four cards at a time to form a pile.</p>
-<p>The top cards of each pile are available for play to the
-foundations or on the tableau piles. The foundations are built up
-by suit, with the cards on the tableau are built down, also by
-suit.</p>
-<p>One card can be moved at a time. However, the player is allowed
-to move a sequence of cards as a unit to another pile with an
-appropriate card (e.g. 6-5-4-3 of spades can be placed on the 7 of
-spades).</p>
-<p>When all possible moves are made (or the player has done all the
-possible moves one can make), the piles are picked up in reverse
-order. For example, the twelfth pile is placed over the eleventh
-pile, and this new pile is placed on the tenth pile, and so on.
-Then, without shuffling, the cards are dealt to as many piles of
-four as the remaining decks will allow. To ensure that the order of
-the cards is not disturbed for the most part, it is suggested that
-the cards are dealt four at time. This can be done only twice.</p>
-<p>The game is won successfully when all cards are built onto the
-foundations up to Kings.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Perseverance_%28solitaire%29">http://en.wikipedia.org/wiki/Perseverance_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Perseverance is a solitaire card game played with a deck of 52 playing cards.
+The reason is not known for the name is not known, but probably, the player
+must play this game with perseverance to succeed.
+<p>
+First, the four aces are taken out of the deck. These form the four
+foundations.
+<p>
+Then the rest are shuffled and dealt into twelve piles of four cards each. One
+can distribute one card at a time for each pile or deal four cards at a time
+to form a pile.
+<p>
+The top cards of each pile are available for play to the foundations or on the
+tableau piles. The foundations are built up by suit, with the cards on the
+tableau are built down, also by suit.
+<p>
+One card can be moved at a time. However, the player is allowed to move a
+sequence of cards as a unit to another pile with an appropriate card (e.g.
+6-5-4-3 of spades can be placed on the 7 of spades).
+<p>
+When all possible moves are made (or the player has done all the possible
+moves one can make), the piles are picked up in reverse order. For example,
+the twelfth pile is placed over the eleventh pile, and this new pile is placed
+on the tenth pile, and so on. Then, without shuffling, the cards are dealt to
+as many piles of four as the remaining decks will allow. To ensure that the
+order of the cards is not disturbed for the most part, it is suggested that
+the cards are dealt four at time. This can be done only twice.
+<p>
+The game is won successfully when all cards are built onto the foundations up
+to Kings.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Perseverance_%28solitaire%29">http://en.wikipedia.org/wiki/Perseverance_(solitaire)</a>)</i>

--- a/html-src/wikipedia/pussinthecorner.html
+++ b/html-src/wikipedia/pussinthecorner.html
@@ -1,42 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Puss in the Corner</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Puss in the Corner is a solitaire card game which is played with
-a deck of 52 playing cards. It is similar to another solitaire game
-Sir Tommy, but with modifications and with the waste piles placed
-at the corners of the foundations, hence the name.</p>
-<p>First, the four aces are separated from the rest of the deck and
-placed side by side in two cards of two, forming a square. The four
-waste piles, which initially would contain a card each, are located
-at the corners of the square.</p>
-<p>Building on the foundations is up by color (red suits on red,
-black suits on black, no matter the suit) to kings. The player
-first examines the cards to move any cards that can be built on the
-foundations. If a gap occurs, it is not immediately filled. Only
-one card can be moved at a time.</p>
-<p>After the sufficient cards are built, four cards, one at a time,
-are dealt onto any of the wastepiles (not necessarily one on each
-waste piles). Afterwards, any cards that can be built to the
-foundations are moved. There should be no building on the
-wastepiles themselves. The process is repeated, i.e. dealing four
-cards any on the wastepiles and moving any available cards (the top
-card of each wastepile) to the foundations over and over, until the
-stock is exhausted.</p>
-<p>After the stock is exhausted, the player can do a redeal. To do
-this, the player must pick up the four waste piles in any order one
-wishes, and without shuffling, restarts dealing four cards,
-restarting the process. The game ends when this second stock is
-used up.</p>
-<p>The game is won when all the cards end up in the
-foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Puss_in_the_Corner">http://en.wikipedia.org/wiki/Puss_in_the_Corner</a>)</i></p>
-</body>
-</html>
+<p>
+Puss in the Corner is a solitaire card game which is played with a deck of 52
+playing cards. It is similar to another solitaire game Sir Tommy, but with
+modifications and with the waste piles placed at the corners of the
+foundations, hence the name.
+<p>
+First, the four aces are separated from the rest of the deck and placed side
+by side in two cards of two, forming a square. The four waste piles, which
+initially would contain a card each, are located at the corners of the square.
+<p>
+Building on the foundations is up by color (red suits on red, black suits on
+black, no matter the suit) to kings. The player first examines the cards to
+move any cards that can be built on the foundations. If a gap occurs, it is
+not immediately filled. Only one card can be moved at a time.
+<p>
+After the sufficient cards are built, four cards, one at a time, are dealt
+onto any of the wastepiles (not necessarily one on each waste piles).
+Afterwards, any cards that can be built to the foundations are moved. There
+should be no building on the wastepiles themselves. The process is repeated,
+i.e. dealing four cards any on the wastepiles and moving any available cards
+(the top card of each wastepile) to the foundations over and over, until the
+stock is exhausted.
+<p>
+After the stock is exhausted, the player can do a redeal. To do this, the
+player must pick up the four waste piles in any order one wishes, and without
+shuffling, restarts dealing four cards, restarting the process. The game ends
+when this second stock is used up.
+<p>
+The game is won when all the cards end up in the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Puss_in_the_Corner">http://en.wikipedia.org/wiki/Puss_in_the_Corner</a>)</i>

--- a/html-src/wikipedia/rougeetnoir.html
+++ b/html-src/wikipedia/rougeetnoir.html
@@ -1,55 +1,47 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Rouge et Noir</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Rouge et Noir (i. e. red and black) is a solitaire card game
-which is played using two decks of playing cards. Invented by
-Charles Jewell, it is one unique game where two types of building
-are done in the same game. It should not be confused with the
-similarly named Red and Black, although the latter can also be
-known under this name.</p>
-<p>In this game, there are ten columns. The first column contains
-eight cards, the second column contains seven cards, the third
-contains six and so on until the eighth and ninth columns each
-contain one card. The ten column is left empty at the start of the
-game. All cards in each column except for the top card are faced
-down.</p>
-<p>The object of the game is to release two red aces and two black
-aces (regardless of suit) to become foundations and built each of
-them up by color to kings, while at the same time built four
-columns of cards in the tableau, each starting with a King and
-built down by alternating color.</p>
-<p>All exposed cards are available for play to be built either on
-the foundations or in the tableau. Building in the tableau is down
-by alternating color. Sequences can be moved in part or in whole
-and any empty column can be filled only by a King or a sequence
-that begins with a King.</p>
-<p>When there are no more moves to be played, one card is placed
-onto each column from the stock; afterwards, play proceeds as
-normal. This cycle continues until the entire stock has run
-out.</p>
-<p>When a sequence that starts with a King, ends with an Ace, and
-is built down in alternating colors is formed, it may be discarded
-at the player's discretion.</p>
-<p>The game ends when soon after the stock has run out. The game is
-won when 52 cards are built onto the four foundations while four
-King sequences are discarded.</p>
-<p>In winning such a game, the player must decide which cards
-should be built one at a time into the four foundations and which
-must be built into King-foundations which should be discarded
-later. As a suggestion, the player should do neither to help
-cleaning up a column later. It also helps when the player should
-not touch a completed column of thirteen cards to aid in splitting
-and reach the faced down cards. It is also good to focus on
-releasing the face down cards on the leftmost columns, especially
-the first three ones.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Rouge_et_Noir">http://en.wikipedia.org/wiki/Rouge_et_Noir</a>)</i></p>
-</body>
-</html>
+<p>
+Rouge et Noir (i. e. red and black) is a solitaire card game which is played
+using two decks of playing cards. Invented by Charles Jewell, it is one unique
+game where two types of building are done in the same game. It should not be
+confused with the similarly named Red and Black, although the latter can also
+be known under this name.
+<p>
+In this game, there are ten columns. The first column contains eight cards,
+the second column contains seven cards, the third contains six and so on until
+the eighth and ninth columns each contain one card. The ten column is left
+empty at the start of the game. All cards in each column except for the top
+card are faced down.
+<p>
+The object of the game is to release two red aces and two black aces
+(regardless of suit) to become foundations and built each of them up by color
+to kings, while at the same time built four columns of cards in the tableau,
+each starting with a King and built down by alternating color.
+<p>
+All exposed cards are available for play to be built either on the foundations
+or in the tableau. Building in the tableau is down by alternating color.
+Sequences can be moved in part or in whole and any empty column can be filled
+only by a King or a sequence that begins with a King.
+<p>
+When there are no more moves to be played, one card is placed onto each column
+from the stock; afterwards, play proceeds as normal. This cycle continues
+until the entire stock has run out.
+<p>
+When a sequence that starts with a King, ends with an Ace, and is built down
+in alternating colors is formed, it may be discarded at the player's
+discretion.
+<p>
+The game ends when soon after the stock has run out. The game is won when 52
+cards are built onto the four foundations while four King sequences are
+discarded.
+<p>
+In winning such a game, the player must decide which cards should be built one
+at a time into the four foundations and which must be built into
+King-foundations which should be discarded later. As a suggestion, the player
+should do neither to help cleaning up a column later. It also helps when the
+player should not touch a completed column of thirteen cards to aid in
+splitting and reach the faced down cards. It is also good to focus on
+releasing the face down cards on the leftmost columns, especially the first
+three ones.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Rouge_et_Noir">http://en.wikipedia.org/wiki/Rouge_et_Noir</a>)</i>

--- a/html-src/wikipedia/royalmarriage.html
+++ b/html-src/wikipedia/royalmarriage.html
@@ -1,34 +1,25 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Royal Marriage</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Royal Marriage is a solitaire card game using a deck of 52
-playing cards.</p>
-<p>The game is so called because the player seems to remove
-anything that comes between the Queen and the King of the same suit
-for them to "marry." Although the King and the Queen may be of any
-suit, commonly it is the King and Queen of Hearts that are being
-"wed." For this same object, this game is also called
-Betrothal.</p>
-<p>The Queen of the suit chosen (most commonly the Queen of Hearts)
-is placed immediately on the table while her corresponding King (in
-this case, the King of Hearts) will always be dealt last. The
-remaining fifty cards are shuffled and placed on the top of the
-King.</p>
-<p>Cards are dealt one at a time to the right of the Queen. When a
-pair of cards with the same rank or suit are found to be separated
-by one or two cards, those in-between cards are discarded.
-Afterwards, the player can look for any resulting pairs with
-in-between cards to be discarded.</p>
-<p>The game is won when Queen and the King are brought together
-with all other cards discarded.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Royal_Marriage">http://en.wikipedia.org/wiki/Royal_Marriage</a>)</i></p>
-</body>
-</html>
+<p>
+Royal Marriage is a solitaire card game using a deck of 52 playing cards.
+<p>
+The game is so called because the player seems to remove anything that comes
+between the Queen and the King of the same suit for them to "marry." Although
+the King and the Queen may be of any suit, commonly it is the King and Queen
+of Hearts that are being "wed." For this same object, this game is also called
+Betrothal.
+<p>
+The Queen of the suit chosen (most commonly the Queen of Hearts) is placed
+immediately on the table while her corresponding King (in this case, the King
+of Hearts) will always be dealt last. The remaining fifty cards are shuffled
+and placed on the top of the King.
+<p>
+Cards are dealt one at a time to the right of the Queen. When a pair of cards
+with the same rank or suit are found to be separated by one or two cards,
+those in-between cards are discarded. Afterwards, the player can look for any
+resulting pairs with in-between cards to be discarded.
+<p>
+The game is won when Queen and the King are brought together with all other
+cards discarded.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Royal_Marriage">http://en.wikipedia.org/wiki/Royal_Marriage</a>)</i>

--- a/html-src/wikipedia/saliclaw.html
+++ b/html-src/wikipedia/saliclaw.html
@@ -1,42 +1,33 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Salic Law</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Salic Law is a solitaire card game using two decks of 52 playing
-cards each. It is named after the Salic Law which prohibits women
-from ascending to the throne or obtaining inheritance.</p>
-<p>First, the Queens are taken out of the stock. Then a King is
-placed on the tableau. The rest on the cards are shuffled and dealt
-on the King to form a column. The player deals as many cards over
-the King until another King appears, starting a new column. This is
-done until all eight Kings are laid out cards have been dealt,
-resulting in eight columns of various lengths.</p>
-<p>During dealing, whenever an Ace appears, it is put onto the
-foundations. In fact, once aces are in the foundations over the
-kings, they can be built up to Jacks regardless of suit, even while
-dealing is in progress as long as the top cards of the columns
-already dealt are available for play, as well as any applicable
-card that appears during dealing.</p>
-<p>Once all cards have been dealt, building to the foundations
-continue. Cards on the tableau cannot be built on each other.
-However, a column containing just a King is considered vacant and
-any card can be placed there. One card can be moved at a time and
-as mentioned earlier, the top card of each column is available for
-play.</p>
-<p>The game is won when all cards available are placed on the
-foundations with the Jacks on the top of the foundations and the
-Kings exposed.</p>
-<p>Sometimes, players still give the Queens a decorative role by
-putting them between the foundations and the King columns or
-shuffling them with the rest of the deck and putting them between
-the foundations and the columns later.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Salic_Law_%28solitaire%29">http://en.wikipedia.org/wiki/Salic_Law_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Salic Law is a solitaire card game using two decks of 52 playing cards each.
+It is named after the Salic Law which prohibits women from ascending to the
+throne or obtaining inheritance.
+<p>
+First, the Queens are taken out of the stock. Then a King is placed on the
+tableau. The rest on the cards are shuffled and dealt on the King to form a
+column. The player deals as many cards over the King until another King
+appears, starting a new column. This is done until all eight Kings are laid
+out cards have been dealt, resulting in eight columns of various lengths.
+<p>
+During dealing, whenever an Ace appears, it is put onto the foundations. In
+fact, once aces are in the foundations over the kings, they can be built up to
+Jacks regardless of suit, even while dealing is in progress as long as the top
+cards of the columns already dealt are available for play, as well as any
+applicable card that appears during dealing.
+<p>
+Once all cards have been dealt, building to the foundations continue. Cards on
+the tableau cannot be built on each other. However, a column containing just a
+King is considered vacant and any card can be placed there. One card can be
+moved at a time and as mentioned earlier, the top card of each column is
+available for play.
+<p>
+The game is won when all cards available are placed on the foundations with
+the Jacks on the top of the foundations and the Kings exposed.
+<p>
+Sometimes, players still give the Queens a decorative role by putting them
+between the foundations and the King columns or shuffling them with the rest
+of the deck and putting them between the foundations and the columns later.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Salic_Law_%28solitaire%29">http://en.wikipedia.org/wiki/Salic_Law_(solitaire)</a>)</i>

--- a/html-src/wikipedia/sevendevils.html
+++ b/html-src/wikipedia/sevendevils.html
@@ -1,43 +1,36 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Seven Devils</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Seven Devils is arguably the most difficult of all solitaire
-games. It is a two pack game widely available as a computer
-version.</p>
-<p>28 cards are dealt out to seven diminishing columns with the
-bottom card of each column face up, and a further seven cards (the
-"devil") are dealt face up to the right of the columns.</p>
-<p>The aim is to move all the cards into thirteen-card sequences on
-the goal piles (at the right of the board), ascending in sequence
-and following suit, starting with the Aces.</p>
-<p>Cards on the table can be stacked red-on-black in descending
-sequence. Any card can be used to fill an empty column.</p>
-<p>Only one card can be moved at a time, but if there are empty
-columns multiple cards can be moved as if the empty columns were
-used as temporary spots.</p>
-<p>The seven devils in the right-hand stack cannot be placed on
-other stacks, and can be moved only to the goal piles.</p>
-<p>The difficulty of this game arises from three factors</p>
+<p>
+Seven Devils is arguably the most difficult of all solitaire games. It is a
+two pack game widely available as a computer version.
+<p>
+28 cards are dealt out to seven diminishing columns with the bottom card of
+each column face up, and a further seven cards (the "devil") are
+dealt face up to the right of the columns.
+<p>
+The aim is to move all the cards into thirteen-card sequences on the goal
+piles (at the right of the board), ascending in sequence and following suit,
+starting with the Aces.
+<p>
+Cards on the table can be stacked red-on-black in descending sequence. Any
+card can be used to fill an empty column.
+<p>
+Only one card can be moved at a time, but if there are empty columns multiple
+cards can be moved as if the empty columns were used as temporary spots.
+<p>
+The seven devils in the right-hand stack cannot be placed on other stacks, and
+can be moved only to the goal piles.
+<p>
+The difficulty of this game arises from three factors
 <ul>
-<li>Many games are unwinnable from the start. If two higher cards
-overlie any card in the same suit in the devil, the lower card can
-never be reached.</li>
-<li>Even if this is not the case, if high cards overlay lower ones
-in the devil, the low cards can be very difficult to get to.</li>
-<li>If low cards like twos or threes cannot be played to a column,
-they will be buried in the discard pile, and become difficult to
-retrieve.</li>
-<li>Key low cards may be hidden face down in columns where they may
-well prove inaccessible</li>
+<li>Many games are unwinnable from the start. If two higher cards overlie any
+card in the same suit in the devil, the lower card can never be reached.
+<li>Even if this is not the case, if high cards overlay lower ones in the
+devil, the low cards can be very difficult to get to.
+<li>If low cards like twos or threes cannot be played to a column, they will
+be buried in the discard pile, and become difficult to retrieve.
+<li>Key low cards may be hidden face down in columns where they may well prove
+inaccessible
 </ul>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Seven_Devils">http://en.wikipedia.org/wiki/Seven_Devils</a>)</i></p>
-</body>
-</html>
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Seven_Devils">http://en.wikipedia.org/wiki/Seven_Devils</a>)</i>

--- a/html-src/wikipedia/shamrocksii.html
+++ b/html-src/wikipedia/shamrocksii.html
@@ -1,37 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Shamrocks</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Shamrocks is a solitaire game akin to <a href=
-"labellelucie.html">La Belle Lucie</a>. The object is the same as
-the latter: move the cards into the foundations.</p>
-<p>The game is layout out as in La Belle Lucie: seventeen piles of
-three cards are placed on the tableau with one card counting as an
-eighteenth. Any card that can be moved to the foundations should be
-moved and built up by suit (starting from the ace). The top card of
-each pile can be used for play and once a pile is empty, it cannot
-be refilled.</p>
-<p>But its similarity to La Belle Lucie ends there. Before the game
-begins, each King which is on top or middle of its respective pile
-is placed underneath. (Morehead and Mott-Smith's rules to the game
-specifically states that a King that is on top of a lower-ranked
-card of the same suit should be placed under that lower-ranked
-card, no matter what else in its pile.) To play on the tableau, a
-card can be placed over a card that is one rank higher or lower,
-regardless of suit (a <b>6</b><img src="../images/s.gif" /> can be
-placed on a <b>7</b><img src="../images/c.gif" /> or a
-<b>5</b><img src="../images/d.gif" />). However, each pile can hold
-no more than three cards at a time; thus no card can be placed on a
-pile with three cards.</p>
-<p>The game is won when all of the cards have been moved to the
-foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Shamrocks">http://en.wikipedia.org/wiki/Shamrocks</a>)</i></p>
-</body>
-</html>
+<p>
+Shamrocks is a solitaire game akin to <a href="labellelucie.html">La Belle
+Lucie</a>. The object is the same as the latter: move the cards into the
+foundations.
+<p>
+The game is layout out as in La Belle Lucie: seventeen piles of three cards
+are placed on the tableau with one card counting as an eighteenth. Any card
+that can be moved to the foundations should be moved and built up by suit
+(starting from the ace). The top card of each pile can be used for play and
+once a pile is empty, it cannot be refilled.
+<p>
+But its similarity to La Belle Lucie ends there. Before the game begins, each
+King which is on top or middle of its respective pile is placed underneath.
+(Morehead and Mott-Smith's rules to the game specifically states that a King
+that is on top of a lower-ranked card of the same suit should be placed under
+that lower-ranked card, no matter what else in its pile.) To play on the
+tableau, a card can be placed over a card that is one rank higher or lower,
+regardless of suit (a <b>6</b><img src="../images/s.gif"> can be placed on a
+<b>7</b><img src="../images/c.gif"> or a <b>5</b><img src="../images/d.gif">).
+However, each pile can hold no more than three cards at a time; thus no card
+can be placed on a pile with three cards.
+<p>
+The game is won when all of the cards have been moved to the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Shamrocks">http://en.wikipedia.org/wiki/Shamrocks</a>)</i>

--- a/html-src/wikipedia/slyfox.html
+++ b/html-src/wikipedia/slyfox.html
@@ -1,56 +1,48 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Sly Fox</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Sly Fox is a solitaire card game played with two decks of 52
-playing cards each. It is probably named because the player has to
-be "sly as fox," so to speak, to win, if played correctly.</p>
-<p>First, one king and one ace of each suit are removed. The aces
-are placed vertically on one side of the tableau, the kings are
-placed on the other side. These form the foundations.</p>
-<p>The rest of the cards are shuffled and twenty cards are placed
-between the ace-foundations and the king foundations. These 20
-cards form the reserve and are available to play only onto the
-foundations. The aces are built up, while the kings are built down,
-all by suit.</p>
-<p>Gameplay is divided into three phases.</p>
-<p>The first phase involves moving the cards from the reserve to
-the foundations for building only. When a card leaves the
-foundation, the gap it leaves behind is immediately filled with a
-new card from the stock. When all possible moves are made, or when
-the player had done all the moves he can make, play moves to the
-second phase.</p>
-<p>The second phase of gameplay involves dealing 20 cards from the
-stock, one at a time, to any of the 20 piles (the cards already
-there serve as bases) on the reserve. It does not matter where each
-card ends up; a pile can contain more than two cards while a pile
-would end up with just one card. In this phase, no building is
-allowed until all twenty cards are deal. Once the twenty cards are
-dealt, gameplay moves to the third phase.</p>
-<p>The third phase is similar to the first phase, moving cards from
-the reserve to the foundations. The top cards of each reserve pile
-are available for play. This time though, when gaps occur, they are
-not immediately filled. Furthermore, the cards on the reserve are
-not built on each other; they can only be transferred to the
-foundations, and cards on the foundations cannot be moved once
-built. When all possible moves have been made, or when the player
-has made all moves one can make, gameplay moves back to the second
-phase.</p>
-<p>During this deal of 20 new cards, the player has the discretion
-of filling the gaps left behind during the third phase. When all
-twenty cards are dealt, gameplay shifts to the third phase. The
-second and third phases are repeated until the stock has been used
-up.</p>
-<p>The game is won when all cards end up in the foundations. As
-mentioned earlier, if done correctly, it can be won; but chances of
-doing this are low.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Sly_Fox_%28solitaire%29">http://en.wikipedia.org/wiki/Sly_Fox_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Sly Fox is a solitaire card game played with two decks of 52 playing cards
+each. It is probably named because the player has to be "sly as fox," so to
+speak, to win, if played correctly.
+<p>
+First, one king and one ace of each suit are removed. The aces are placed
+vertically on one side of the tableau, the kings are placed on the other side.
+These form the foundations.
+<p>
+The rest of the cards are shuffled and twenty cards are placed between the
+ace-foundations and the king foundations. These 20 cards form the reserve and
+are available to play only onto the foundations. The aces are built up, while
+the kings are built down, all by suit.
+<p>
+Gameplay is divided into three phases.
+<p>
+The first phase involves moving the cards from the reserve to the foundations
+for building only. When a card leaves the foundation, the gap it leaves behind
+is immediately filled with a new card from the stock. When all possible moves
+are made, or when the player had done all the moves he can make, play moves to
+the second phase.
+<p>
+The second phase of gameplay involves dealing 20 cards from the stock, one at
+a time, to any of the 20 piles (the cards already there serve as bases) on the
+reserve. It does not matter where each card ends up; a pile can contain more
+than two cards while a pile would end up with just one card. In this phase, no
+building is allowed until all twenty cards are deal. Once the twenty cards are
+dealt, gameplay moves to the third phase.
+<p>
+The third phase is similar to the first phase, moving cards from the reserve
+to the foundations. The top cards of each reserve pile are available for play.
+This time though, when gaps occur, they are not immediately filled.
+Furthermore, the cards on the reserve are not built on each other; they can
+only be transferred to the foundations, and cards on the foundations cannot be
+moved once built. When all possible moves have been made, or when the player
+has made all moves one can make, gameplay moves back to the second phase.
+<p>
+During this deal of 20 new cards, the player has the discretion of filling the
+gaps left behind during the third phase. When all twenty cards are dealt,
+gameplay shifts to the third phase. The second and third phases are repeated
+until the stock has been used up.
+<p>
+The game is won when all cards end up in the foundations. As mentioned
+earlier, if done correctly, it can be won; but chances of doing this are low.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Sly_Fox_%28solitaire%29">http://en.wikipedia.org/wiki/Sly_Fox_(solitaire)</a>)</i>

--- a/html-src/wikipedia/sthelena.html
+++ b/html-src/wikipedia/sthelena.html
@@ -1,72 +1,65 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>St. Helena</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>St. Helena (also known as Napoleon's Favorite or Washington's
-Favorite) is a solitaire card game using two decks of playing cards
-mixed together. Despite its name, it has no connection the island
-with the same name. Furthermore, because of its game play, it
-should not be confused with Napoleon at St. Helena a.k.a. Forty
-Thieves. Explained here is the prevalent version.</p>
-<p>First, one king and one ace of each suit are removed to become
-the bases for the foundations. The kings form the upper
-foundations, while the aces form the lower foundations. Then, the
-rest of the cards are dealt clockwise into twelve piles that run
-from above the left king to its left. The tableau and foundations
-should look like this:</p>
+<p>
+St. Helena (also known as Napoleon's Favorite or Washington's Favorite) is a
+solitaire card game using two decks of playing cards mixed together. Despite
+its name, it has no connection the island with the same name. Furthermore,
+because of its game play, it should not be confused with Napoleon at St.
+Helena a.k.a. Forty Thieves. Explained here is the prevalent version.
+<p>
+First, one king and one ace of each suit are removed to become the bases for
+the foundations. The kings form the upper foundations, while the aces form the
+lower foundations. Then, the rest of the cards are dealt clockwise into twelve
+piles that run from above the left king to its left. The tableau and
+foundations should look like this:
 <pre>
     1  2  3  4
 12  K  K  K  K  5
 11  A  A  A  A  6
    10  9  8  7
 </pre>
-<p>The object is to build the upper foundations down by suit to
-aces while the lower foundations up by suit.</p>
-<p>The top card of each pile surrounding the foundations is
-available for play onto another pile or to the foundations.
-Building on the piles is either up or down by suit. However a king
-cannot be placed over an ace and an ace cannot be placed over a
-king. Only one card can be moved at a time.</p>
-<p>There is no mention in <i>The Complete Book of Solitaire and
-Patience Games</i> of what to do on the spaces. This gives rise to
-at least two rule sets: one that allows any card to be placed in a
-space; and another that does not allow a space to be filled.</p>
-<p>For the first deal, there are restrictions as to which card goes
-to which foundation. Cards on piles 1 to 4 are available only to
-the upper foundations, cards on piles 7 to 10 are available only to
-the lower foundations, and cards on piles 5, 6, 11, and 12 are
-available to either the upper or lower foundations.</p>
-<p>After all possible moves have been made, the piles are collected
-in reverse order. That is, Pile 12 is placed over the Pile 11, then
-the new pile is placed over Pile 10, and so on until all piles are
-placed over Pile 1. Then, without reshuffling, they are redealt
-again, one by one, into twelve piles. This can be done twice. But
-after the cards are dealt anew, the restrictions no longer apply,
-i.e. a card can be placed in any foundation. This goes for after
-the second redeal.</p>
-<p>The game is won when all cards are built into the
-foundations.</p>
+<p>
+The object is to build the upper foundations down by suit to aces while the
+lower foundations up by suit.
+<p>
+The top card of each pile surrounding the foundations is available for play
+onto another pile or to the foundations. Building on the piles is either up or
+down by suit. However a king cannot be placed over an ace and an ace cannot be
+placed over a king. Only one card can be moved at a time.
+<p>
+There is no mention in <i>The Complete Book of Solitaire and Patience
+Games</i> of what to do on the spaces. This gives rise to at least two rule
+sets: one that allows any card to be placed in a space; and another that does
+not allow a space to be filled.
+<p>
+For the first deal, there are restrictions as to which card goes to which
+foundation. Cards on piles 1 to 4 are available only to the upper foundations,
+cards on piles 7 to 10 are available only to the lower foundations, and cards
+on piles 5, 6, 11, and 12 are available to either the upper or lower
+foundations.
+<p>
+After all possible moves have been made, the piles are collected in reverse
+order. That is, Pile 12 is placed over the Pile 11, then the new pile is
+placed over Pile 10, and so on until all piles are placed over Pile 1. Then,
+without reshuffling, they are redealt again, one by one, into twelve piles.
+This can be done twice. But after the cards are dealt anew, the restrictions
+no longer apply, i.e. a card can be placed in any foundation. This goes for
+after the second redeal.
+<p>
+The game is won when all cards are built into the foundations.
+
 <h3>Louis</h3>
-<p>Louis is a solitaire variant of St. Helena. It is played exactly
-as St. Helena except for the follow modifications:</p>
+<p>
+Louis is a solitaire variant of St. Helena. It is played exactly as St. Helena
+except for the follow modifications:
 <ul>
-<li>First, 12 cards are dealt, one on each pile. From these twelve,
-the player builds playable cards onto the foundations, filling a
-gap every time a card is played. Once the game goes on standstill
-at this point, the rest of the deck is dealt onto the twelve
-piles.</li>
-<li>All top cards of piles are available to be built in any
-foundation (no restrictions).</li>
-<li>Building in the piles can be up or down, but always by
-suit.</li>
+<li>First, 12 cards are dealt, one on each pile. From these twelve, the player
+builds playable cards onto the foundations, filling a gap every time a card is
+played. Once the game goes on standstill at this point, the rest of the deck
+is dealt onto the twelve piles.
+<li>All top cards of piles are available to be built in any foundation (no
+restrictions).
+<li>Building in the piles can be up or down, but always by suit.
 </ul>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/St._Helena_%28solitaire%29">http://en.wikipedia.org/wiki/St._Helena_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/St._Helena_%28solitaire%29">http://en.wikipedia.org/wiki/St._Helena_(solitaire)</a>)</i>

--- a/html-src/wikipedia/stonewall.html
+++ b/html-src/wikipedia/stonewall.html
@@ -1,33 +1,27 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Stonewall</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Stonewall is a solitaire card game using a deck of 52 playing
-cards. It is probably named because the player seems to break down
-walls as one exposes more of the face-down cards. Its tableau is
-similar to that of Flower Garden with its beds as columns.</p>
-<p>Thirty-six cards are dealt onto the tableau into six columns of
-six cards each. It should be noted that the exposed (top) card and
-the third and fifth cards from it are faced up while the second,
-fourth, and sixth cards from the top are faced down. The 16
-leftover cards act as the reserve.</p>
-<p>The object of the game is to move the Aces to the foundations
-and build each of them up by suit.</p>
-<p>The top cards of each column, as well as all the cards in the
-reserve, are available for play to the foundations or the tableau.
-Building on the tableau is down by alternating colors and a
-sequence (or a part of a sequence) can be moved as unit. Any gap on
-the tableau can be filled by any exposed card or any sequence.</p>
-<p>The game is won when all cards are built onto the foundations.
-But chances of winning are low, especially, for instance, that the
-needed cards are those faced down.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Stonewall_%28solitaire%29">http://en.wikipedia.org/wiki/Stonewall_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Stonewall is a solitaire card game using a deck of 52 playing cards. It is
+probably named because the player seems to break down walls as one exposes
+more of the face-down cards. Its tableau is similar to that of Flower Garden
+with its beds as columns.
+<p>
+Thirty-six cards are dealt onto the tableau into six columns of six cards
+each. It should be noted that the exposed (top) card and the third and fifth
+cards from it are faced up while the second, fourth, and sixth cards from the
+top are faced down. The 16 leftover cards act as the reserve.
+<p>
+The object of the game is to move the Aces to the foundations and build each
+of them up by suit.
+<p>
+The top cards of each column, as well as all the cards in the reserve, are
+available for play to the foundations or the tableau. Building on the tableau
+is down by alternating colors and a sequence (or a part of a sequence) can be
+moved as unit. Any gap on the tableau can be filled by any exposed card or any
+sequence.
+<p>
+The game is won when all cards are built onto the foundations. But chances of
+winning are low, especially, for instance, that the needed cards are those
+faced down.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Stonewall_%28solitaire%29">http://en.wikipedia.org/wiki/Stonewall_(solitaire)</a>)</i>

--- a/html-src/wikipedia/sultan.html
+++ b/html-src/wikipedia/sultan.html
@@ -1,40 +1,32 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Sultan</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Sultan (or Sultan of Turkey) is a solitaire card game, meaning
-it is played only by one person. However this game uses two packs
-of playing cards.</p>
-<p>These cards make up the foundations and will be built up by suit
-in order. On the single Ace of hearts foundation, the next cards
-will be 2 of hearts, 3 of hearts, etc,. On the Kings, the order is
-Ace, 2, 3, etc, of the appropriate suits. Throughout the game, the
-only card which you cannot place other cards on is the King of
-hearts (the Sultan) in the center location.</p>
-<p>Six cards (or eight in some versions) from the deck are placed
-around the main layout to make up the reserve.</p>
-<p>The player then makes moves, which may be:</p>
+<p>
+Sultan (or Sultan of Turkey) is a solitaire card game, meaning it is played
+only by one person. However this game uses two packs of playing cards.
+<p>
+These cards make up the foundations and will be built up by suit in order. On
+the single Ace of hearts foundation, the next cards will be 2 of hearts, 3 of
+hearts, etc,. On the Kings, the order is Ace, 2, 3, etc, of the appropriate
+suits. Throughout the game, the only card which you cannot place other cards
+on is the King of hearts (the Sultan) in the center location.
+<p>
+Six cards (or eight in some versions) from the deck are placed around the main
+layout to make up the reserve.
+<p>
+The player then makes moves, which may be:
 <ul>
-<li>Taking the top card from the face-down deck and placing it in
-the face-up waste pile.</li>
-<li>Taking the top card from the waste and adding it to one of the
-foundation cards.</li>
-<li>Moving a card from the reserve into the main design (following
-on the suit) and then replacing it with the next card from the
-deck.</li>
+<li>Taking the top card from the face-down deck and placing it in the face-up
+waste pile.
+<li>Taking the top card from the waste and adding it to one of the foundation
+cards.
+<li>Moving a card from the reserve into the main design (following on the
+suit) and then replacing it with the next card from the deck.
 </ul>
-<p>The goal is to end the game with the Sultan (King of Hearts)
-surrounded by his "Queens". When there are no more cards in the
-deck, the player may re-deal (shuffle the waste and place
-face-down), but only twice per game. This means the player may only
-run through the deck three times total, and then the game ends.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Sultan_%28solitaire%29">http://en.wikipedia.org/wiki/Sultan_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+The goal is to end the game with the Sultan (King of Hearts) surrounded by his
+"Queens". When there are no more cards in the deck, the player may re-deal
+(shuffle the waste and place face-down), but only twice per game. This means
+the player may only run through the deck three times total, and then the game
+ends.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Sultan_%28solitaire%29">http://en.wikipedia.org/wiki/Sultan_(solitaire)</a>)</i>

--- a/html-src/wikipedia/tournament.html
+++ b/html-src/wikipedia/tournament.html
@@ -1,59 +1,51 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Tournament</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Tournament is a solitaire card game which uses two decks of
-playing cards shuffled together. Despite the name, the game play
-doesn't seem to be related to the word <i>tournament</i>.</p>
-<p>First, the cards are shuffled and dealt as two columns of four
-cards laid out. The player must make sure that these eight cards
-include either a king, an ace, or both. If neither a king or an ace
-is found among these eight cards, all cards are collected and
-shuffled and two new columns of four cards are dealt. As long there
-is no king or ace among the eight cards, the shuffling and dealing
-continues. When at least a king or an ace are present, six columns
-of four cards are then dealt. At least a king or an ace must be
-present among the first eight cards for the game to work. The first
-eight cards compose the reserve (or "the kibitzers") and the six
-columns of four cards form the tableau (or "the dormitzers").</p>
-<p>The object of the game is to free one king and one ace of each
-suit and built them by suit. The kings should be built down while
-the aces should be built up.</p>
-<p>The top cards of each column on the tableau and all eight cards
-on the reserve are available.</p>
-<p>The cards on the reserve are available to be built on the
-foundations, and any space it leaves behind are filled from any
-from the tableau. But filling spaces doesn't have to be done
-immediately; it is the player's discretion on whether to fill a gap
-or leave it open.</p>
-<p>The cards on the tableau are available only to be built on the
-foundation or placed on a space in the reserve; they are not built
-on each other. In case there is a gap resulting on all cards on the
-column leaving it, it is immediately filled by a new set of four
-cards.</p>
-<p>Furthermore, the top cards of foundations are available to be
-built on each other, handy when the two foundations of the same
-suit meet.</p>
-<p>When the player has made all the moves one could make, four
-cards from the stock are deal onto each column. Then game play
-continues. Dealing of new cards and making of new moves continue
-until all cards have been played.</p>
-<p>After the game play goes on a standstill, the player then
-collects all the cards on the tableau by first gathering the
-rightmost column and placing it on the pile to its left, and then
-placing this new pile to the pile on its left and so on. Then,
-without shuffling, six new columns of four cards each are dealt.
-And game play continues as before. This can be done twice in the
-game.</p>
-<p>The game is won when all cards are dealt onto the
-foundations.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Tournament_%28solitaire%29">http://en.wikipedia.org/wiki/Tournament_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Tournament is a solitaire card game which uses two decks of playing cards
+shuffled together. Despite the name, the game play doesn't seem to be related
+to the word <i>tournament</i>.
+<p>
+First, the cards are shuffled and dealt as two columns of four cards laid out.
+The player must make sure that these eight cards include either a king, an
+ace, or both. If neither a king or an ace is found among these eight cards,
+all cards are collected and shuffled and two new columns of four cards are
+dealt. As long there is no king or ace among the eight cards, the shuffling
+and dealing continues. When at least a king or an ace are present, six columns
+of four cards are then dealt. At least a king or an ace must be present among
+the first eight cards for the game to work. The first eight cards compose the
+reserve (or "the kibitzers") and the six columns of four cards form the
+tableau (or "the dormitzers").
+<p>
+The object of the game is to free one king and one ace of each suit and built
+them by suit. The kings should be built down while the aces should be built
+up.
+<p>
+The top cards of each column on the tableau and all eight cards on the reserve
+are available.
+<p>
+The cards on the reserve are available to be built on the foundations, and any
+space it leaves behind are filled from any from the tableau. But filling
+spaces doesn't have to be done immediately; it is the player's discretion on
+whether to fill a gap or leave it open.
+<p>
+The cards on the tableau are available only to be built on the foundation or
+placed on a space in the reserve; they are not built on each other. In case
+there is a gap resulting on all cards on the column leaving it, it is
+immediately filled by a new set of four cards.
+<p>
+Furthermore, the top cards of foundations are available to be built on each
+other, handy when the two foundations of the same suit meet.
+<p>
+When the player has made all the moves one could make, four cards from the
+stock are deal onto each column. Then game play continues. Dealing of new
+cards and making of new moves continue until all cards have been played.
+<p>
+After the game play goes on a standstill, the player then collects all the
+cards on the tableau by first gathering the rightmost column and placing it on
+the pile to its left, and then placing this new pile to the pile on its left
+and so on. Then, without shuffling, six new columns of four cards each are
+dealt. And game play continues as before. This can be done twice in the game.
+<p>
+The game is won when all cards are dealt onto the foundations.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Tournament_%28solitaire%29">http://en.wikipedia.org/wiki/Tournament_(solitaire)</a>)</i>

--- a/html-src/wikipedia/treasuretrove.html
+++ b/html-src/wikipedia/treasuretrove.html
@@ -1,56 +1,48 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Osmosis</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Osmosis (also known as Treasure Trove) is a solitaire game
-played with a deck of 52 playing cards where the object, like many
-solitaire games, is to put the cards into foundations, although not
-in numerical order.</p>
-<p>Game play consists of a tableau with four piles of four cards
-each (one face-up card on top of three face-down cards). A
-seventeenth card is put in the first of four foundations. Cards
-with the same suit as this card must be moved to this foundation
-and the three other foundations must begin with cards of the same
-rank. All undealt cards make up the stock.</p>
-<p>The top cards in each pile in the tableau are the only cards in
-play and must be moved to the foundations. A card can be moved to a
-foundation if a card of the same value has already been placed in
-the foundation before it. Once cards have been placed on the
-foundation, any face-down cards remaining in the tableau are turned
-face-up. When placing cards from the tableau is no longer possible,
-one can use the stock, deal three cards at a time, and use its top
-card to make possible moves. One can redeal the stock as long as
-there are possible moves from the stock or from the tableau to the
-foundations.</p>
-<p>Here's an example (foundations only):</p>
+<p>
+Osmosis (also known as Treasure Trove) is a solitaire game played with a deck
+of 52 playing cards where the object, like many solitaire games, is to put the
+cards into foundations, although not in numerical order.
+<p>
+Game play consists of a tableau with four piles of four cards each (one
+face-up card on top of three face-down cards). A seventeenth card is put in
+the first of four foundations. Cards with the same suit as this card must be
+moved to this foundation and the three other foundations must begin with cards
+of the same rank. All undealt cards make up the stock.
+<p>
+The top cards in each pile in the tableau are the only cards in play and must
+be moved to the foundations. A card can be moved to a foundation if a card of
+the same value has already been placed in the foundation before it. Once cards
+have been placed on the foundation, any face-down cards remaining in the
+tableau are turned face-up. When placing cards from the tableau is no longer
+possible, one can use the stock, deal three cards at a time, and use its top
+card to make possible moves. One can redeal the stock as long as there are
+possible moves from the stock or from the tableau to the foundations.
+<p>
+Here's an example (foundations only):
 <pre>
-<img src="../images/h.gif" /> 7 8 10 2 4 9 K A
-<img src="../images/s.gif" /> 7 A 8 K 9
-<img src="../images/d.gif" /> 7 8 K
+<img src="../images/h.gif"> 7 8 10 2 4 9 K A
+<img src="../images/s.gif"> 7 A 8 K 9
+<img src="../images/d.gif"> 7 8 K
 </pre>
-<p>Suppose that from the example above, any heart card can be moved
-to the top foundation. One can also place 10<img src=
-"../images/s.gif" /> into its foundation, but one cannot put
-2<img src="../images/d.gif" /> yet into its foundation because
-2<img src="../images/s.gif" /> hasn't turned up yet in its
-foundation. No club cannot be placed at this time as the 7<img src=
-"../images/c.gif" /> hasn't appeared.</p>
-<p>The game is won when all cards have been moved to the
-foundations. But winning any game can rely on where certain cards
-are placed in the either one of the piles in the tableau or in the
-stock pile. Because of this, finishing a game of Osmosis is slim if
-not rare.</p>
+<p>
+Suppose that from the example above, any heart card can be moved to the top
+foundation. One can also place 10<img src="../images/s.gif"> into its
+foundation, but one cannot put 2<img src="../images/d.gif"> yet into its
+foundation because 2<img src="../images/s.gif"> hasn't turned up yet in its
+foundation. No club cannot be placed at this time as the 7<img
+src="../images/c.gif"> hasn't appeared.
+<p>
+The game is won when all cards have been moved to the foundations. But winning
+any game can rely on where certain cards are placed in the either one of the
+piles in the tableau or in the stock pile. Because of this, finishing a game
+of Osmosis is slim if not rare.
+
 <h3>Peek</h3>
-<p>Peek is another solitaire card game using a deck of 52 playing
-cards. It is played exactly as Osmosis except all the cards on this
-game's tableau are face-up.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Osmosis_%28solitaire%29">http://en.wikipedia.org/wiki/Osmosis_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Peek is another solitaire card game using a deck of 52 playing cards. It is
+played exactly as Osmosis except all the cards on this game's tableau are
+face-up.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Osmosis_%28solitaire%29">http://en.wikipedia.org/wiki/Osmosis_(solitaire)</a>)</i>

--- a/html-src/wikipedia/virginiareel.html
+++ b/html-src/wikipedia/virginiareel.html
@@ -1,63 +1,60 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Virginia Reel</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Virginia Reel is a solitaire card game which uses two decks of
-52 playing cards mixed together. The object of the game is to place
-all the cards in the 24 foundations.</p>
-<p>First three cards, a 2, a 3, and a 4, are placed vertically.
-Then, beside each of the three cards is a row of seven cards. The
-first card in each row shows that it is the row for all other cards
-with the same rank. The first row is known as the "2s' row," the
-second row the "3s' row," and the third row the "4s' row."</p>
-<p>A fourth row of eight cards is dealt. This serves as the reserve
-with each card forming a pile.</p>
-<p>The foundations are built up by suit in intervals of three. The
-table below shows how.</p>
+<p>
+Virginia Reel is a solitaire card game which uses two decks of 52 playing
+cards mixed together. The object of the game is to place all the cards in the
+24 foundations.
+<p>
+First three cards, a 2, a 3, and a 4, are placed vertically. Then, beside each
+of the three cards is a row of seven cards. The first card in each row shows
+that it is the row for all other cards with the same rank. The first row is
+known as the "2s' row," the second row the "3s' row," and the third row the
+"4s' row."
+<p>
+A fourth row of eight cards is dealt. This serves as the reserve with each
+card forming a pile.
+<p>
+The foundations are built up by suit in intervals of three. The table below
+shows how.
 <pre>
 <b>2</b>  5  8  J
 <b>3</b>  6  9  Q
 <b>4</b>  7 10  K
 </pre>
-<p>To play, a card can be moved to a foundation or to a rightful
-row from the other rows or from the reserve. But the player has to
-bear in mind that when a card is moved from anywhere in the
-tableau, <i>the gap it leaves behind must be filled with a card
-appropriate for the row where the gap is located</i>. For instance,
-when a card has left the 2s' row, the gap it left behind must be
-filled with a 2, either from the other rows or from the reserve.
-This is especially true at the beginning of the game, where some
-cards are on each other's rows like a 4 in the 3s' row and a 3 in
-the 4s' row. Exchanging cards to their rightful rows in this case
-is also possible.</p>
-<p>While the first card in each row is already a foundation in
-itself and it can be built on, once a card ends up in its proper
-row no matter where in the row, it becomes a foundation itself.</p>
-<p>The top cards in the reserve are in play and can be placed on
-the foundations, or be placed on a row (if it is a 2, 3, or 4), but
-empty piles are not filled until a new batch of eight cards are
-dealt every time no more moves are possible.</p>
-<p>Aces play no part in this game. Any ace that is in the reserve
-is immediately discarded. But an ace in any of the rows must be
-replaced by any applicable card for that row. So in order to
-discard an ace from the 2s' row, for example, a 2 must be available
-to replace it.</p>
-<p>The game is considered won when all the cards are in
-foundations, with all face cards on top.</p>
+<p>
+To play, a card can be moved to a foundation or to a rightful row from the
+other rows or from the reserve. But the player has to bear in mind that when a
+card is moved from anywhere in the tableau, <i>the gap it leaves behind must be
+filled with a card appropriate for the row where the gap is located</i>. For
+instance, when a card has left the 2s' row, the gap it left behind must be
+filled with a 2, either from the other rows or from the reserve. This is
+especially true at the beginning of the game, where some cards are on each
+other's rows like a 4 in the 3s' row and a 3 in the 4s' row. Exchanging cards
+to their rightful rows in this case is also possible.
+<p>
+While the first card in each row is already a foundation in itself and it can
+be built on, once a card ends up in its proper row no matter where in the row,
+it becomes a foundation itself.
+<p>
+The top cards in the reserve are in play and can be placed on the foundations,
+or be placed on a row (if it is a 2, 3, or 4), but empty piles are not filled
+until a new batch of eight cards are dealt every time no more moves are
+possible.
+<p>
+Aces play no part in this game. Any ace that is in the reserve is immediately
+discarded. But an ace in any of the rows must be replaced by any applicable
+card for that row. So in order to discard an ace from the 2s' row, for
+example, a 2 must be available to replace it.
+<p>
+The game is considered won when all the cards are in foundations, with all
+face cards on top.
+<p>
 <h3>Royal Parade</h3>
-<p>Royal Parade is another solitaire card game which is played much
-the same way as Virginia Reel. The difference between this game and
-Virginia Reel is that in Royal Parade when a card is moved from
-anywhere in the tableau, <i>the gap it leaves behind does not have
-to be filled right away</i>. It can be filled later by a card
-appropriate for the row that the gap is located in.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Virginia_Reel_%28solitaire%29">http://en.wikipedia.org/wiki/Virginia_Reel_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Royal Parade is another solitaire card game which is played much the same way
+as Virginia Reel. The difference between this game and Virginia Reel is that
+in Royal Parade when a card is moved from anywhere in the tableau, <i>the gap
+it leaves behind does not have to be filled right away</i>. It can be filled
+later by a card appropriate for the row that the gap is located in.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Virginia_Reel_%28solitaire%29">http://en.wikipedia.org/wiki/Virginia_Reel_(solitaire)</a>)</i>

--- a/html-src/wikipedia/zodiac.html
+++ b/html-src/wikipedia/zodiac.html
@@ -1,62 +1,54 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<meta name="generator" content=
-"HTML Tidy for HTML5 for Linux version 5.4.0" />
-<title></title>
-</head>
-<body>
 <h1>Zodiac</h1>
 <h3>From Wikipedia, the free encyclopedia</h3>
-<p>Zodiac is a solitaire card game which is played with two decks
-of playing cards shuffled together. It is an old game which first
-appeared in Lady Adelaide Cadogan's book <i>Illustrated Games of
-Patience</i> is so-named probably because of its "globe"-shaped
-layout.</p>
-<p>First, eight cards are deal in a row. They form the cells which
-make up the reserve, or the "Equator". Each reserve cell can only
-hold one card. Then twenty four cards are dealt in a circle
-surrounding the Equator to form the tableau, or the "Zodiac."</p>
-<p>The game is divided into two phases: the first phases consists
-of playing the rest of the cards into the Zodiac and the Equator;
-the second phase is the building of the cards into the
-foundations.</p>
-<p>In the first phase of the game, the cards in the Zodiac are
-built up or down by suit; the build can change direction in the
-same pile. However, the cards in Zodiac cannot be touched until the
-second phase. This means that until the second phase starts, the
-cards in the Zodiac cannot be used to build on each other. Also,
-any card build on a pile in the Zodiac stays there until the start
-of the second phase.</p>
-<p>The cards on the Equator are used to build on the cards on the
-Zodiac. The space in the Equator can be filled with an available
-card from the stock or the top card of the wastepile. However,
-filling a space is not compulsory, i.e. a player can leave a space
-open for as long as the player finds it advantageous.</p>
-<p>Meanwhile, the stock is dealt one card at a time, and unplayable
-cards are placed on a wastepile, the top card of which is available
-to be built on a pile in the Zodiac or to fill a space on the
-Equator. Once the stock runs out, the player can just pick up the
-remaining cards in the wastepile and turn it face down to make it
-the new stock. The player can do this as many times as he wants as
-long as there still more cards neither in the Zodiac nor in the
-Equator.</p>
-<p>Only when all cards are both in the Zodiac and in the Equator,
-the second phase begins. The cards in the Zodiac and Equator are
-built straight to the foundations. The foundations are built up by
-suit from Aces to Kings. The game is won when all the cards are
-built on the foundations.</p>
-<p>At any point in the game, when it becomes stuck, i.e. the cards
-in the stock/wastepile cannot be built without blocking other cards
-during the first phase, or encountering a block during the second
-phase, the game is lost.</p>
-<p>Obviously the player must have great care and consideration in
-building the cards in the Zodiac in order for the game to be won.
-Also, the layout of the game is large when played with
-standard-sized playing cards. So, as a suggestion, the player can
-just deal eight cards for the Equator and twenty-four cards for the
-Zodiac to save space.</p>
-<p><i>(Retrieved from <a href=
-"http://en.wikipedia.org/wiki/Zodiac_%28solitaire%29">http://en.wikipedia.org/wiki/Zodiac_(solitaire)</a>)</i></p>
-</body>
-</html>
+<p>
+Zodiac is a solitaire card game which is played with two decks of playing
+cards shuffled together. It is an old game which first appeared in Lady
+Adelaide Cadogan's book <i>Illustrated Games of Patience</i> is so-named
+probably because of its "globe"-shaped layout.
+<p>
+First, eight cards are deal in a row. They form the cells which make up the
+reserve, or the "Equator". Each reserve cell can only hold one card. Then
+twenty four cards are dealt in a circle surrounding the Equator to form the
+tableau, or the "Zodiac."
+<p>
+The game is divided into two phases: the first phases consists of playing the
+rest of the cards into the Zodiac and the Equator; the second phase is the
+building of the cards into the foundations.
+<p>
+In the first phase of the game, the cards in the Zodiac are built up or down
+by suit; the build can change direction in the same pile. However, the cards
+in Zodiac cannot be touched until the second phase. This means that until the
+second phase starts, the cards in the Zodiac cannot be used to build on each
+other. Also, any card build on a pile in the Zodiac stays there until the
+start of the second phase.
+<p>
+The cards on the Equator are used to build on the cards on the Zodiac. The
+space in the Equator can be filled with an available card from the stock or
+the top card of the wastepile. However, filling a space is not compulsory,
+i.e. a player can leave a space open for as long as the player finds it
+advantageous.
+<p>
+Meanwhile, the stock is dealt one card at a time, and unplayable cards are
+placed on a wastepile, the top card of which is available to be built on a
+pile in the Zodiac or to fill a space on the Equator. Once the stock runs out,
+the player can just pick up the remaining cards in the wastepile and turn it
+face down to make it the new stock. The player can do this as many times as he
+wants as long as there still more cards neither in the Zodiac nor in the
+Equator.
+<p>
+Only when all cards are both in the Zodiac and in the Equator, the second
+phase begins. The cards in the Zodiac and Equator are built straight to the
+foundations. The foundations are built up by suit from Aces to Kings. The game
+is won when all the cards are built on the foundations.
+<p>
+At any point in the game, when it becomes stuck, i.e. the cards in the
+stock/wastepile cannot be built without blocking other cards during the first
+phase, or encountering a block during the second phase, the game is lost.
+<p>
+Obviously the player must have great care and consideration in building the
+cards in the Zodiac in order for the game to be won. Also, the layout of the
+game is large when played with standard-sized playing cards. So, as a
+suggestion, the player can just deal eight cards for the Equator and
+twenty-four cards for the Zodiac to save space.
+<p>
+<i>(Retrieved from <a href="http://en.wikipedia.org/wiki/Zodiac_%28solitaire%29">http://en.wikipedia.org/wiki/Zodiac_(solitaire)</a>)</i>

--- a/pysollib/htmllib2.py
+++ b/pysollib/htmllib2.py
@@ -64,6 +64,25 @@ class HTMLParser(htmllib.HTMLParser):
             else:
                 self.formatter.add_flowing_data(data)
 
+    def handle_starttag(self, tag, attrs):
+        try:
+            method = getattr(self, 'start_' + tag)
+        except AttributeError:
+            try:
+                method = getattr(self, 'do_' + tag)
+            except AttributeError:
+                self.unknown_starttag(tag, attrs)
+                return
+        method(attrs)
+
+    def handle_endtag(self, tag):
+        try:
+            method = getattr(self, 'end_' + tag)
+        except AttributeError:
+            self.unknown_endtag(tag)
+            return
+        method()
+
     # --- Hooks to save data; shouldn't need to be overridden
 
     def save_bgn(self):

--- a/pysollib/htmllib2.py
+++ b/pysollib/htmllib2.py
@@ -4,7 +4,11 @@ See the HTML 2.0 specification:
 http://www.w3.org/hypertext/WWW/MarkUp/html-spec/html-spec_toc.html
 """
 
-import html.parser as htmllib
+try:
+    import html.parser as htmllib
+except ImportError:
+    # For Python 2 tests compatibility
+    import HTMLParser as htmllib
 
 from formatter import AS_IS
 

--- a/pysollib/htmllib2.py
+++ b/pysollib/htmllib2.py
@@ -4,18 +4,18 @@ See the HTML 2.0 specification:
 http://www.w3.org/hypertext/WWW/MarkUp/html-spec/html-spec_toc.html
 """
 
-import sgmllib
+import html.parser as htmllib
 
 from formatter import AS_IS
 
 __all__ = ["HTMLParser", "HTMLParseError"]
 
 
-class HTMLParseError(sgmllib.SGMLParseError):
+class HTMLParseError(RuntimeError):
     """Error raised when an HTML document can't be parsed."""
 
 
-class HTMLParser(sgmllib.SGMLParser):
+class HTMLParser(htmllib.HTMLParser):
     """This is the basic HTML parser class.
 
     It supports all entity names required by the XHTML 1.0 Recommendation.
@@ -33,14 +33,14 @@ class HTMLParser(sgmllib.SGMLParser):
         the parser.
 
         """
-        sgmllib.SGMLParser.__init__(self, verbose)
+        htmllib.HTMLParser.__init__(self)
         self.formatter = formatter
 
     def error(self, message):
         raise HTMLParseError(message)
 
     def reset(self):
-        sgmllib.SGMLParser.reset(self)
+        htmllib.HTMLParser.reset(self)
         self.savedata = None
         self.isindex = 0
         self.title = None

--- a/pysollib/htmllib2.py
+++ b/pysollib/htmllib2.py
@@ -26,7 +26,7 @@ class HTMLParser(htmllib.HTMLParser):
 
     from six.moves.html_entities import entitydefs
 
-    def __init__(self, formatter, verbose=0):
+    def __init__(self, formatter):
         """Creates an instance of the HTMLParser class.
 
         The formatter parameter is the formatter instance associated with


### PR DESCRIPTION
This pull request fixes the HTML help system of PySolFC and removes dependency on sgmllib3k.

### HTML help

All HTML help files were reverted to state before [ada977](https://github.com/shlomif/PySolFC/commit/ada97788799e2f28f3c16a453196c5acc1f09ecb).
Correct way to "compile" help files is by calling ```make rules``` (this was also changed in README).

Processing of these files is done in ```gen-html.py```, that was converted to python 3 and issues with unclosed files were fixed.

After this change, the help system correctly shows pages for individual game rules, alternate names, includes header and footer for each page and other things.

### sgmllib3k

```sgmllib``` was replaced by ```html.parser```. Code for handling tags inspired by sgmllib was added, so correct handling function for a given tag is called and formatting works correctly.
When running tests with python 2, there were import errors, since html.parser has different name in python 2, so a fallback to that module name was added.

Dependencies on sgmllib3k were removed from appveyor and travis.

### Things to do

Since html help should be created with ```make rules```, this should be somehow added to the appveyor script, but I'd like someone else to look at it as I'm not familiar with it.

Otherwise, all tests from the testing suite passed.