### PR TITLE
Fix appveyor artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,6 +30,7 @@ test_script:
     - set FCS_USE_TEST_RUN=1
     - gmake pretest
     - perl run-tests.pl
+    - gmake rules
     - python3 setup.py py2exe
     - 7z a -r pysol_win_dist.7z dist\
 artifacts:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,7 @@ install:
     - python3 -mpip install random2
     - python3 -mpip install py2exe
     - python3 -mpip install six
+    - python3 -mpip install Pillow
     - perl -v
     - copy C:\msys64\mingw64\bin\mingw32-make.exe C:\msys64\mingw64\bin\make.exe
     - SET PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%

--- a/pysollib/main.py
+++ b/pysollib/main.py
@@ -38,6 +38,7 @@ from pysollib.pysolaudio import AbstractAudioClient, \
         PysolSoundServerModuleClient
 from pysollib.pysolaudio import Win32AudioClient, OSSAudioClient, \
         PyGameAudioClient, KivyAudioClient
+from pysollib.pysolaudio import pysolsoundserver
 from pysollib.settings import TITLE, SOUND_MOD, TOOLKIT
 from pysollib.winsystems import init_root_window
 
@@ -268,7 +269,8 @@ def pysol_init(app, args):
         snd.append(PyGameAudioClient)
         if TOOLKIT == 'kivy':
             snd.append(KivyAudioClient)
-        snd.append(PysolSoundServerModuleClient)
+        if pysolsoundserver:
+            snd.append(PysolSoundServerModuleClient)
         snd.append(OSSAudioClient)
         snd.append(Win32AudioClient)
         snd.append(AbstractAudioClient)


### PR DESCRIPTION
This fixes appveyor build for Windows by including the rules and Pillow package (so that images are loaded correctly).
It also checks if pysolsoundserver is available. If not, it doesn't raise an exception when trying to start audio server.
This PR is related to issue #58.