### PR TITLE
FHS compliance and ignore removed copyright

### DIFF
--- a/docs/pysolfc.6
+++ b/docs/pysolfc.6
@@ -69,9 +69,9 @@ the current directory
 .br
 /usr/local/share/PySolFC
 .br
-/usr/games/PySolFC
+/usr/share/games/PySolFC
 .br
-/usr/local/games/PySolFC
+/usr/local/share/games/PySolFC
 .PP
 Options are saved in \fB~/.PySolFC/options.cfg\fR
 .PP

--- a/pysollib/app.py
+++ b/pysollib/app.py
@@ -1211,11 +1211,10 @@ Please select a %s type %s.
                     d = os.path.join(dirname, name)
                     if not os.path.isdir(d):
                         continue
-                    f1 = os.path.join(d, "config.txt")
-                    f2 = os.path.join(d, "COPYRIGHT")
-                    if os.path.isfile(f1) and os.path.isfile(f2):
+                    f = os.path.join(d, "config.txt")
+                    if os.path.isfile(f):
                         try:
-                            cs = self._readCardsetConfig(d, f1)
+                            cs = self._readCardsetConfig(d, f)
                             if cs:
                                 # from pprint import pprint
                                 # print cs.name
@@ -1232,7 +1231,7 @@ Please select a %s type %s.
                                     fnames[cs.name] = 1
                             else:
                                 print_err('fail _readCardsetConfig: %s %s'
-                                          % (d, f1))
+                                          % (d, f))
                                 pass
                         except Exception:
                             # traceback.print_exc()

--- a/pysollib/settings.py
+++ b/pysollib/settings.py
@@ -63,8 +63,8 @@ if os.name == 'posix':
     DATA_DIRS = [
         '/usr/share/PySolFC',
         '/usr/local/share/PySolFC',
-        '/usr/games/PySolFC',
-        '/usr/local/games/PySolFC',
+        '/usr/share/games/PySolFC',
+        '/usr/local/share/games/PySolFC',
         ]
 if os.name == 'nt':
     pass


### PR DESCRIPTION
My overarching goal is to simplify the Debian packaging by bringing the changes upstream where possible.

The first commit fixes the default search paths by adding `.../share/...` that was missing.

The second commit allows one to use cardsets which don't have a COPYRIGHT file.