### PR TITLE
Update pysol.desktop for unix desktop integration

### DIFF
--- a/data/pysol.desktop
+++ b/data/pysol.desktop
@@ -1,8 +1,10 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=PySol Fan Club Edition
+Comment=More than 1000 solitaire card games
 Exec=pysol.py
+StartupWMClass=Pysol
 Terminal=false
 Type=Application
 Categories=Game;CardGame;
+Keywords=solitaire;patience;cards;pysolfc;klondike;
 Icon=/usr/share/icons/pysol01.png


### PR DESCRIPTION
I'm working on getting the Debian package updated to 2.6.4, and while doing that also checked out the desktop file which seemed to need a little update. 