### PR TITLE
Include cardsets in MacOS .app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ deploy:
 dist: trusty
 before_install:
     - if test "$TRAVIS_OS_NAME" = "osx" ; then export CPPFLAGS="$CPPFLAGS -I$(brew --prefix openssl)/include" PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig:$PKG_CONFIG_PATH" LDFLAGS="$LDFLAGS -L$(brew --prefix openssl)/lib" ;fi
+    - if test "$TRAVIS_OS_NAME" = "osx" ; then wget --content-disposition https://sourceforge.net/projects/pysolfc/files/PySolFC-Cardsets/minimal/PySolFC-Cardsets--Minimal-2.0.tar.xz/download && tar xJf PySolFC-Cardsets--Minimal-2.0.tar.xz && mv PySolFC-Cardsets--Minimal-2.0/cardset-* data ; fi
 install:
     - sudo cpanm Code::TidyAll::Plugin::Flake8 Perl::Tidy Test::Code::TidyAll Test::Differences Test::TrailingSpace
     - export PY_MODS='pycotap random2 six'

--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
+brew "perl"
 brew "cpanminus"
 brew "gettext", link: true
 brew "gnutls"


### PR DESCRIPTION
This fixes #102 by, when building the `.app`, downloading the `PySolFC-Cardsets--Minimal` tarball from SourceForge and unpacking it where the `.app`-building process looks for cardsets.

When I created the my fork, Travis CI invariably reported test failures from the Mac builders even for unmodified code. While I'm not sure why tests failed running under `kingjon3377/PySolFC` but not under `shlomif/PySolFC`, I did find that installing a more recent Perl through Homebrew was enough to see those tests pass for the unmodified code. So that change is also included here; if you prefer, I could open a separate pull request for that instead.

With these changes applied, opening `PySolFC.app` using the `open` command (or, I presume, double-clicking it or opening it using Spotlight or any other "normal" invocation) seems to hang (as in the experiment I mentioned in the last paragraph of my initial report in #102), but I found I can get the window to appear by clicking the icon in the Dock, and I'm used to invoking the app's binary from the command line (because 2.0 crashed without the command-line parameter `--nosound`), so I'm not too worried about that.