### PR TITLE
Define canMoveCards() for Hanafuda sequence stacks

### DIFF
--- a/pysollib/games/ultra/hanafuda_common.py
+++ b/pysollib/games/ultra/hanafuda_common.py
@@ -286,6 +286,9 @@ class Hanafuda_SequenceStack(Flower_OpenStack):
             return cards[0].rank == 0 or self.cap.base_rank == ANY_RANK
         return self.isHanafudaSequence([stackcards[-1], cards[0]])
 
+    def canMoveCards(self, cards):
+        return self.basicCanMoveCards(cards) and self.isHanafudaSequence(cards)
+
 
 class Oonsoo_SequenceStack(Flower_OpenStack):
 
@@ -297,6 +300,9 @@ class Oonsoo_SequenceStack(Flower_OpenStack):
         if not len(stackcards):
             return cards[0].rank == 0 or self.cap.base_rank == ANY_RANK
         return self.isHanafudaSequence([stackcards[-1], cards[0]], 0)
+
+    def canMoveCards(self, cards):
+        return self.basicCanMoveCards(cards) and self.isHanafudaSequence(cards, 0)
 
 
 class FlowerClock_RowStack(Flower_OpenStack):


### PR DESCRIPTION
Hi,

I'm forwarding a patch by fbriere. It has been lingering in https://bugs.debian.org/859047 for a couple of years now. I do not know the rules to Hanafuda, but the effect on Firecracker is as he describes.

From: Frédéric Brière <fbriere@fbriere.net>
To: Debian Bug Tracking System <submit@bugs.debian.org>
Subject: pysolfc: Any stack of Hanafuda cards is always movable
Date: Wed, 29 Mar 2017 14:49:27 -0400
> Any stack of Hanafuda cards is always deemed movable, even if it is out
> of sequence.  The effect can easily be seen a game such as Firecracker,
> where:
> 
>  - Any stack can be dragged as a whole (but not released)
>  - "Highlight piles" will highlight everything
>  - Asking for a hint will ignore most valid moves
> 
> This is due to Hanafuda_SequenceStack lacking a canMoveCards() method.