### PR TITLE
Localization changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ rules:
 
 pot:
 	./scripts/all_games.py gettext > po/games.pot
-	xgettext --keyword=n_ -o po/pysol.pot \
+	xgettext --keyword=n_ --add-comments=TRANSLATORS: -o po/pysol.pot \
 		pysollib/*.py pysollib/*/*.py pysollib/*/*/*.py data/pysolfc.glade
 	set -e; \
 	for lng in ru de pl it; do \

--- a/po/de_pysol.po
+++ b/po/de_pysol.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PySol 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-18 19:21+0300\n"
+"POT-Creation-Date: 2019-08-31 00:20+0300\n"
 "PO-Revision-Date: 2007-09-05 17:43+0400\n"
 "Last-Translator: H. Schaekel <Holger.Schaekel@web.de>\n"
 "Language-Team: German\n"
@@ -12,14 +12,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: pysollib/actions.py:232 pysollib/kivy/toolbar.py:191
-#: pysollib/tile/toolbar.py:176 pysollib/tk/toolbar.py:176
+#: pysollib/actions.py:232 pysollib/kivy/menubar.py:291
+#: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
+#: pysollib/tk/toolbar.py:176
 msgid "New game"
 msgstr "Neues Spiel"
 
 #: pysollib/actions.py:247 pysollib/kivy/menubar.py:1667
-#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1014
-#: pysollib/ui/tktile/menubar.py:1030
+#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1015
+#: pysollib/ui/tktile/menubar.py:1031
 msgid "Select game"
 msgstr "Spiel auswählen"
 
@@ -49,19 +50,19 @@ msgstr ""
 "\n"
 "Neue Spielnummer eingeben"
 
-#: pysollib/actions.py:293 pysollib/app.py:523 pysollib/app.py:817
-#: pysollib/game/__init__.py:1270 pysollib/game/__init__.py:2487
-#: pysollib/kivy/tkhtml.py:690 pysollib/kivy/tkstats.py:249
+#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/app.py:818
+#: pysollib/game/__init__.py:1305 pysollib/game/__init__.py:2526
+#: pysollib/kivy/tkhtml.py:691 pysollib/kivy/tkstats.py:254
 #: pysollib/kivy/tkwidget.py:97 pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/pysolgtk/tkhtml.py:542
-#: pysollib/pysolgtk/tkstats.py:556 pysollib/pysolgtk/tkwidget.py:151
+#: pysollib/pysolgtk/tkstats.py:557 pysollib/pysolgtk/tkwidget.py:151
 #: pysollib/tile/fontsdialog.py:140 pysollib/tile/fontsdialog.py:202
 #: pysollib/tile/menubar.py:111 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:545
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/soundoptionsdialog.py:188 pysollib/tile/timeoutsdialog.py:92
-#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:540
-#: pysollib/tile/tkstats.py:645 pysollib/tile/tkstats.py:726
+#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:541
+#: pysollib/tile/tkstats.py:646 pysollib/tile/tkstats.py:727
 #: pysollib/tile/tkwidget.py:138 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/playeroptionsdialog.py:64
@@ -69,45 +70,45 @@ msgstr ""
 #: pysollib/tk/selectcardset.py:506 pysollib/tk/selecttile.py:152
 #: pysollib/tk/soundoptionsdialog.py:152 pysollib/tk/soundoptionsdialog.py:193
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkstats.py:278
-#: pysollib/tk/tkstats.py:505 pysollib/tk/tkstats.py:574
-#: pysollib/tk/tkstats.py:591 pysollib/tk/tkstats.py:639
-#: pysollib/tk/tkstats.py:712 pysollib/tk/tkstats.py:796
-#: pysollib/tk/tkstats.py:963 pysollib/tk/tkwidget.py:143
+#: pysollib/tk/tkstats.py:506 pysollib/tk/tkstats.py:575
+#: pysollib/tk/tkstats.py:592 pysollib/tk/tkstats.py:640
+#: pysollib/tk/tkstats.py:713 pysollib/tk/tkstats.py:797
+#: pysollib/tk/tkstats.py:964 pysollib/tk/tkwidget.py:143
 #: pysollib/tk/tkwidget.py:351 pysollib/tk/wizarddialog.py:132
 #: pysollib/ui/tktile/colorsdialog.py:118
 #: pysollib/ui/tktile/edittextdialog.py:38
 #: pysollib/ui/tktile/gameinfodialog.py:152 pysollib/ui/tktile/tkhtml.py:435
 msgid "&OK"
-msgstr "ОК"
+msgstr "&OK"
 
 #: pysollib/actions.py:293
 msgid "&Next number"
-msgstr "Nächste Nummer"
+msgstr "&Nächste Nummer"
 
-#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/game/__init__.py:1270
-#: pysollib/game/__init__.py:1939 pysollib/game/__init__.py:1957
-#: pysollib/game/__init__.py:1965 pysollib/game/__init__.py:1972
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2068
-#: pysollib/kivy/selectcardset.py:61
+#: pysollib/actions.py:293 pysollib/app.py:525 pysollib/game/__init__.py:1305
+#: pysollib/game/__init__.py:1979 pysollib/game/__init__.py:1995
+#: pysollib/game/__init__.py:2003 pysollib/game/__init__.py:2010
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2069
+#: pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/pysolgtk/selectgame.py:324
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/tile/fontsdialog.py:140
 #: pysollib/tile/fontsdialog.py:202 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:543
-#: pysollib/tile/selectgame.py:308 pysollib/tile/selectgame.py:438
+#: pysollib/tile/selectgame.py:306 pysollib/tile/selectgame.py:436
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/timeoutsdialog.py:92 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/menubar.py:89
 #: pysollib/tk/menubar.py:90 pysollib/tk/playeroptionsdialog.py:64
 #: pysollib/tk/playeroptionsdialog.py:138 pysollib/tk/selectcardset.py:313
-#: pysollib/tk/selectgame.py:310 pysollib/tk/selectgame.py:439
+#: pysollib/tk/selectgame.py:306 pysollib/tk/selectgame.py:437
 #: pysollib/tk/selecttile.py:152 pysollib/tk/soundoptionsdialog.py:152
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkwidget.py:351
 #: pysollib/tk/wizarddialog.py:132 pysollib/ui/tktile/colorsdialog.py:118
 #: pysollib/ui/tktile/edittextdialog.py:38
 msgid "&Cancel"
-msgstr "Abbruch"
+msgstr "&Abbruch"
 
 #: pysollib/actions.py:311
 msgid "Select random game"
@@ -119,208 +120,243 @@ msgstr "Nächstes Spiel auswählen"
 
 #: pysollib/actions.py:384 pysollib/kivy/toolbar.py:206
 #: pysollib/tile/toolbar.py:191 pysollib/tk/toolbar.py:191
-msgid "Quit "
-msgstr "Beenden "
+#, python-format
+msgid "Quit %s"
+msgstr "%s beenden"
 
 #: pysollib/actions.py:447
 msgid "Clear bookmarks"
 msgstr "Lesezeichen löschen"
 
 #: pysollib/actions.py:448
-msgid "Clear all bookmarks ?"
+msgid "Clear all bookmarks?"
 msgstr "Alle Lesezeichen löschen?"
 
-#: pysollib/actions.py:459
+#: pysollib/actions.py:459 pysollib/kivy/menubar.py:293
 msgid "Restart game"
 msgstr "Spiel Neustart"
 
 #: pysollib/actions.py:460
-msgid "Restart this game ?"
+msgid "Restart this game?"
 msgstr "Dieses Spiel neustarten?"
 
-#: pysollib/actions.py:505
+#: pysollib/actions.py:506
 #, python-format
 msgid ""
-"Comments for %s:\n"
+"Comments for %(game)s %(id)s:\n"
 "\n"
 msgstr ""
-"Kommentare für %s:\n"
+"Kommentare für %(game)s %(id)s:\n"
 "\n"
 
-#: pysollib/actions.py:507
-msgid "Comments for "
-msgstr "Kommentare für "
+#: pysollib/actions.py:508
+#, python-format
+msgid "Comments for %(id)s"
+msgstr "Kommentare für %(id)s"
 
-#: pysollib/actions.py:525 pysollib/actions.py:549
+#: pysollib/actions.py:526 pysollib/actions.py:551
 msgid "Error while writing to file"
 msgstr "Fehler beim Schreiben in die Datei"
 
-#: pysollib/actions.py:528 pysollib/actions.py:552
-msgid " Info"
-msgstr " Info"
+#: pysollib/actions.py:529 pysollib/actions.py:554
+#, python-format
+msgid "%s Info"
+msgstr "%s Info"
 
-#: pysollib/actions.py:529
+#: pysollib/actions.py:530
+#, python-format
 msgid ""
 "Comments were appended to\n"
 "\n"
+"%(filename)s"
 msgstr ""
 "Kommentare wurden angehängt an\n"
 "\n"
+"%(filename)s"
 
-#: pysollib/actions.py:538
-msgid "Demo statistics"
-msgstr "Demo Statistiken"
-
-#: pysollib/actions.py:541
-msgid "Your statistics"
-msgstr "Ihre Statistiken"
-
-#: pysollib/actions.py:553
+#: pysollib/actions.py:540
+#, python-format
 msgid ""
-" were appended to\n"
+"Demo statistics were appended to\n"
 "\n"
+"%(filename)s"
 msgstr ""
-" wird angehängt an\n"
+"Demo Statistiken wurden angehängt an\n"
 "\n"
+"%(filename)s"
 
-#: pysollib/actions.py:567
-msgid " Demo"
-msgstr " Demo"
+#: pysollib/actions.py:543
+#, python-format
+msgid ""
+"Your statistics were appended to\n"
+"\n"
+"%(filename)s"
+msgstr ""
+"Ihre Statistiken wurden angehängt an\n"
+"\n"
+"%(filename)s"
 
-#: pysollib/actions.py:567
-msgid " Demo "
-msgstr " Demo "
+#: pysollib/actions.py:581
+#, fuzzy, python-format
+msgid "%(app)s Demo Statistics for %(game)s"
+msgstr "Statistiken für %(game)s"
 
-#: pysollib/actions.py:570 pysollib/actions.py:591
-msgid " for "
-msgstr " für "
+#: pysollib/actions.py:582
+#, python-format
+msgid "Statistics for %(game)s"
+msgstr "Statistiken für %(game)s"
 
-#: pysollib/actions.py:576 pysollib/stats.py:202
-msgid "Statistics for "
-msgstr "Statistiken für "
+#: pysollib/actions.py:587
+#, python-format
+msgid "%(app)s Demo Statistics"
+msgstr "%(app)s Demo Statistiken"
 
-#: pysollib/actions.py:581 pysollib/kivy/menubar.py:1613
-#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:176
-#: pysollib/tile/selectgame.py:387 pysollib/tile/tkstats.py:51
-#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:387
-#: pysollib/tk/toolbar.py:188
-msgid "Statistics"
-msgstr "Statistiken"
+#: pysollib/actions.py:588 pysollib/stats.py:202
+#, python-format
+msgid "Statistics for %(player)s"
+msgstr "Statistiken für %(player)s"
 
-#: pysollib/actions.py:585 pysollib/tile/tkstats.py:522 data/pysolfc.glade:1404
-msgid "Full log"
-msgstr "Volles Protokoll"
+#: pysollib/actions.py:592
+#, python-format
+msgid "%(app)s Demo Full log"
+msgstr ""
 
-#: pysollib/actions.py:588 pysollib/tile/tkstats.py:526 data/pysolfc.glade:1466
-msgid "Session log"
-msgstr "Sitzungsprotokoll"
+#: pysollib/actions.py:593 pysollib/stats.py:235
+#, python-format
+msgid "Full log for %(player)s"
+msgstr "Volles Protokoll für %(player)s"
 
-#: pysollib/actions.py:595
+#: pysollib/actions.py:596
+#, python-format
+msgid "%(app)s Demo Session log"
+msgstr "%(app)s Demo Sitzungsprotokoll"
+
+#: pysollib/actions.py:597 pysollib/stats.py:242
+#, python-format
+msgid "Session log for %(player)s"
+msgstr "Sitzungsprotokoll für %(player)s"
+
+#. TRANSLATORS: eg. top 10 or top 5 results for a certain game
+#: pysollib/actions.py:601
+#, fuzzy, python-format
+msgid "%(app)s Demo Top %(tops)d for %(game)s"
+msgstr "Statistiken für %(game)s"
+
+#: pysollib/actions.py:602
+#, python-format
+msgid "Top %(tops)d for %(game)s"
+msgstr ""
+
+#: pysollib/actions.py:606
 msgid "Game Info"
 msgstr "Spiel Info"
 
-#: pysollib/actions.py:598
+#: pysollib/actions.py:609
 msgid "Statistics progression"
 msgstr "Progessive Statistiken"
 
-#: pysollib/actions.py:616
+#: pysollib/actions.py:627
 msgid "Reset all statistics"
 msgstr "Rest aller Statisken"
 
-#: pysollib/actions.py:617
-#, python-format
+#: pysollib/actions.py:628
+#, fuzzy, python-format
 msgid ""
 "Reset ALL statistics and logs for player\n"
-"%s ?"
+"%(player)s?"
 msgstr ""
 "Rest aller Statistiken und Protokolle für Spieler\n"
-"%s?"
+"%(player)s?"
 
-#: pysollib/actions.py:626
+#: pysollib/actions.py:638
 msgid "Reset game statistics"
 msgstr "Reset Spielstatistiken"
 
-#: pysollib/actions.py:627
+#: pysollib/actions.py:639
 #, fuzzy, python-format
 msgid ""
 "Reset statistics and logs for player\n"
-"%s\n"
+"%(player)s\n"
 "and game\n"
-"%s ?"
+"%(game)s?"
 msgstr ""
 "Rest aller Statistiken und Protokolle für Spieler\n"
 "%s?"
 
-#: pysollib/actions.py:692
+#: pysollib/actions.py:704
 msgid "Play demo"
 msgstr "Demo spielen"
 
-#: pysollib/actions.py:704
+#: pysollib/actions.py:716
 msgid "Set player options"
 msgstr "Spieleroptionen setzen"
 
-#: pysollib/actions.py:720 data/pysolfc.glade:1986
+#: pysollib/actions.py:732 data/pysolfc.glade:1986
 msgid "Set colors"
 msgstr "Farben setzen"
 
-#: pysollib/actions.py:738
+#: pysollib/actions.py:750
 msgid "Set fonts"
 msgstr "Schriften einstellen"
 
-#: pysollib/actions.py:748 data/pysolfc.glade:1493
+#: pysollib/actions.py:760 data/pysolfc.glade:1493
 msgid "Set timeouts"
 msgstr "Zeitablauf setzen"
 
 #: pysollib/app.py:332
-msgid "can't find game: "
+#, python-format
+msgid "can't find game: %(game)s"
 msgstr ""
 
-#: pysollib/app.py:525 pysollib/game/__init__.py:1939
-#: pysollib/game/__init__.py:1957 pysollib/game/__init__.py:1965
-#: pysollib/game/__init__.py:1972 pysollib/ui/tktile/menubar.py:300
+#: pysollib/app.py:526 pysollib/game/__init__.py:1979
+#: pysollib/game/__init__.py:1995 pysollib/game/__init__.py:2003
+#: pysollib/game/__init__.py:2010 pysollib/ui/tktile/menubar.py:300
 msgid "&New game"
-msgstr "Neues Spiel"
+msgstr "&Neues Spiel"
 
-#: pysollib/app.py:671
-#, python-format
-msgid "Loading %s %s..."
+#: pysollib/app.py:672
+#, fuzzy, python-format
+msgid "Loading cardset %s..."
 msgstr "Lade %s %s..."
 
-#: pysollib/app.py:713
-msgid " load error"
-msgstr " Ladefehler"
-
 #: pysollib/app.py:714
-msgid "Error while loading "
+#, fuzzy
+msgid "Cardset load error"
+msgstr "Kartenset-Ladefehler"
+
+#: pysollib/app.py:715
+#, fuzzy
+msgid "Error while loading cardset"
 msgstr "Fehler während des Ladens"
 
-#: pysollib/app.py:809
-msgid "Incompatible "
-msgstr "Inkompatibel "
+#: pysollib/app.py:810
+#, fuzzy
+msgid "Incompatible cardset"
+msgstr "Inkompatibel Kartenset"
 
-#: pysollib/app.py:811
-#, python-format
+#: pysollib/app.py:812
+#, fuzzy, python-format
 msgid ""
-"The currently selected %s %s\n"
+"The currently selected cardset %(cardset)s\n"
 "is not compatible with the game\n"
-"%s\n"
+"%(game)s\n"
 "\n"
-"Please select a %s type %s.\n"
+"Please select a %(correct_type)s type cardset.\n"
 msgstr ""
-"Die aktuell gewählte %s %s\n"
-"ist mit dem Spiel nicht kompatibel\n"
-"%s\n"
+"Die aktuell gewählte Kartenset %(cardset)s\n"
+"ist nicht kompatibel mit dem Spiel\n"
+"%(game)s\n"
 "\n"
-"Bitte als %s Typ %s.\n"
+"Bitte wählen Sie ein %(correct_type)s-Kartenset.\n"
 
-#: pysollib/app.py:855
-#, python-format
-msgid "Please select a %s type %s"
-msgstr "Bitte wählen Sie ein %s als Typ %s"
+#: pysollib/app.py:856
+#, fuzzy, python-format
+msgid "Please select a %s type cardset"
+msgstr "Bitte wählen Sie ein %s-Kartenset"
 
-#: pysollib/app.py:1063
+#: pysollib/app.py:1064
 #, python-format
-msgid "error loading plugin %s: %s"
+msgid "error loading plugin %(file)s: %(err)s"
 msgstr ""
 
 #: pysollib/gamedb.py:109
@@ -533,24 +569,24 @@ msgid "Puzzle type"
 msgstr "Puzzle"
 
 #: pysollib/help.py:43
-msgid "A Python Solitaire Game Collection\n"
-msgstr "Eine Python Spielesammlung\n"
+msgid "A Python Solitaire Game Collection"
+msgstr "Eine Python Spielesammlung"
 
 #: pysollib/help.py:45
-msgid "A World Domination Project\n"
-msgstr "Ein \"World Domination\" Projekt\n"
+msgid "A World Domination Project"
+msgstr "Ein „World Domination“ Projekt"
 
 #: pysollib/help.py:46
 msgid "&Nice"
-msgstr "Nett"
+msgstr "&Nett"
 
 #: pysollib/help.py:46
 msgid "&Credits..."
-msgstr "Danksagung..."
+msgstr "&Danksagung..."
 
 #: pysollib/help.py:48
 msgid "&Enjoy"
-msgstr "Genießen"
+msgstr "G&enießen"
 
 #: pysollib/help.py:49
 #, python-format
@@ -558,14 +594,16 @@ msgid "Version %s"
 msgstr "Version %s"
 
 #: pysollib/help.py:50
-msgid "About "
-msgstr "Über "
+#, python-format
+msgid "About %s"
+msgstr "Über %s"
 
 #: pysollib/help.py:52
 #, python-format
 msgid ""
 "PySol Fan Club edition\n"
-"%s%s\n"
+"%(description)s\n"
+"%(versioninfo)s\n"
 "\n"
 "Copyright (C) 1998 - 2003 Markus F.X.J. Oberhumer.\n"
 "Copyright (C) 2003 Mt. Hood Playing Card Co.\n"
@@ -578,14 +616,14 @@ msgid ""
 "For more information about this application visit"
 msgstr ""
 
-#: pysollib/help.py:88
+#: pysollib/help.py:90
 msgid "Credits"
 msgstr "Danksagung"
 
-#: pysollib/help.py:89
+#: pysollib/help.py:91
 #, python-format
 msgid ""
-" credits go to:\n"
+"%(app)s credits go to:\n"
 "\n"
 "Volker Weidner for getting me into Solitaire\n"
 "Guido van Rossum for the initial example program\n"
@@ -594,21 +632,26 @@ msgid ""
 "The Gnome AisleRiot team for parts of the documentation\n"
 "Natascha\n"
 "\n"
-"The Python, %s, SDL & Linux crews\n"
+"The Python, %(gui_library)s, SDL & Linux crews\n"
 "for making this program possible"
 msgstr ""
 
-#: pysollib/help.py:125
-msgid " HTML Problem"
-msgstr " HTML Problem"
+#: pysollib/help.py:127 pysollib/kivy/tkhtml.py:687
+#, python-format
+msgid "%s HTML Problem"
+msgstr "%s HTML Problem"
 
-#: pysollib/help.py:126
-msgid "Cannot find help document\n"
+#: pysollib/help.py:128
+#, fuzzy, python-format
+msgid ""
+"Cannot find help document\n"
+"%s"
 msgstr "Kann kein Hilfedokument finden\n"
 
-#: pysollib/help.py:139
-msgid " Help"
-msgstr " Hilfe"
+#: pysollib/help.py:141
+#, python-format
+msgid "%s Help"
+msgstr "%s Hilfe"
 
 #: pysollib/main.py:58 pysollib/main.py:70 pysollib/main.py:304
 #, python-format
@@ -618,50 +661,46 @@ msgstr "%s Installationsfehler"
 #: pysollib/main.py:59
 #, fuzzy, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Cardsets should be installed into:\n"
-"%s/cardsets/\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "Keine Kartensets gefunden!!!\n"
 "\n"
 "Hauptverzeichnis ist:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Biite überprüfen Sie Ihre %s Installation.\n"
+"Bitte überprüfen Sie die Installation von %(app)s.\n"
 
-#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:312
+#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:313
 #: pysollib/ui/tktile/menubar.py:346
 msgid "&Quit"
-msgstr "Beenden"
+msgstr "&Beenden"
 
 #: pysollib/main.py:71
 #, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "Keine Kartensets gefunden!!!\n"
 "\n"
 "Hauptverzeichnis ist:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Biite überprüfen Sie Ihre %s Installation.\n"
+"Bitte überprüfen Sie die Installation von %(app)s.\n"
 
 #: pysollib/main.py:96
 #, python-format
-msgid ""
-"%s\n"
-"try %s --help for more information"
-msgstr ""
-"%s\n"
-"Versuchen Sie %s --help für mehr Informationen"
+msgid "try %s --help for more information"
+msgstr "versuchen Sie %s --help für weitere Informationen"
 
 #: pysollib/main.py:128
 #, python-format
@@ -721,20 +760,20 @@ msgstr "Willkommen zu %s"
 #, python-format
 msgid ""
 "\n"
-"No games were found !!!\n"
+"No games were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "\n"
 "Keine Spiele gefunden!!!\n"
 "\n"
 "Hauptdatenverzeichnis ist:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Überprüfen Sie Ihre Installation %s.\n"
+"Überprüfen Sie Ihre Installation %(app)s.\n"
 
 #: pysollib/options.py:266
 msgid "Unknown"
@@ -1078,8 +1117,8 @@ msgid "Unlimited redeals."
 msgstr "Unlimitierte Neudecks."
 
 #: pysollib/stack.py:1948
-#, python-format
-msgid "%d readeal"
+#, fuzzy, python-format
+msgid "%d redeal"
 msgid_plural "%d redeals"
 msgstr[0] "%d Wiederholung"
 msgstr[1] "%d Wiederholungen"
@@ -1288,66 +1327,66 @@ msgstr "Zwischentalon."
 msgid "Free cell."
 msgstr "Free Cell."
 
-#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:421
-#: pysollib/pysolgtk/tkstats.py:458 pysollib/tile/tkstats.py:674
+#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:422
+#: pysollib/pysolgtk/tkstats.py:459 pysollib/tile/tkstats.py:675
 msgid "Game"
 msgstr "Spiel"
 
-#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:422
-#: pysollib/tile/tkstats.py:908 pysollib/tile/tkstats.py:977
-#: pysollib/tile/tkstats.py:978 pysollib/tk/tkstats.py:886
-#: pysollib/tk/tkstats.py:887 pysollib/tk/tkstats.py:934
+#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:423
+#: pysollib/tile/tkstats.py:909 pysollib/tile/tkstats.py:978
+#: pysollib/tile/tkstats.py:979 pysollib/tk/tkstats.py:887
+#: pysollib/tk/tkstats.py:888 pysollib/tk/tkstats.py:935
 msgid "Played"
 msgstr "Gespielt"
 
-#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:423
-#: pysollib/tile/tkstats.py:914 pysollib/tile/tkstats.py:982
-#: pysollib/tile/tkstats.py:983 pysollib/tk/tkstats.py:891
-#: pysollib/tk/tkstats.py:892 pysollib/tk/tkstats.py:942
+#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/tile/tkstats.py:915 pysollib/tile/tkstats.py:983
+#: pysollib/tile/tkstats.py:984 pysollib/tk/tkstats.py:892
+#: pysollib/tk/tkstats.py:893 pysollib/tk/tkstats.py:943
 msgid "Won"
 msgstr "Gewonnen"
 
-#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:425
 msgid "Lost"
 msgstr "Verloren"
 
 #: pysollib/stats.py:44 pysollib/pysolgtk/statusbar.py:98
-#: pysollib/pysolgtk/tkstats.py:425 pysollib/tile/statusbar.py:154
+#: pysollib/pysolgtk/tkstats.py:426 pysollib/tile/statusbar.py:154
 #: pysollib/tk/statusbar.py:151 data/pysolfc.glade:1133
 msgid "Playing time"
 msgstr "Spielzeit"
 
-#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:426
+#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:427
 #: data/pysolfc.glade:1178
 msgid "Moves"
 msgstr "Bewegungen"
 
-#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:427
-#: pysollib/tile/tkstats.py:920 pysollib/tile/tkstats.py:950
-#: pysollib/tile/tkstats.py:969 pysollib/tile/tkstats.py:987
-#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:878
-#: pysollib/tk/tkstats.py:896 pysollib/tk/tkstats.py:950
+#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:428
+#: pysollib/tile/tkstats.py:921 pysollib/tile/tkstats.py:951
+#: pysollib/tile/tkstats.py:970 pysollib/tile/tkstats.py:988
+#: pysollib/tk/tkstats.py:860 pysollib/tk/tkstats.py:879
+#: pysollib/tk/tkstats.py:897 pysollib/tk/tkstats.py:951
 msgid "% won"
 msgstr "% gewonnen"
 
 #: pysollib/stats.py:108 pysollib/pysolgtk/statusbar.py:100
-#: pysollib/pysolgtk/tkstats.py:389 pysollib/pysolgtk/tkstats.py:459
-#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:677
-#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:670
+#: pysollib/pysolgtk/tkstats.py:390 pysollib/pysolgtk/tkstats.py:460
+#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:678
+#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:671
 msgid "Game number"
 msgstr "Spielenummer"
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:390
-#: pysollib/pysolgtk/tkstats.py:460 pysollib/tile/tkstats.py:680
-#: pysollib/tk/tkstats.py:673
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:391
+#: pysollib/pysolgtk/tkstats.py:461 pysollib/tile/tkstats.py:681
+#: pysollib/tk/tkstats.py:674
 msgid "Started at"
 msgstr "Gestartet bei"
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:461
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:462
 msgid "Status"
 msgstr "Status"
 
-#: pysollib/stats.py:132 pysollib/tile/tkstats.py:696
+#: pysollib/stats.py:132 pysollib/tile/tkstats.py:697
 #, python-format
 msgid "** UNKNOWN %d **"
 msgstr ""
@@ -1368,23 +1407,16 @@ msgstr "Nicht gewonnen"
 msgid "Perfect"
 msgstr "Perfekt"
 
-#: pysollib/stats.py:201 pysollib/stats.py:233 pysollib/stats.py:240
+#: pysollib/stats.py:201 pysollib/stats.py:234 pysollib/stats.py:241
+#: pysollib/kivy/menubar.py:443
 msgid "Demo"
 msgstr "Demo"
 
 #: pysollib/stats.py:212 pysollib/pysolgtk/tkstats.py:70
 #: pysollib/tile/tkstats.py:371 pysollib/tk/tkstats.py:413
 #, python-format
-msgid "Total (%d out of %d games)"
-msgstr "Total (%d aus %d Spielen)"
-
-#: pysollib/stats.py:234
-msgid "Full log for "
-msgstr "Voll für Dich "
-
-#: pysollib/stats.py:241
-msgid "Session log for "
-msgstr "Sitzungsprotokoll für "
+msgid "Total (%(played)d out of %(total)d games)"
+msgstr "Total (%(played)d aus %(total)d Spielen)"
 
 #: pysollib/util.py:45
 msgid "Club"
@@ -1451,48 +1483,48 @@ msgid "Initial setting:"
 msgstr "Initiale Einstellung:"
 
 #: pysollib/wizardutil.py:105 pysollib/pysolgtk/selectgame.py:114
-#: pysollib/tile/selectgame.py:393 pysollib/tk/selectgame.py:395
+#: pysollib/tile/selectgame.py:391 pysollib/tk/selectgame.py:392
 msgid "Name:"
 msgstr "Name:"
 
 #: pysollib/wizardutil.py:109 pysollib/kivy/selectgame.py:202
 #: pysollib/pysolgtk/selectgame.py:236 pysollib/pysolgtk/selectgame.py:473
-#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:563
-#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:564
+#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:561
+#: pysollib/tk/selectgame.py:179 pysollib/tk/selectgame.py:562
 msgid "Luck only"
 msgstr "Nur Glück"
 
 #: pysollib/wizardutil.py:110 pysollib/kivy/selectgame.py:204
 #: pysollib/pysolgtk/selectgame.py:237 pysollib/pysolgtk/selectgame.py:474
-#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:564
-#: pysollib/tk/selectgame.py:183 pysollib/tk/selectgame.py:565
+#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:562
+#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:563
 msgid "Mostly luck"
 msgstr "Meist glücklich"
 
 #: pysollib/wizardutil.py:111 pysollib/wizardutil.py:115
 #: pysollib/kivy/selectgame.py:206 pysollib/pysolgtk/selectgame.py:238
 #: pysollib/pysolgtk/selectgame.py:475 pysollib/tile/selectgame.py:183
-#: pysollib/tile/selectgame.py:565 pysollib/tk/selectgame.py:185
-#: pysollib/tk/selectgame.py:566
+#: pysollib/tile/selectgame.py:563 pysollib/tk/selectgame.py:183
+#: pysollib/tk/selectgame.py:564
 msgid "Balanced"
 msgstr "Ausgewogen"
 
 #: pysollib/wizardutil.py:112 pysollib/kivy/selectgame.py:208
 #: pysollib/pysolgtk/selectgame.py:239 pysollib/pysolgtk/selectgame.py:476
-#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:566
-#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:567
+#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:564
+#: pysollib/tk/selectgame.py:186 pysollib/tk/selectgame.py:565
 msgid "Mostly skill"
 msgstr "viel Geschicklichkeit"
 
 #: pysollib/wizardutil.py:113 pysollib/kivy/selectgame.py:210
 #: pysollib/pysolgtk/selectgame.py:240 pysollib/pysolgtk/selectgame.py:477
-#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:567
-#: pysollib/tk/selectgame.py:190 pysollib/tk/selectgame.py:568
+#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:565
+#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:566
 msgid "Skill only"
 msgstr "Nur Geschicklichkeit"
 
 #: pysollib/wizardutil.py:116 pysollib/pysolgtk/selectgame.py:118
-#: pysollib/tile/selectgame.py:397 pysollib/tk/selectgame.py:399
+#: pysollib/tile/selectgame.py:395 pysollib/tk/selectgame.py:396
 msgid "Skill level:"
 msgstr "Schwierigkeitsgrad:"
 
@@ -1547,8 +1579,8 @@ msgstr "Gründe für eine Scheidung"
 #: pysollib/wizardutil.py:147 pysollib/wizardutil.py:185
 #: pysollib/wizardutil.py:243 pysollib/wizardutil.py:301
 #: pysollib/pysolgtk/selectgame.py:117 pysollib/tile/selectcardset.py:454
-#: pysollib/tile/selectgame.py:396 pysollib/tk/selectcardset.py:445
-#: pysollib/tk/selectgame.py:398
+#: pysollib/tile/selectgame.py:394 pysollib/tk/selectcardset.py:445
+#: pysollib/tk/selectgame.py:395
 msgid "Type:"
 msgstr "Typ:"
 
@@ -1570,7 +1602,7 @@ msgstr "Drei neue Decks"
 
 #: pysollib/wizardutil.py:155 pysollib/kivy/selectgame.py:252
 #: pysollib/pysolgtk/selectgame.py:273 pysollib/tile/selectgame.py:231
-#: pysollib/tk/selectgame.py:233
+#: pysollib/tk/selectgame.py:231
 msgid "Unlimited redeals"
 msgstr "Unlimitierte Neudecks"
 
@@ -1640,6 +1672,7 @@ msgid "Direction:"
 msgstr "Richtung:"
 
 #: pysollib/wizardutil.py:204 pysollib/wizardutil.py:250
+#: pysollib/kivy/menubar.py:884
 msgid "None"
 msgstr "Nein"
 
@@ -1764,127 +1797,115 @@ msgstr "Reserven"
 msgid "Opening deal"
 msgstr "Eröffnungskauf"
 
-#: pysollib/game/__init__.py:139 pysollib/game/__init__.py:145
-#, fuzzy
+#: pysollib/game/__init__.py:140 pysollib/game/__init__.py:146
 msgid "Player\n"
-msgstr "Spieler"
+msgstr "Spieler\n"
 
-#: pysollib/game/__init__.py:1266
+#: pysollib/game/__init__.py:1301
 #, fuzzy
-msgid "Discard current game ?"
+msgid "Discard current game?"
 msgstr ""
 "Neustart des\n"
 "aktuellen Spiels"
 
-#: pysollib/game/__init__.py:1887
+#: pysollib/game/__init__.py:1922
 #, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of playing time\n"
-"and # %d in the %s of moves."
+"# %(timerank)d in the top %(tops)d of playing time\n"
+"and # %(movesrank)d in the top %(tops)d of moves."
 msgstr ""
 
-#: pysollib/game/__init__.py:1893
+#: pysollib/game/__init__.py:1930
 #, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of playing time."
+"# %(timerank)d in the top %(tops)d of playing time."
 msgstr ""
 
-#: pysollib/game/__init__.py:1898
+#: pysollib/game/__init__.py:1936
 #, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of moves."
+"# %(movesrank)d in the top %(tops)s of moves."
 msgstr ""
 
-#: pysollib/game/__init__.py:1931 pysollib/game/__init__.py:1947
+#: pysollib/game/__init__.py:1971 pysollib/game/__init__.py:1987
 #, python-format
 msgid ""
-"Your playing time is %s\n"
-"for %d move."
+"Your playing time is %(time)s\n"
+"for %(n)d move."
 msgid_plural ""
-"Your playing time is %s\n"
-"for %d moves."
+"Your playing time is %(time)s\n"
+"for %(n)d moves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: pysollib/game/__init__.py:1936 pysollib/game/__init__.py:1952
-#: pysollib/pysolgtk/soundoptionsdialog.py:71
+#: pysollib/game/__init__.py:1975
+msgid ""
+"Congratulations, this\n"
+"was a truly perfect game!"
+msgstr ""
+
+#: pysollib/game/__init__.py:1977 pysollib/game/__init__.py:1993
+#: pysollib/kivy/tkwidget.py:170 pysollib/pysolgtk/soundoptionsdialog.py:71
 #: pysollib/tile/soundoptionsdialog.py:83 pysollib/tk/soundoptionsdialog.py:85
 msgid "Game won"
 msgstr "Spiel gewonnen"
 
-#: pysollib/game/__init__.py:1937
-#, python-format
-msgid ""
-"\n"
-"Congratulations, this\n"
-"was a truly perfect game !\n"
-"\n"
-"%s\n"
-"%s\n"
+#: pysollib/game/__init__.py:1991
+msgid "Congratulations, you did it!"
 msgstr ""
 
-#: pysollib/game/__init__.py:1954
-#, python-format
-msgid ""
-"\n"
-"Congratulations, you did it !\n"
-"\n"
-"%s\n"
-"%s\n"
-msgstr ""
-
-#: pysollib/game/__init__.py:1963 pysollib/game/__init__.py:1970
-#: pysollib/pysolgtk/soundoptionsdialog.py:69
+#: pysollib/game/__init__.py:2001 pysollib/game/__init__.py:2008
+#: pysollib/kivy/tkwidget.py:173 pysollib/pysolgtk/soundoptionsdialog.py:69
 #: pysollib/tile/soundoptionsdialog.py:81 pysollib/tk/soundoptionsdialog.py:83
 msgid "Game finished"
 msgstr "Spiel beendet"
 
-#: pysollib/game/__init__.py:1964 pysollib/game/__init__.py:2488
-#, fuzzy
+#: pysollib/game/__init__.py:2002 pysollib/game/__init__.py:2527
 msgid ""
 "\n"
 "Game finished\n"
-msgstr "Spiel beendet"
+msgstr ""
+"\n"
+"Spiel beendet\n"
 
-#: pysollib/game/__init__.py:1971
+#: pysollib/game/__init__.py:2009
 msgid ""
 "\n"
 "Game finished, but not without my help...\n"
 msgstr ""
 
-#: pysollib/game/__init__.py:1972
-#, fuzzy
+#: pysollib/game/__init__.py:2010
 msgid "&Restart"
-msgstr "Neustart"
+msgstr "Neusta&rt"
 
-#: pysollib/game/__init__.py:2368
+#: pysollib/game/__init__.py:2406
 #, python-format
 msgid "Score %6d"
 msgstr ""
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 msgid "&Great"
 msgstr ""
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 msgid "&Cool"
 msgstr ""
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 msgid "&Yeah"
 msgstr ""
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 msgid "&Wow"
 msgstr ""
 
-#: pysollib/game/__init__.py:2474
+#: pysollib/game/__init__.py:2512
 #, python-format
 msgid ""
 "\n"
@@ -1895,62 +1916,61 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: pysollib/game/__init__.py:2478 pysollib/game/__init__.py:2492
-#: pysollib/game/__init__.py:2506
-#, fuzzy
-msgid " Autopilot"
-msgstr "Autopilot gewinnt"
+#: pysollib/game/__init__.py:2517 pysollib/game/__init__.py:2532
+#: pysollib/game/__init__.py:2547
+#, python-format
+msgid "%s Autopilot"
+msgstr "%s Autopilot"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Oh well"
 msgstr ""
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&That's life"
 msgstr ""
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Hmm"
 msgstr ""
 
-#: pysollib/game/__init__.py:2507
+#: pysollib/game/__init__.py:2548
 msgid ""
 "\n"
 "This won't come out...\n"
 msgstr ""
 
-#: pysollib/game/__init__.py:2966
+#: pysollib/game/__init__.py:3000
 #, fuzzy
 msgid "Set bookmark"
 msgstr "Lesezeichen löschen"
 
-#: pysollib/game/__init__.py:2967
+#: pysollib/game/__init__.py:3001
 #, python-format
-msgid "Replace existing bookmark %d ?"
+msgid "Replace existing bookmark %d?"
 msgstr ""
 
-#: pysollib/game/__init__.py:2988
+#: pysollib/game/__init__.py:3022
 #, fuzzy
 msgid "Goto bookmark"
 msgstr "Lesezeichen löschen"
 
-#: pysollib/game/__init__.py:2989
-#, python-format
-msgid "Goto bookmark %d ?"
-msgstr ""
+#: pysollib/game/__init__.py:3023
+#, fuzzy, python-format
+msgid "Goto bookmark %d?"
+msgstr "Lesezeichen löschen"
 
-#: pysollib/game/__init__.py:3015
+#: pysollib/game/__init__.py:3049
 #, fuzzy
 msgid "Open game"
 msgstr "Neues Spiel"
 
-#: pysollib/game/__init__.py:3028 pysollib/game/__init__.py:3037
-#: pysollib/game/__init__.py:3043
-#, fuzzy
+#: pysollib/game/__init__.py:3062 pysollib/game/__init__.py:3071
+#: pysollib/game/__init__.py:3077
 msgid "Load game error"
-msgstr " Ladefehler"
+msgstr "Ladefehler"
 
-#: pysollib/game/__init__.py:3030
+#: pysollib/game/__init__.py:3064
 msgid ""
 "Error while loading game.\n"
 "\n"
@@ -1958,41 +1978,41 @@ msgid ""
 "but this could also be a bug you might want to report."
 msgstr ""
 
-#: pysollib/game/__init__.py:3038
+#: pysollib/game/__init__.py:3072
 #, fuzzy
 msgid "Error while loading game"
 msgstr "Fehler während des Ladens"
 
-#: pysollib/game/__init__.py:3045
+#: pysollib/game/__init__.py:3079
 msgid ""
 "Internal error while loading game.\n"
 "\n"
 "Please report this bug."
 msgstr ""
 
-#: pysollib/game/__init__.py:3071 pysollib/ui/tktile/menubar.py:1675
+#: pysollib/game/__init__.py:3105 pysollib/ui/tktile/menubar.py:1677
 #, fuzzy
 msgid "Save game error"
 msgstr "Spiel speichern"
 
-#: pysollib/game/__init__.py:3072
+#: pysollib/game/__init__.py:3106
 #, fuzzy
 msgid "Error while saving game"
 msgstr "Fehler während des Ladens"
 
-#: pysollib/game/__init__.py:3091
+#: pysollib/game/__init__.py:3125
 #, python-format
 msgid "Invalid or damaged %s save file"
 msgstr ""
 
-#: pysollib/game/__init__.py:3111
+#: pysollib/game/__init__.py:3145
 #, python-format
 msgid ""
 "Cannot load games saved with\n"
-"%s version %s"
+"%(app)s version %(ver)s"
 msgstr ""
 
-#: pysollib/game/__init__.py:3130
+#: pysollib/game/__init__.py:3164
 #, python-format
 msgid ""
 "Cannot load this game from version %s\n"
@@ -2044,7 +2064,7 @@ msgstr "Tableau. Erstellt nach unten nach Farbe oder denselben Rang."
 
 #: pysollib/games/fan.py:315
 msgid "X"
-msgstr "Х"
+msgstr "X"
 
 #: pysollib/games/fan.py:315
 msgid "Draw"
@@ -2077,10 +2097,10 @@ msgstr "Reserve. Nur Könige sind erlaubt."
 
 #: pysollib/games/matriarchy.py:123
 #, python-format
-msgid "Round %d/%d"
-msgstr "Runde %d/%d"
+msgid "Round %(round)d/%(max_rounds)d"
+msgstr "Runde %(round)d/%(max_rounds)d"
 
-#: pysollib/games/matriarchy.py:125
+#: pysollib/games/matriarchy.py:126
 #, fuzzy, python-format
 msgid "Deal %d"
 msgstr "Aufnahmen"
@@ -2111,7 +2131,7 @@ msgstr "Punkte:\tDiese Hand:  "
 
 #: pysollib/games/threepeaks.py:202
 msgid "\tThis game:  "
-msgstr "        Dieses Spiel:  "
+msgstr "\tDieses Spiel:  "
 
 #: pysollib/games/tournament.py:224
 msgid "Reserve. Build down by suit."
@@ -2161,6 +2181,494 @@ msgstr ""
 "Tableau. Aufgebaut unabhängig von der Farbe, kann jede aufgedeckte Karte "
 "unabhängig der Sequenz bewegt werden."
 
+#: pysollib/kivy/menubar.py:179
+msgid "File"
+msgstr "Datei"
+
+#: pysollib/kivy/menubar.py:183
+msgid "Games"
+msgstr "Spiele"
+
+#: pysollib/kivy/menubar.py:188 pysollib/kivy/menubar.py:1605
+#, fuzzy
+msgid "Tools"
+msgstr "Toolbar"
+
+#: pysollib/kivy/menubar.py:192 pysollib/kivy/menubar.py:1613
+#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:177
+#: pysollib/tile/selectgame.py:385 pysollib/tile/tkstats.py:51
+#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:384
+#: pysollib/tk/toolbar.py:188
+msgid "Statistics"
+msgstr "Statistiken"
+
+#: pysollib/kivy/menubar.py:196
+msgid "Assist"
+msgstr "Hinweise"
+
+#: pysollib/kivy/menubar.py:201 pysollib/kivy/menubar.py:1629
+msgid "Options"
+msgstr "Optionen"
+
+#: pysollib/kivy/menubar.py:206 pysollib/kivy/menubar.py:320
+#: pysollib/kivy/menubar.py:1637
+msgid "Help"
+msgstr "Hilfe"
+
+#: pysollib/kivy/menubar.py:227
+msgid "Recent games"
+msgstr "Zuletzt gespielte"
+
+#: pysollib/kivy/menubar.py:240
+msgid "Favorite games"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:243
+msgid "<Add>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:245
+msgid "<Remove>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:296 pysollib/kivy/toolbar.py:197
+#: pysollib/pysolgtk/soundoptionsdialog.py:63
+#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
+#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
+msgid "Undo"
+msgstr "Zurück"
+
+#: pysollib/kivy/menubar.py:298 pysollib/kivy/toolbar.py:198
+#: pysollib/pysolgtk/soundoptionsdialog.py:64
+#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
+#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
+msgid "Redo"
+msgstr "Vorwärts"
+
+#: pysollib/kivy/menubar.py:300
+#, fuzzy
+msgid "Redo all"
+msgstr "Vorwärts"
+
+#: pysollib/kivy/menubar.py:303 pysollib/kivy/menubar.py:517
+#: pysollib/pysolgtk/soundoptionsdialog.py:56
+#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
+msgid "Auto drop"
+msgstr "Auto Aufdecken"
+
+#: pysollib/kivy/menubar.py:305 pysollib/kivy/toolbar.py:200
+#: pysollib/tile/toolbar.py:185 pysollib/tk/toolbar.py:185
+msgid "Shuffle tiles"
+msgstr "Steine Mischen"
+
+#: pysollib/kivy/menubar.py:307
+#, fuzzy
+msgid "Deal cards"
+msgstr "Zwischentalon aufheben"
+
+#: pysollib/kivy/menubar.py:310 pysollib/kivy/toolbar.py:201
+#: pysollib/tile/toolbar.py:186 pysollib/tk/toolbar.py:186
+msgid "Pause"
+msgstr "Pause"
+
+#: pysollib/kivy/menubar.py:315
+msgid "Load game"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:317 pysollib/tile/toolbar.py:180
+#: pysollib/tk/toolbar.py:180
+msgid "Save game"
+msgstr "Spiel speichern"
+
+#: pysollib/kivy/menubar.py:371
+msgid "Current game..."
+msgstr "Aktuelles Spiel..."
+
+#: pysollib/kivy/menubar.py:434
+msgid "Hint"
+msgstr "Hinweis"
+
+#: pysollib/kivy/menubar.py:437
+#, fuzzy
+msgid "Highlight piles"
+msgstr "Spielfeldstapel hervorheben:"
+
+#: pysollib/kivy/menubar.py:509
+msgid "Automatic play"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:512
+#, fuzzy
+msgid "Auto face up"
+msgstr "Auto-Flip"
+
+#: pysollib/kivy/menubar.py:522
+#, fuzzy
+msgid "Auto deal"
+msgstr "Auto-Flip"
+
+#: pysollib/kivy/menubar.py:529
+msgid "Quick play"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:537
+#, fuzzy
+msgid "Assist level"
+msgstr "Hinweise"
+
+#: pysollib/kivy/menubar.py:540
+#, fuzzy
+msgid "Enable undo"
+msgstr "Sound aktivieren"
+
+#: pysollib/kivy/menubar.py:545
+#, fuzzy
+msgid "Enable bookmarks"
+msgstr "Lesezeichen löschen"
+
+#: pysollib/kivy/menubar.py:550
+#, fuzzy
+msgid "Enable hint"
+msgstr "Sound aktivieren"
+
+#: pysollib/kivy/menubar.py:555
+#, fuzzy
+msgid "Enable shuffle"
+msgstr "Sound aktivieren"
+
+#: pysollib/kivy/menubar.py:560
+#, fuzzy
+msgid "Enable highlight piles"
+msgstr "Spielfeldstapel hervorheben:"
+
+#: pysollib/kivy/menubar.py:565
+#, fuzzy
+msgid "Enable highlight cards"
+msgstr "Hervorhebung Karten:"
+
+#: pysollib/kivy/menubar.py:570
+#, fuzzy
+msgid "Enable highlight same rank"
+msgstr "Gleichen Rang hervorheben:"
+
+#: pysollib/kivy/menubar.py:575
+#, fuzzy
+msgid "Highlight no matching"
+msgstr "Keine passenden hervorheben:"
+
+#: pysollib/kivy/menubar.py:582
+msgid "Show removed tiles (in Mahjongg games)"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:587
+msgid "Show hint arrow (in Shisen-Sho games)"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:597
+#, fuzzy
+msgid "Sound"
+msgstr "Runde %d"
+
+#: pysollib/kivy/menubar.py:600
+#, fuzzy
+msgid "Enable"
+msgstr "Sound aktivieren"
+
+#: pysollib/kivy/menubar.py:605
+msgid "Volume"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:608
+msgid "100%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:612
+msgid "75%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:616
+msgid "50%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:620
+msgid "25%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:625
+msgid "Samples"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:630
+msgid "are you sure"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:636
+#, fuzzy
+msgid "auto drop"
+msgstr "Auto Aufdecken"
+
+#: pysollib/kivy/menubar.py:642
+#, fuzzy
+msgid "auto flip"
+msgstr "Auto-Flip"
+
+#: pysollib/kivy/menubar.py:648
+#, fuzzy
+msgid "auto pilot lost"
+msgstr "Autopilot verliert"
+
+#: pysollib/kivy/menubar.py:654
+#, fuzzy
+msgid "auto pilot won"
+msgstr "Autopilot gewinnt"
+
+#: pysollib/kivy/menubar.py:660
+#, fuzzy
+msgid "deal"
+msgstr "Neue Karten"
+
+#: pysollib/kivy/menubar.py:666
+#, fuzzy
+msgid "deal waste"
+msgstr "Zwischentalon aufheben"
+
+#: pysollib/kivy/menubar.py:672
+#, fuzzy
+msgid "drop pair"
+msgstr "Paar fallen lassen"
+
+#: pysollib/kivy/menubar.py:678
+#, fuzzy
+msgid "drop"
+msgstr "Auto Aufdecken"
+
+#: pysollib/kivy/menubar.py:684
+#, fuzzy
+msgid "flip"
+msgstr "Auto-Flip"
+
+#: pysollib/kivy/menubar.py:690
+#, fuzzy
+msgid "move"
+msgstr "Kein Zug"
+
+#: pysollib/kivy/menubar.py:696
+#, fuzzy
+msgid "no move"
+msgstr "Kein Zug"
+
+#: pysollib/kivy/menubar.py:702
+msgid "redo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:708
+#, fuzzy
+msgid "start drag"
+msgstr "Start ziehen"
+
+#: pysollib/kivy/menubar.py:714
+#, fuzzy
+msgid "turn waste"
+msgstr "Zwischentalon umlegen"
+
+#: pysollib/kivy/menubar.py:720
+msgid "undo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:726
+#, fuzzy
+msgid "game finished"
+msgstr "Spiel beendet"
+
+#: pysollib/kivy/menubar.py:732
+#, fuzzy
+msgid "game lost"
+msgstr "Spiel verloren"
+
+#: pysollib/kivy/menubar.py:738
+#, fuzzy
+msgid "game perfect"
+msgstr "Perfekt"
+
+#: pysollib/kivy/menubar.py:744
+#, fuzzy
+msgid "game won"
+msgstr "Spiel gewonnen"
+
+#: pysollib/kivy/menubar.py:752
+#, fuzzy
+msgid "Cardsets"
+msgstr "Alle Kartensets"
+
+#: pysollib/kivy/menubar.py:792
+#, fuzzy
+msgid "Table"
+msgstr "Tableau"
+
+#: pysollib/kivy/menubar.py:795
+msgid "Solid colors"
+msgstr "Einfache Farben"
+
+#: pysollib/kivy/menubar.py:800 pysollib/pysolgtk/selecttile.py:105
+#: pysollib/tile/selecttile.py:74 pysollib/tk/selecttile.py:73
+msgid "Blue"
+msgstr "Blau"
+
+#: pysollib/kivy/menubar.py:805 pysollib/pysolgtk/selecttile.py:106
+#: pysollib/tile/selecttile.py:75 pysollib/tk/selecttile.py:74
+#: pysollib/games/ultra/dashavatara.py:361 pysollib/games/ultra/mughal.py:264
+msgid "Green"
+msgstr "Grün"
+
+#: pysollib/kivy/menubar.py:810 pysollib/pysolgtk/selecttile.py:107
+#: pysollib/tile/selecttile.py:76 pysollib/tk/selecttile.py:75
+msgid "Navy"
+msgstr "Marine"
+
+#: pysollib/kivy/menubar.py:815 pysollib/pysolgtk/selecttile.py:108
+#: pysollib/tile/selecttile.py:77 pysollib/tk/selecttile.py:76
+#: pysollib/games/ultra/dashavatara.py:362
+msgid "Olive"
+msgstr "Olive"
+
+#: pysollib/kivy/menubar.py:820 pysollib/pysolgtk/selecttile.py:109
+#: pysollib/tile/selecttile.py:78 pysollib/tk/selecttile.py:77
+#: pysollib/games/ultra/dashavatara.py:362 pysollib/games/ultra/mughal.py:264
+msgid "Orange"
+msgstr "Orange"
+
+#: pysollib/kivy/menubar.py:825 pysollib/pysolgtk/selecttile.py:110
+#: pysollib/tile/selecttile.py:79 pysollib/tk/selecttile.py:78
+msgid "Teal"
+msgstr "Krickente"
+
+#: pysollib/kivy/menubar.py:830
+msgid "Tiles and Images"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:850
+msgid "Card view"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:853
+msgid "Card shadow"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:858
+msgid "Shade legal moves"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:863
+msgid "Negative cards bottom"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:868 pysollib/ui/tktile/menubar.py:559
+msgid "Shrink face-down cards"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:873
+msgid "Shade filled stacks"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:881
+msgid "Animations"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:889
+msgid "Very fast"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:894
+msgid "Fast"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:899
+msgid "Medium"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:904
+msgid "Slow"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:909
+msgid "Very slow"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:916
+msgid "Redeal animation"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:921
+msgid "Winning animation"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:929
+msgid "Touch mode"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:932
+msgid "Drag-and-Drop"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:937
+msgid "Point-and-Click"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:971 pysollib/tile/toolbar.py:202
+#: pysollib/tk/toolbar.py:211
+msgid "Toolbar"
+msgstr "Toolbar"
+
+#: pysollib/kivy/menubar.py:974 pysollib/ui/tktile/menubar.py:41
+msgid "Hide"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:989 pysollib/ui/tktile/menubar.py:50
+msgid "Left"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:993 pysollib/ui/tktile/menubar.py:53
+msgid "Right"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1030
+msgid "Startup splash screen"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1035
+msgid "Winning splash"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1058
+msgid "Contents"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1062
+msgid "How to play"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1066 pysollib/kivy/toolbar.py:204
+#: pysollib/tile/toolbar.py:189 pysollib/tk/toolbar.py:189
+msgid "Rules for this game"
+msgstr "Regeln dieses Spiels"
+
+#: pysollib/kivy/menubar.py:1070
+msgid "License terms"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1074
+#, python-format
+msgid "About %s..."
+msgstr "Über %s..."
+
+#: pysollib/kivy/menubar.py:1348
+msgid "Menu"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1576 pysollib/ui/tktile/menubar.py:971
+msgid "<none>"
+msgstr ""
+
 #: pysollib/kivy/menubar.py:1589
 msgid "Main Menu"
 msgstr ""
@@ -2169,288 +2677,328 @@ msgstr ""
 msgid "File Menu"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:1605
-#, fuzzy
-msgid "Tools"
-msgstr "Toolbar"
-
 #: pysollib/kivy/menubar.py:1621
-#, fuzzy
 msgid "Assists"
 msgstr "Hinweise"
 
-#: pysollib/kivy/menubar.py:1629
-#, fuzzy
-msgid "Options"
-msgstr "Optionen"
+#. TRANSLATORS: Usually, 'PySol files'
+#: pysollib/kivy/menubar.py:1795 pysollib/ui/tktile/menubar.py:1136
+#, python-format
+msgid "%s files"
+msgstr ""
 
-#: pysollib/kivy/menubar.py:1637
-#, fuzzy
-msgid "Help"
-msgstr " Hilfe"
+#: pysollib/kivy/menubar.py:1796 pysollib/ui/tktile/menubar.py:1137
+msgid "All files"
+msgstr ""
 
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2067
-#: pysollib/kivy/selectcardset.py:61 pysollib/pysolgtk/selectcardset.py:229
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2068
+#: pysollib/kivy/selectcardset.py:57 pysollib/pysolgtk/selectcardset.py:229
 #: pysollib/tk/menubar.py:89 pysollib/tk/menubar.py:90
 #: pysollib/tk/selectcardset.py:313
 msgid "&Load"
-msgstr "Laden"
+msgstr "&Laden"
 
-#: pysollib/kivy/menubar.py:2068 pysollib/kivy/selectcardset.py:61
+#: pysollib/kivy/menubar.py:2069 pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/tile/selectcardset.py:318
 #: pysollib/tk/menubar.py:90
 msgid "&Info..."
-msgstr "Info..."
+msgstr "&Info..."
 
-#: pysollib/kivy/menubar.py:2072 pysollib/tile/menubar.py:90
-#: pysollib/tk/menubar.py:94
-msgid "Select "
-msgstr "Auswählen "
+#: pysollib/kivy/menubar.py:2072 pysollib/pysolgtk/menubar.py:696
+msgid "Select cardset"
+msgstr "Karten wählen"
 
-#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1664
+#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1666
 msgid "Solitaire Wizard"
 msgstr "Solitär Assistent"
 
 #: pysollib/kivy/selectgame.py:83 pysollib/tile/selectgame.py:84
-#: pysollib/tk/selectgame.py:85
+#: pysollib/tk/selectgame.py:84
 msgid "(no games)"
 msgstr "(keine Spiele)"
 
 #: pysollib/kivy/selectgame.py:104 pysollib/pysolgtk/selectgame.py:227
-#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:109
+#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:108
 msgid "Mahjongg Games"
 msgstr "Mahjongg Spiele"
 
 #: pysollib/kivy/selectgame.py:108 pysollib/pysolgtk/selectgame.py:233
-#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:113
+#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:112
 msgid "French games"
 msgstr "Französische Spiele"
 
 #: pysollib/kivy/selectgame.py:111 pysollib/pysolgtk/selectgame.py:229
-#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:116
+#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:115
 msgid "Oriental Games"
 msgstr "Orientalische Spiele"
 
 #: pysollib/kivy/selectgame.py:114 pysollib/pysolgtk/selectgame.py:231
-#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:119
+#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:118
 msgid "Special Games"
 msgstr "Spezialspiele"
 
 #: pysollib/kivy/selectgame.py:117 pysollib/pysolgtk/selectgame.py:315
-#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:122
+#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:121
 msgid "Original Games"
 msgstr "Originale Spiele"
 
 #: pysollib/kivy/selectgame.py:146 pysollib/pysolgtk/selectgame.py:216
-#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:170
+#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:168
 msgid "All Games"
 msgstr "Alle Spiele"
 
 #: pysollib/kivy/selectgame.py:157 pysollib/pysolgtk/selectgame.py:286
-#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:138
+#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:137
 msgid "by Compatibility"
 msgstr "nach Kompatibilität"
 
 #: pysollib/kivy/selectgame.py:168 pysollib/pysolgtk/selectgame.py:293
-#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:149
-msgid "New games in v. "
-msgstr "Neue Spiele in v. "
+#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:147
+#, python-format
+msgid "New games in v. %(version)s"
+msgstr "Neue Spiele in v. %(version)s"
 
 #: pysollib/kivy/selectgame.py:171 pysollib/pysolgtk/selectgame.py:296
-#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:152
+#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:150
 msgid "by PySol version"
 msgstr "nach PySol Version"
 
 #: pysollib/kivy/selectgame.py:183 pysollib/tile/selectgame.py:161
-#: pysollib/tk/selectgame.py:163
+#: pysollib/tk/selectgame.py:161
+#, fuzzy
 msgid "by Inventors"
 msgstr "nach Investoren"
 
 #: pysollib/kivy/selectgame.py:191 pysollib/pysolgtk/selectgame.py:218
-#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:172
+#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:170
 msgid "Popular Games"
 msgstr "Populäre Spiele"
 
 #: pysollib/kivy/selectgame.py:198 pysollib/pysolgtk/selectgame.py:217
-#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:171
+#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:169
 msgid "Alternate Names"
 msgstr "Alternative Namen"
 
 #: pysollib/kivy/selectgame.py:201 pysollib/pysolgtk/selectgame.py:243
-#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:180
+#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:178
 msgid "by Skill Level"
 msgstr "nach Schwierigkeitsgrad"
 
 #: pysollib/kivy/selectgame.py:213 pysollib/pysolgtk/selectgame.py:247
-#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:193
+#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:191
 msgid "by Game Feature"
 msgstr "nach Spielmerkmal"
 
 #: pysollib/kivy/selectgame.py:214 pysollib/pysolgtk/selectgame.py:260
-#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:194
+#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:192
 msgid "by Number of Cards"
 msgstr "nach Nummer der Karten"
 
 #: pysollib/kivy/selectgame.py:215 pysollib/pysolgtk/selectgame.py:249
-#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:195
+#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:193
 msgid "32 cards"
 msgstr "32 Karten"
 
 #: pysollib/kivy/selectgame.py:217 pysollib/pysolgtk/selectgame.py:250
-#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:197
+#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:195
 msgid "48 cards"
 msgstr "48 Karten"
 
 #: pysollib/kivy/selectgame.py:219 pysollib/pysolgtk/selectgame.py:251
-#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:199
+#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:197
 msgid "52 cards"
 msgstr "52 Karten"
 
 #: pysollib/kivy/selectgame.py:221 pysollib/pysolgtk/selectgame.py:252
-#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:201
+#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:199
 msgid "64 cards"
 msgstr "64 Karten"
 
 #: pysollib/kivy/selectgame.py:223 pysollib/pysolgtk/selectgame.py:253
-#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:203
+#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:201
 msgid "78 cards"
 msgstr "78 Karten"
 
 #: pysollib/kivy/selectgame.py:225 pysollib/pysolgtk/selectgame.py:254
-#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:205
+#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:203
 msgid "104 cards"
 msgstr "104 Karten"
 
 #: pysollib/kivy/selectgame.py:227 pysollib/pysolgtk/selectgame.py:255
-#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:207
+#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:205
 msgid "144 cards"
 msgstr "144 Karten"
 
 #: pysollib/kivy/selectgame.py:229 pysollib/pysolgtk/selectgame.py:256
-#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:210
+#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:208
 msgid "Other number"
 msgstr "Andere Nummer"
 
 #: pysollib/kivy/selectgame.py:233 pysollib/pysolgtk/selectgame.py:267
-#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:214
+#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:212
 msgid "by Number of Decks"
 msgstr "nach Nummern der Decks"
 
 #: pysollib/kivy/selectgame.py:234 pysollib/pysolgtk/selectgame.py:262
-#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:215
+#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:213
 msgid "1 deck games"
 msgstr "1 Deck Spiele"
 
 #: pysollib/kivy/selectgame.py:236 pysollib/pysolgtk/selectgame.py:263
-#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:217
+#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:215
 msgid "2 deck games"
 msgstr "2 Deck Spiele"
 
 #: pysollib/kivy/selectgame.py:238 pysollib/pysolgtk/selectgame.py:264
-#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:219
+#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:217
 msgid "3 deck games"
 msgstr "3 Deck Spiele"
 
 #: pysollib/kivy/selectgame.py:240 pysollib/pysolgtk/selectgame.py:265
-#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:221
+#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:219
 msgid "4 deck games"
 msgstr "4 Deck Spiele"
 
 #: pysollib/kivy/selectgame.py:243 pysollib/pysolgtk/selectgame.py:278
-#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:224
+#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:222
 msgid "by Number of Redeals"
 msgstr "nach Anzahl der Neudecks"
 
 #: pysollib/kivy/selectgame.py:244 pysollib/pysolgtk/selectgame.py:269
-#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:225
+#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:223
 msgid "No redeal"
 msgstr "Kein neues Aufheben"
 
 #: pysollib/kivy/selectgame.py:246 pysollib/pysolgtk/selectgame.py:270
-#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:227
+#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:225
 msgid "1 redeal"
 msgstr "1 neues Deck"
 
 #: pysollib/kivy/selectgame.py:248 pysollib/pysolgtk/selectgame.py:271
-#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:229
+#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:227
 msgid "2 redeals"
 msgstr "2 Neu Mischen"
 
 #: pysollib/kivy/selectgame.py:250 pysollib/pysolgtk/selectgame.py:272
-#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:231
+#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:229
 msgid "3 redeals"
 msgstr "3 Neu Mischen"
 
 #: pysollib/kivy/selectgame.py:256 pysollib/pysolgtk/selectgame.py:275
-#: pysollib/tile/selectgame.py:236 pysollib/tk/selectgame.py:238
+#: pysollib/tile/selectgame.py:234 pysollib/tk/selectgame.py:234
 msgid "Other number of redeals"
 msgstr "Andere Nummer von Neukarten"
 
 #: pysollib/kivy/selectgame.py:264 pysollib/pysolgtk/selectgame.py:311
-#: pysollib/tile/selectgame.py:243 pysollib/tk/selectgame.py:245
+#: pysollib/tile/selectgame.py:241 pysollib/tk/selectgame.py:241
 msgid "Other Categories"
 msgstr "Andere Kategorien"
 
 #: pysollib/kivy/selectgame.py:265 pysollib/pysolgtk/selectgame.py:300
-#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:246
+#: pysollib/tile/selectgame.py:242 pysollib/tk/selectgame.py:242
 msgid "Games for Children (very easy)"
 msgstr "Spiele für Kinder (sehr einfach)"
 
 #: pysollib/kivy/selectgame.py:267 pysollib/pysolgtk/selectgame.py:302
-#: pysollib/tile/selectgame.py:246 pysollib/tk/selectgame.py:248
+#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:244
 msgid "Games with Scoring"
 msgstr "Spiele mit Punkte"
 
 #: pysollib/kivy/selectgame.py:269 pysollib/pysolgtk/selectgame.py:304
-#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:251
+#: pysollib/tile/selectgame.py:247 pysollib/tk/selectgame.py:247
 msgid "Games with Separate Decks"
 msgstr "Spiele mit separaten Decks"
 
 #: pysollib/kivy/selectgame.py:271 pysollib/pysolgtk/selectgame.py:306
-#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:253
+#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:249
 msgid "Open Games (all cards visible)"
 msgstr "Öffne Spiele (alle Karten sichtbar)"
 
 #: pysollib/kivy/selectgame.py:273 pysollib/pysolgtk/selectgame.py:308
-#: pysollib/tile/selectgame.py:253 pysollib/tk/selectgame.py:255
+#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:251
 msgid "Relaxed Variants"
 msgstr "Entspannte Varianten"
+
+#: pysollib/kivy/tkhtml.py:409
+msgid "Browser"
+msgstr ""
+
+#: pysollib/kivy/tkhtml.py:434 pysollib/pysolgtk/tkhtml.py:218
+#: pysollib/tile/tkhtml.py:77 pysollib/tk/tkhtml.py:72
+msgid "Index"
+msgstr "Index"
+
+#: pysollib/kivy/tkhtml.py:435 pysollib/pysolgtk/tkhtml.py:219
+#: pysollib/tile/tkhtml.py:81 pysollib/tk/tkhtml.py:76
+msgid "Back"
+msgstr "Zurück"
+
+#: pysollib/kivy/tkhtml.py:437 pysollib/pysolgtk/tkhtml.py:220
+#: pysollib/tile/tkhtml.py:85 pysollib/tk/tkhtml.py:80
+msgid "Forward"
+msgstr "Vorwärts"
+
+#: pysollib/kivy/tkhtml.py:438 pysollib/pysolgtk/tkhtml.py:221
+#: pysollib/tile/tkhtml.py:89 pysollib/tk/tkhtml.py:84
+msgid "Close"
+msgstr "Schließen"
 
 #: pysollib/kivy/tkstats.py:148 pysollib/tile/tkstats.py:163
 #: pysollib/tk/tkstats.py:53
 msgid "Demo games"
 msgstr "Spieledemo"
 
-#: pysollib/kivy/tkstats.py:220 pysollib/pysolgtk/selectgame.py:123
-#: pysollib/tile/selectgame.py:402 pysollib/tile/tkstats.py:182
-#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:404
+#: pysollib/kivy/tkstats.py:175
+#, python-format
+msgid ""
+"Total:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+"\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:187
+#, python-format
+msgid ""
+"Current Session:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:225 pysollib/pysolgtk/selectgame.py:123
+#: pysollib/tile/selectgame.py:400 pysollib/tile/tkstats.py:182
+#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:401
 #: pysollib/tk/tkstats.py:87 pysollib/tk/tkstats.py:141 data/pysolfc.glade:241
 #: data/pysolfc.glade:519
 msgid "Won:"
 msgstr "Gewonnen:"
 
-#: pysollib/kivy/tkstats.py:222 pysollib/pysolgtk/selectgame.py:124
-#: pysollib/tile/selectgame.py:403 pysollib/tile/tkstats.py:183
-#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:405
+#: pysollib/kivy/tkstats.py:227 pysollib/pysolgtk/selectgame.py:124
+#: pysollib/tile/selectgame.py:401 pysollib/tile/tkstats.py:183
+#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:402
 #: pysollib/tk/tkstats.py:88 pysollib/tk/tkstats.py:143 data/pysolfc.glade:307
 #: data/pysolfc.glade:544
 msgid "Lost:"
 msgstr "Verloren:"
 
-#: pysollib/kivy/tkstats.py:224 pysollib/tile/tkstats.py:184
+#: pysollib/kivy/tkstats.py:229 pysollib/tile/tkstats.py:184
 #: pysollib/tile/tkstats.py:238 pysollib/tk/tkstats.py:89
 #: pysollib/tk/tkstats.py:145 data/pysolfc.glade:266 data/pysolfc.glade:569
 msgid "Total:"
 msgstr "Total:"
 
-#: pysollib/kivy/tkstats.py:250 pysollib/tk/tkstats.py:279
+#: pysollib/kivy/tkstats.py:255 pysollib/tk/tkstats.py:279
 msgid "&All games..."
-msgstr "Alle Spiele..."
+msgstr "&Alle Spiele..."
 
-#: pysollib/kivy/tkstats.py:252 pysollib/tile/tkstats.py:102
+#: pysollib/kivy/tkstats.py:257 pysollib/tile/tkstats.py:102
 #: pysollib/tk/tkstats.py:281
 msgid "&Reset..."
-msgstr "Reset..."
+msgstr "&Reset..."
+
+#: pysollib/kivy/tkwidget.py:183
+msgid "Error"
+msgstr ""
 
 #: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
 #: pysollib/tk/toolbar.py:176
@@ -2471,22 +3019,10 @@ msgstr ""
 "Neustart des\n"
 "aktuellen Spiels"
 
-#: pysollib/kivy/toolbar.py:197 pysollib/pysolgtk/soundoptionsdialog.py:63
-#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
-#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
-msgid "Undo"
-msgstr "Zurück"
-
 #: pysollib/kivy/toolbar.py:197 pysollib/tile/toolbar.py:182
 #: pysollib/tk/toolbar.py:182
 msgid "Undo last move"
 msgstr "Zurück letzter Zug"
-
-#: pysollib/kivy/toolbar.py:198 pysollib/pysolgtk/soundoptionsdialog.py:64
-#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
-#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
-msgid "Redo"
-msgstr "Vorwärts"
 
 #: pysollib/kivy/toolbar.py:198 pysollib/tile/toolbar.py:183
 #: pysollib/tk/toolbar.py:183
@@ -2508,16 +3044,6 @@ msgstr "Karten Auto Aufdecken"
 msgid "Shuffle"
 msgstr "Mischen"
 
-#: pysollib/kivy/toolbar.py:200 pysollib/tile/toolbar.py:185
-#: pysollib/tk/toolbar.py:185
-msgid "Shuffle tiles"
-msgstr "Steine Mischen"
-
-#: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
-#: pysollib/tk/toolbar.py:186
-msgid "Pause"
-msgstr "Pause"
-
 #: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
 #: pysollib/tk/toolbar.py:186
 msgid "Pause game"
@@ -2527,11 +3053,6 @@ msgstr "Spiel pausieren"
 #: pysollib/tk/toolbar.py:189
 msgid "Rules"
 msgstr "Regeln"
-
-#: pysollib/kivy/toolbar.py:204 pysollib/tile/toolbar.py:189
-#: pysollib/tk/toolbar.py:189
-msgid "Rules for this game"
-msgstr "Regeln dieses Spiels"
 
 #: pysollib/kivy/toolbar.py:206 pysollib/tile/toolbar.py:191
 #: pysollib/tk/toolbar.py:191
@@ -2558,20 +3079,15 @@ msgstr "Orientalische Spiele"
 msgid "Save Game"
 msgstr "Spiel speichern"
 
-#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1298
+#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1300
 #: data/pysolfc.glade:4127
 msgid "Sound settings"
 msgstr "Ton Einstellungen"
 
-#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1521
+#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1523
 #, fuzzy
 msgid "Select table background"
 msgstr "Hintergrundfarbe wählen"
-
-#: pysollib/pysolgtk/menubar.py:696
-#, fuzzy
-msgid "Select cardset"
-msgstr "Name wählen"
 
 #: pysollib/pysolgtk/playeroptionsdialog.py:62
 #: pysollib/tile/playeroptionsdialog.py:61
@@ -2649,114 +3165,82 @@ msgstr "nach Nationalität"
 msgid "by Date"
 msgstr "nach Tag"
 
-#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:384
-#: pysollib/tk/selectgame.py:386
+#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:382
+#: pysollib/tk/selectgame.py:383
 msgid "About game"
-msgstr "Über das Spiel "
+msgstr "Über das Spiel"
 
-#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:394
-#: pysollib/tk/selectgame.py:396
+#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:392
+#: pysollib/tk/selectgame.py:393
 msgid "Alternate names:"
 msgstr "Alternative Namen:"
 
-#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:395
-#: pysollib/tk/selectgame.py:397
+#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:393
+#: pysollib/tk/selectgame.py:394
 msgid "Category:"
 msgstr "Kategorie:"
 
-#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:398
-#: pysollib/tk/selectgame.py:400
+#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:396
+#: pysollib/tk/selectgame.py:397
 msgid "Decks:"
 msgstr "Decks:"
 
-#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:399
-#: pysollib/tk/selectgame.py:401
+#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:397
+#: pysollib/tk/selectgame.py:398
 msgid "Redeals:"
 msgstr "Neue Karten:"
 
-#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:401
-#: pysollib/tk/selectgame.py:403
+#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:399
+#: pysollib/tk/selectgame.py:400
 msgid "Played:"
 msgstr "Gespielt:"
 
-#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:404
-#: pysollib/tile/tkstats.py:777 pysollib/tk/selectgame.py:406
-#: pysollib/tk/tkstats.py:740 data/pysolfc.glade:717
+#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:402
+#: pysollib/tile/tkstats.py:778 pysollib/tk/selectgame.py:403
+#: pysollib/tk/tkstats.py:741 data/pysolfc.glade:717
 msgid "Playing time:"
 msgstr "Spielzeit:"
 
-#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:405
-#: pysollib/tile/tkstats.py:784 pysollib/tk/selectgame.py:407
-#: pysollib/tk/tkstats.py:747 data/pysolfc.glade:813
+#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:403
+#: pysollib/tile/tkstats.py:785 pysollib/tk/selectgame.py:404
+#: pysollib/tk/tkstats.py:748 data/pysolfc.glade:813
 msgid "Moves:"
 msgstr "Bewegungen:"
 
-#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:406
-#: pysollib/tk/selectgame.py:408
+#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:404
+#: pysollib/tk/selectgame.py:405
 msgid "% won:"
 msgstr "% gewonnen:"
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:438
-#: pysollib/tk/selectgame.py:439 pysollib/ui/tktile/menubar.py:352
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:436
+#: pysollib/tk/selectgame.py:437 pysollib/ui/tktile/menubar.py:352
 msgid "&Select"
-msgstr "Auswählen"
+msgstr "Au&swählen"
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:437
-#: pysollib/tk/selectgame.py:439
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:435
+#: pysollib/tk/selectgame.py:436
 msgid "&Rules"
-msgstr "Regeln"
+msgstr "&Regeln"
 
-#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:518
-#: pysollib/tk/selectgame.py:519
-msgid "Playable Preview - "
-msgstr "Spielbare Vorschau - "
+#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:516
+#: pysollib/tk/selectgame.py:517
+#, python-format
+msgid "Playable Preview - %(game)s"
+msgstr "Spielbare Vorschau - %(game)s"
 
-#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:571
-#: pysollib/tk/selectgame.py:572
+#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:569
+#: pysollib/tk/selectgame.py:570
 msgid "variable"
 msgstr "variabel"
 
-#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:573
-#: pysollib/tk/selectgame.py:574
+#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:571
+#: pysollib/tk/selectgame.py:572
 msgid "unlimited"
 msgstr "unlimitiert"
 
 #: pysollib/pysolgtk/selecttile.py:104
-#, fuzzy
 msgid "Solid color"
 msgstr "Einfache Farben"
-
-#: pysollib/pysolgtk/selecttile.py:105 pysollib/tile/selecttile.py:74
-#: pysollib/tk/selecttile.py:73
-msgid "Blue"
-msgstr "Blau"
-
-#: pysollib/pysolgtk/selecttile.py:106 pysollib/tile/selecttile.py:75
-#: pysollib/tk/selecttile.py:74 pysollib/games/ultra/dashavatara.py:361
-#: pysollib/games/ultra/mughal.py:264
-msgid "Green"
-msgstr "Grün"
-
-#: pysollib/pysolgtk/selecttile.py:107 pysollib/tile/selecttile.py:76
-#: pysollib/tk/selecttile.py:75
-msgid "Navy"
-msgstr "Marine"
-
-#: pysollib/pysolgtk/selecttile.py:108 pysollib/tile/selecttile.py:77
-#: pysollib/tk/selecttile.py:76 pysollib/games/ultra/dashavatara.py:362
-msgid "Olive"
-msgstr "Olive"
-
-#: pysollib/pysolgtk/selecttile.py:109 pysollib/tile/selecttile.py:78
-#: pysollib/tk/selecttile.py:77 pysollib/games/ultra/dashavatara.py:362
-#: pysollib/games/ultra/mughal.py:264
-msgid "Orange"
-msgstr "Orange"
-
-#: pysollib/pysolgtk/selecttile.py:110 pysollib/tile/selecttile.py:79
-#: pysollib/tk/selecttile.py:78
-msgid "Teal"
-msgstr "Krickente"
 
 #: pysollib/pysolgtk/selecttile.py:121 pysollib/tile/selecttile.py:82
 #: pysollib/tk/selecttile.py:81
@@ -2813,11 +3297,6 @@ msgstr "Fallen lassen"
 msgid "Drop pair"
 msgstr "Paar fallen lassen"
 
-#: pysollib/pysolgtk/soundoptionsdialog.py:56
-#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
-msgid "Auto drop"
-msgstr "Auto Aufdecken"
-
 #: pysollib/pysolgtk/soundoptionsdialog.py:58
 #: pysollib/tile/soundoptionsdialog.py:70 pysollib/tk/soundoptionsdialog.py:72
 msgid "Flip"
@@ -2868,35 +3347,15 @@ msgstr "Bewegungen/total"
 msgid "Games played: won/lost"
 msgstr "Gespielt: gewonnen/verloren"
 
-#: pysollib/pysolgtk/tkhtml.py:218 pysollib/tile/tkhtml.py:77
-#: pysollib/tk/tkhtml.py:72
-msgid "Index"
-msgstr "Index"
-
-#: pysollib/pysolgtk/tkhtml.py:219 pysollib/tile/tkhtml.py:81
-#: pysollib/tk/tkhtml.py:76
-msgid "Back"
-msgstr "Zurück"
-
-#: pysollib/pysolgtk/tkhtml.py:220 pysollib/tile/tkhtml.py:85
-#: pysollib/tk/tkhtml.py:80
-msgid "Forward"
-msgstr "Vorwärts"
-
-#: pysollib/pysolgtk/tkhtml.py:221 pysollib/tile/tkhtml.py:89
-#: pysollib/tk/tkhtml.py:84
-msgid "Close"
-msgstr "Schließen"
-
 #: pysollib/pysolgtk/tkhtml.py:437 pysollib/ui/tktile/tkhtml.py:314
 #, python-format
 msgid ""
-"HTML limitation:\n"
-"The %s protocol is not supported yet.\n"
+"%(app)s HTML limitation:\n"
+"The %(protocol)s protocol is not supported yet.\n"
 "\n"
 "Please use your standard web browser\n"
 "to open the following URL:\n"
-"%s\n"
+"%(url)s\n"
 msgstr ""
 
 #: pysollib/pysolgtk/tkhtml.py:464 pysollib/pysolgtk/tkhtml.py:469
@@ -2904,38 +3363,38 @@ msgstr ""
 msgid "Unable to service request:\n"
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:328 pysollib/tile/tkstats.py:290
+#: pysollib/pysolgtk/tkstats.py:329 pysollib/tile/tkstats.py:290
 #: pysollib/tk/tkstats.py:266
 msgid "No games"
 msgstr "Keine Spiele"
 
-#: pysollib/pysolgtk/tkstats.py:388 pysollib/tile/tkstats.py:670
-#: pysollib/tk/tkstats.py:667
+#: pysollib/pysolgtk/tkstats.py:389 pysollib/tile/tkstats.py:671
+#: pysollib/tk/tkstats.py:668
 msgid "N"
 msgstr "N"
 
-#: pysollib/pysolgtk/tkstats.py:391 pysollib/tile/tkstats.py:683
-#: pysollib/tk/tkstats.py:676
+#: pysollib/pysolgtk/tkstats.py:392 pysollib/tile/tkstats.py:684
+#: pysollib/tk/tkstats.py:677
 msgid "Result"
 msgstr "Ergebnis"
 
-#: pysollib/pysolgtk/tkstats.py:526 pysollib/tile/tkstats.py:613
-#: pysollib/tk/tkstats.py:608
+#: pysollib/pysolgtk/tkstats.py:527 pysollib/tile/tkstats.py:614
+#: pysollib/tk/tkstats.py:609
 msgid "Highlight piles: "
 msgstr "Spielfeldstapel hervorheben: "
 
-#: pysollib/pysolgtk/tkstats.py:527 pysollib/tile/tkstats.py:614
-#: pysollib/tk/tkstats.py:609
+#: pysollib/pysolgtk/tkstats.py:528 pysollib/tile/tkstats.py:615
+#: pysollib/tk/tkstats.py:610
 msgid "Highlight cards: "
 msgstr "Hervorhebung Karten: "
 
-#: pysollib/pysolgtk/tkstats.py:528 pysollib/tile/tkstats.py:615
-#: pysollib/tk/tkstats.py:610
+#: pysollib/pysolgtk/tkstats.py:529 pysollib/tile/tkstats.py:616
+#: pysollib/tk/tkstats.py:611
 msgid "Highlight same rank: "
 msgstr "Gleichen Rang hervorheben: "
 
-#: pysollib/pysolgtk/tkstats.py:532 pysollib/tile/tkstats.py:619
-#: pysollib/tk/tkstats.py:614
+#: pysollib/pysolgtk/tkstats.py:533 pysollib/tile/tkstats.py:620
+#: pysollib/tk/tkstats.py:615
 msgid ""
 "\n"
 "Redeals: "
@@ -2943,8 +3402,8 @@ msgstr ""
 "\n"
 "Neu gemischt: "
 
-#: pysollib/pysolgtk/tkstats.py:533 pysollib/tile/tkstats.py:620
-#: pysollib/tk/tkstats.py:615
+#: pysollib/pysolgtk/tkstats.py:534 pysollib/tile/tkstats.py:621
+#: pysollib/tk/tkstats.py:616
 msgid ""
 "\n"
 "Cards in Talon: "
@@ -2952,8 +3411,8 @@ msgstr ""
 "\n"
 "Karten im Talon: "
 
-#: pysollib/pysolgtk/tkstats.py:535 pysollib/tile/tkstats.py:622
-#: pysollib/tk/tkstats.py:617
+#: pysollib/pysolgtk/tkstats.py:536 pysollib/tile/tkstats.py:623
+#: pysollib/tk/tkstats.py:618
 msgid ""
 "\n"
 "Cards in Waste: "
@@ -2961,8 +3420,8 @@ msgstr ""
 "\n"
 "Karten auf Zwischentalon: "
 
-#: pysollib/pysolgtk/tkstats.py:537 pysollib/tile/tkstats.py:624
-#: pysollib/tk/tkstats.py:619
+#: pysollib/pysolgtk/tkstats.py:538 pysollib/tile/tkstats.py:625
+#: pysollib/tk/tkstats.py:620
 msgid ""
 "\n"
 "Cards in Foundations: "
@@ -2970,58 +3429,58 @@ msgstr ""
 "\n"
 "Karten in Endablage: "
 
-#: pysollib/pysolgtk/tkstats.py:542 pysollib/tile/tkstats.py:629
-#: pysollib/tk/tkstats.py:625
+#: pysollib/pysolgtk/tkstats.py:543 pysollib/tile/tkstats.py:630
+#: pysollib/tk/tkstats.py:626
 msgid "Game status"
 msgstr "Spielstatus"
 
-#: pysollib/pysolgtk/tkstats.py:545 pysollib/tile/tkstats.py:632
-#: pysollib/tk/tkstats.py:628
+#: pysollib/pysolgtk/tkstats.py:546 pysollib/tile/tkstats.py:633
+#: pysollib/tk/tkstats.py:629
 msgid "Playing time: "
 msgstr "Spielzeit: "
 
-#: pysollib/pysolgtk/tkstats.py:546 pysollib/tile/tkstats.py:633
-#: pysollib/tk/tkstats.py:629
+#: pysollib/pysolgtk/tkstats.py:547 pysollib/tile/tkstats.py:634
+#: pysollib/tk/tkstats.py:630
 msgid "Started at: "
 msgstr "Gestartet bei: "
 
-#: pysollib/pysolgtk/tkstats.py:547 pysollib/tile/tkstats.py:634
-#: pysollib/tk/tkstats.py:630
+#: pysollib/pysolgtk/tkstats.py:548 pysollib/tile/tkstats.py:635
+#: pysollib/tk/tkstats.py:631
 msgid "Moves: "
 msgstr "Bewegungen: "
 
-#: pysollib/pysolgtk/tkstats.py:548 pysollib/tile/tkstats.py:635
-#: pysollib/tk/tkstats.py:631
+#: pysollib/pysolgtk/tkstats.py:549 pysollib/tile/tkstats.py:636
+#: pysollib/tk/tkstats.py:632
 msgid "Undo moves: "
 msgstr "Züge zurück: "
 
-#: pysollib/pysolgtk/tkstats.py:549 pysollib/tile/tkstats.py:636
-#: pysollib/tk/tkstats.py:632
+#: pysollib/pysolgtk/tkstats.py:550 pysollib/tile/tkstats.py:637
+#: pysollib/tk/tkstats.py:633
 msgid "Bookmark moves: "
 msgstr "Lesezeichen nach: "
 
-#: pysollib/pysolgtk/tkstats.py:550 pysollib/tile/tkstats.py:637
-#: pysollib/tk/tkstats.py:633
+#: pysollib/pysolgtk/tkstats.py:551 pysollib/tile/tkstats.py:638
+#: pysollib/tk/tkstats.py:634
 msgid "Demo moves: "
 msgstr "Demozüge: "
 
-#: pysollib/pysolgtk/tkstats.py:551 pysollib/tile/tkstats.py:638
-#: pysollib/tk/tkstats.py:634
+#: pysollib/pysolgtk/tkstats.py:552 pysollib/tile/tkstats.py:639
+#: pysollib/tk/tkstats.py:635
 msgid "Total player moves: "
 msgstr "Totale Spielerzüge:"
 
-#: pysollib/pysolgtk/tkstats.py:552 pysollib/tile/tkstats.py:639
-#: pysollib/tk/tkstats.py:635
+#: pysollib/pysolgtk/tkstats.py:553 pysollib/tile/tkstats.py:640
+#: pysollib/tk/tkstats.py:636
 msgid "Total moves in this game: "
 msgstr "Totale Züge in diesem Spiel: "
 
-#: pysollib/pysolgtk/tkstats.py:553 pysollib/tile/tkstats.py:640
-#: pysollib/tk/tkstats.py:636
+#: pysollib/pysolgtk/tkstats.py:554 pysollib/tile/tkstats.py:641
+#: pysollib/tk/tkstats.py:637
 msgid "Hints: "
 msgstr "Hinweise: "
 
-#: pysollib/pysolgtk/tkstats.py:557 pysollib/tile/tkstats.py:643
-#: pysollib/tk/tkstats.py:640 pysollib/ui/tktile/menubar.py:420
+#: pysollib/pysolgtk/tkstats.py:558 pysollib/tile/tkstats.py:644
+#: pysollib/tk/tkstats.py:641 pysollib/ui/tktile/menubar.py:420
 msgid "&Statistics..."
 msgstr "Statistiken..."
 
@@ -3091,17 +3550,22 @@ msgstr "Ändern..."
 msgid "Select font"
 msgstr "Schriftauswahl"
 
+#: pysollib/tile/menubar.py:90 pysollib/tk/menubar.py:94
+msgid "Select "
+msgstr "Auswählen "
+
 #: pysollib/tile/menubar.py:106
 msgid "Change theme"
 msgstr "Thema ändern"
 
 #: pysollib/tile/menubar.py:107
+#, python-format
 msgid ""
-"This settings will take effect\n"
-"the next time you restart "
+"These settings will take effect\n"
+"the next time you restart %(app)s"
 msgstr ""
 "Die Einstellungen werden erst nach\n"
-"Neustart des Programms aktiv "
+"Neustart des Programms %(app)s aktiv"
 
 #: pysollib/tile/menubar.py:114
 msgid "Set t&heme"
@@ -3199,7 +3663,7 @@ msgstr ""
 msgid "&Save"
 msgstr "Speichern"
 
-#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:177
+#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:176
 msgid "Custom Games"
 msgstr "Benutzerdef. Spiel"
 
@@ -3213,19 +3677,19 @@ msgstr "Fortschritt anzeigen"
 
 #: pysollib/tile/solverdialog.py:57 pysollib/tk/solverdialog.py:65
 msgid "&Start"
-msgstr "Start"
+msgstr "&Start"
 
 #: pysollib/tile/solverdialog.py:57 pysollib/tk/solverdialog.py:65
 msgid "&Play"
-msgstr "Spielen"
+msgstr "S&pielen"
 
 #: pysollib/tile/solverdialog.py:57 pysollib/tk/solverdialog.py:65
 msgid "&New"
-msgstr "Neu"
+msgstr "&Neu"
 
 #: pysollib/tile/solverdialog.py:57 pysollib/tk/solverdialog.py:65
 msgid "&Close"
-msgstr "Schließen"
+msgstr "S&chließen"
 
 #: pysollib/tile/soundoptionsdialog.py:94 pysollib/tk/soundoptionsdialog.py:96
 #: data/pysolfc.glade:4212
@@ -3254,7 +3718,7 @@ msgstr "Sound aktivieren"
 #: pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tk/soundoptionsdialog.py:152
 msgid "&Apply"
-msgstr "Anwenden"
+msgstr "&Anwenden"
 
 #: pysollib/tile/soundoptionsdialog.py:183
 #: pysollib/tk/soundoptionsdialog.py:188
@@ -3309,14 +3773,14 @@ msgstr "Hervorhebung Karten:"
 msgid "Highlight same rank:"
 msgstr "Gleichen Rang hervorheben:"
 
-#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:740
-#: pysollib/tile/tkstats.py:887 pysollib/tk/tkstats.py:909
+#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:741
+#: pysollib/tile/tkstats.py:888 pysollib/tk/tkstats.py:910
 #: data/pysolfc.glade:660
 msgid "Current game"
 msgstr "Aktuelles Spiel"
 
-#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:748
-#: pysollib/tile/tkstats.py:883 pysollib/tk/tkstats.py:903
+#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:749
+#: pysollib/tile/tkstats.py:884 pysollib/tk/tkstats.py:904
 #: data/pysolfc.glade:1342
 msgid "All games"
 msgstr "Alle Spiele"
@@ -3339,75 +3803,83 @@ msgstr "Total"
 msgid "Current session"
 msgstr "Aktuelle Sitzung"
 
-#: pysollib/tile/tkstats.py:510
+#: pysollib/tile/tkstats.py:511
 msgid "Log"
 msgstr "Protokoll"
 
-#: pysollib/tile/tkstats.py:541 pysollib/tk/tkstats.py:506
-#: pysollib/tk/tkstats.py:575 pysollib/tk/tkstats.py:592
+#: pysollib/tile/tkstats.py:523 data/pysolfc.glade:1404
+msgid "Full log"
+msgstr "Volles Protokoll"
+
+#: pysollib/tile/tkstats.py:527 data/pysolfc.glade:1466
+msgid "Session log"
+msgstr "Sitzungsprotokoll"
+
+#: pysollib/tile/tkstats.py:542 pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:576 pysollib/tk/tkstats.py:593
 msgid "&Save to file"
 msgstr "In Datei speichern"
 
-#: pysollib/tile/tkstats.py:745 pysollib/tk/tkstats.py:785
+#: pysollib/tile/tkstats.py:746 pysollib/tk/tkstats.py:786
 msgid "No TOP for this game"
 msgstr "Keine TOP für dieses Spiel"
 
-#: pysollib/tile/tkstats.py:753
+#: pysollib/tile/tkstats.py:754
 msgid "No TOP for all games"
 msgstr "Keine TOP für alle Spiele"
 
-#: pysollib/tile/tkstats.py:765 pysollib/tk/tkstats.py:732
+#: pysollib/tile/tkstats.py:766 pysollib/tk/tkstats.py:733
 #: data/pysolfc.glade:1005
 msgid "Minimum"
 msgstr "Minimum"
 
-#: pysollib/tile/tkstats.py:767 pysollib/tk/tkstats.py:733
+#: pysollib/tile/tkstats.py:768 pysollib/tk/tkstats.py:734
 #: data/pysolfc.glade:1028
 msgid "Maximum"
 msgstr "Maximum"
 
-#: pysollib/tile/tkstats.py:769 pysollib/tk/tkstats.py:734
+#: pysollib/tile/tkstats.py:770 pysollib/tk/tkstats.py:735
 #: data/pysolfc.glade:1051
 msgid "Average"
 msgstr "Durchschnitt"
 
-#: pysollib/tile/tkstats.py:791 pysollib/tk/tkstats.py:754
+#: pysollib/tile/tkstats.py:792 pysollib/tk/tkstats.py:755
 #: data/pysolfc.glade:909
 msgid "Total moves:"
 msgstr "Alle Züge:"
 
-#: pysollib/tile/tkstats.py:891 pysollib/tk/tkstats.py:915
+#: pysollib/tile/tkstats.py:892 pysollib/tk/tkstats.py:916
 msgid "Statistics for"
 msgstr "Statistiken für"
 
-#: pysollib/tile/tkstats.py:896 pysollib/tk/tkstats.py:920
+#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
 msgid "Last 7 days"
 msgstr "Letzte 7 Tage"
 
-#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
+#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
 msgid "Last month"
 msgstr "Letzter Monat"
 
-#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
+#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
 msgid "Last year"
 msgstr "Letztes Jahr"
 
-#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
+#: pysollib/tile/tkstats.py:900 pysollib/tk/tkstats.py:924
 msgid "All time"
 msgstr "Jederzeit"
 
-#: pysollib/tile/tkstats.py:904 pysollib/tk/tkstats.py:930
+#: pysollib/tile/tkstats.py:905 pysollib/tk/tkstats.py:931
 msgid "Show graphs"
 msgstr "Graphen anzeigen"
 
-#: pysollib/tile/tkstats.py:948 pysollib/tile/tkstats.py:964
-#: pysollib/tile/tkstats.py:1002 pysollib/tk/tkstats.py:857
-#: pysollib/tk/tkstats.py:873 pysollib/tk/tkstats.py:977
+#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:965
+#: pysollib/tile/tkstats.py:1003 pysollib/tk/tkstats.py:858
+#: pysollib/tk/tkstats.py:874 pysollib/tk/tkstats.py:978
 msgid "Games/day"
 msgstr "Spiele/Tag"
 
-#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:1004
-#: pysollib/tk/tkstats.py:858 pysollib/tk/tkstats.py:979
+#: pysollib/tile/tkstats.py:950 pysollib/tile/tkstats.py:1005
+#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:980
 msgid "Games/week"
 msgstr "Spiele/Woche"
 
@@ -3427,17 +3899,9 @@ msgstr ""
 msgid "Save"
 msgstr "Speichern"
 
-#: pysollib/tile/toolbar.py:180 pysollib/tk/toolbar.py:180
-msgid "Save game"
-msgstr "Spiel speichern"
-
 #: pysollib/tile/toolbar.py:188 pysollib/tk/toolbar.py:188
 msgid "View statistics"
 msgstr "Statistiken anzeigen"
-
-#: pysollib/tile/toolbar.py:202 pysollib/tk/toolbar.py:211
-msgid "Toolbar"
-msgstr "Toolbar"
 
 #: pysollib/tile/toolbar.py:209 pysollib/tk/toolbar.py:206
 msgid "Player"
@@ -3459,17 +3923,17 @@ msgstr "Name wählen"
 msgid "Enable samles"
 msgstr "Sound aktivieren"
 
-#: pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:508
 msgid "&Reset all..."
-msgstr "Alles zurücksetzen..."
+msgstr "Alles &zurücksetzen..."
 
-#: pysollib/tk/tkstats.py:574
+#: pysollib/tk/tkstats.py:575
 msgid "Session &log..."
-msgstr "Sitzungsprotokoll..."
+msgstr "&Sitzungsprotokoll..."
 
-#: pysollib/tk/tkstats.py:591
+#: pysollib/tk/tkstats.py:592
 msgid "&Full log..."
-msgstr "Volles Protokoll"
+msgstr "&Volles Protokoll..."
 
 #: pysollib/winsystems/common.py:60
 #, fuzzy
@@ -3737,24 +4201,20 @@ msgid "Filled"
 msgstr ""
 
 #: pysollib/games/ultra/hanafuda.py:526
-#, fuzzy
 msgid "st"
-msgstr "Osten"
+msgstr ""
 
 #: pysollib/games/ultra/hanafuda.py:526
-#, fuzzy
 msgid "nd"
-msgstr "Zurück"
+msgstr ""
 
 #: pysollib/games/ultra/hanafuda.py:526
-#, fuzzy
 msgid "rd"
-msgstr "rot"
+msgstr ""
 
 #: pysollib/games/ultra/hanafuda.py:526
-#, fuzzy
 msgid "th"
-msgstr "Bad"
+msgstr ""
 
 #: pysollib/games/ultra/hanafuda.py:527
 msgid " Deck"
@@ -3869,9 +4329,8 @@ msgid "Stores"
 msgstr "Stores"
 
 #: pysollib/games/ultra/mughal.py:264
-#, fuzzy
 msgid "Tan"
-msgstr "Talon"
+msgstr ""
 
 #: pysollib/ui/tktile/colorsdialog.py:71 data/pysolfc.glade:3111
 msgid "Text foreground:"
@@ -3910,54 +4369,38 @@ msgstr "%d Karte"
 msgid "Compound"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:41
-msgid "Hide"
-msgstr ""
-
 #: pysollib/ui/tktile/menubar.py:44
-#, fuzzy
 msgid "Top"
-msgstr "Zwei"
+msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:47
 msgid "Bottom"
-msgstr ""
-
-#: pysollib/ui/tktile/menubar.py:50
-msgid "Left"
-msgstr ""
-
-#: pysollib/ui/tktile/menubar.py:53
-msgid "Right"
 msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:64
 msgid "Visible buttons"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:296 pysollib/ui/tktile/menubar.py:666
-#, fuzzy
-msgid "&About "
-msgstr "Über "
+#: pysollib/ui/tktile/menubar.py:296
+#, python-format
+msgid "&About %s"
+msgstr "Ü&ber %s"
 
 #: pysollib/ui/tktile/menubar.py:298
 msgid "&File"
-msgstr ""
+msgstr "&Datei"
 
 #: pysollib/ui/tktile/menubar.py:301
-#, fuzzy
 msgid "R&ecent games"
-msgstr "Spiel auswählen"
+msgstr "&Zuletzt gespielte"
 
 #: pysollib/ui/tktile/menubar.py:304
-#, fuzzy
 msgid "Select &random game"
-msgstr "Zufallsspiel auswählen"
+msgstr "Zu&fallsspiel auswählen"
 
 #: pysollib/ui/tktile/menubar.py:306
-#, fuzzy
 msgid "&All games"
-msgstr "Alle Spiele"
+msgstr "&Alle Spiele"
 
 #: pysollib/ui/tktile/menubar.py:309
 #, fuzzy
@@ -3993,14 +4436,12 @@ msgid "Remove &from favorites"
 msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:328
-#, fuzzy
 msgid "&Open..."
-msgstr "Öffnen"
+msgstr "Ö&ffnen..."
 
 #: pysollib/ui/tktile/menubar.py:333
-#, fuzzy
 msgid "Save &as..."
-msgstr "Spiel speichern"
+msgstr "Speichern &unter..."
 
 #: pysollib/ui/tktile/menubar.py:335
 msgid "E&xport current layout..."
@@ -4019,14 +4460,12 @@ msgid "&Edit"
 msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:360
-#, fuzzy
 msgid "&Undo"
-msgstr "Zurück"
+msgstr "&Zurück"
 
 #: pysollib/ui/tktile/menubar.py:363
-#, fuzzy
 msgid "&Redo"
-msgstr "Vorwärts"
+msgstr "&Vorwärts"
 
 #: pysollib/ui/tktile/menubar.py:365
 #, fuzzy
@@ -4054,9 +4493,8 @@ msgid "&Clear bookmarks"
 msgstr "Lesezeichen löschen"
 
 #: pysollib/ui/tktile/menubar.py:391
-#, fuzzy
 msgid "Solitaire &Wizard"
-msgstr "Solitär Assistent"
+msgstr "S&olitär Assistent"
 
 #: pysollib/ui/tktile/menubar.py:393
 #, fuzzy
@@ -4064,9 +4502,8 @@ msgid "&Edit current game"
 msgstr "Aktuelles Spiel"
 
 #: pysollib/ui/tktile/menubar.py:396
-#, fuzzy
 msgid "&Game"
-msgstr "Spiel"
+msgstr "&Spiel"
 
 #: pysollib/ui/tktile/menubar.py:398
 #, fuzzy
@@ -4084,14 +4521,12 @@ msgid "Shu&ffle tiles"
 msgstr "Steine Mischen"
 
 #: pysollib/ui/tktile/menubar.py:407
-#, fuzzy
 msgid "&Pause"
-msgstr "Pause"
+msgstr "&Pause"
 
 #: pysollib/ui/tktile/menubar.py:413
-#, fuzzy
 msgid "S&tatus..."
-msgstr "Status"
+msgstr "S&tatus..."
 
 #: pysollib/ui/tktile/menubar.py:416
 #, fuzzy
@@ -4128,9 +4563,8 @@ msgid "&Find card"
 msgstr "%d Karte"
 
 #: pysollib/ui/tktile/menubar.py:442
-#, fuzzy
 msgid "&Demo"
-msgstr "Demo"
+msgstr "&Demo"
 
 #: pysollib/ui/tktile/menubar.py:445
 #, fuzzy
@@ -4138,18 +4572,16 @@ msgid "Demo (&all games)"
 msgstr "Spieledemo"
 
 #: pysollib/ui/tktile/menubar.py:448 pysollib/ui/tktile/menubar.py:450
-#, fuzzy
 msgid "&Solver"
-msgstr "Silber"
+msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:453
 msgid "&Piles description"
 msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:459
-#, fuzzy
 msgid "&Options"
-msgstr "Optionen"
+msgstr "&Optionen"
 
 #: pysollib/ui/tktile/menubar.py:461
 #, fuzzy
@@ -4252,9 +4684,8 @@ msgid "&Auto scaling"
 msgstr "Auto-Flip"
 
 #: pysollib/ui/tktile/menubar.py:540
-#, fuzzy
 msgid "Cards&et..."
-msgstr "Kartenset"
+msgstr "Kart&enset"
 
 #: pysollib/ui/tktile/menubar.py:543
 msgid "Table t&ile..."
@@ -4281,23 +4712,17 @@ msgstr ""
 msgid "&Negative cards bottom"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:559
-msgid "Shrink face-down cards"
-msgstr ""
-
 #: pysollib/ui/tktile/menubar.py:563
 msgid "Shade &filled stacks"
 msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:566
-#, fuzzy
 msgid "A&nimations"
-msgstr "Tiere"
+msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:568
-#, fuzzy
 msgid "&None"
-msgstr "Nein"
+msgstr "Kei&ne"
 
 #: pysollib/ui/tktile/menubar.py:571
 msgid "&Very fast"
@@ -4362,9 +4787,8 @@ msgid "Time&outs..."
 msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:619
-#, fuzzy
 msgid "&Toolbar"
-msgstr "Toolbar"
+msgstr "&Toolbar"
 
 #: pysollib/ui/tktile/menubar.py:621
 #, fuzzy
@@ -4390,18 +4814,16 @@ msgid "Save games &geometry"
 msgstr "Spiel speichern"
 
 #: pysollib/ui/tktile/menubar.py:637
-#, fuzzy
 msgid "&Demo logo"
-msgstr " Demo "
+msgstr "&Demo logo"
 
 #: pysollib/ui/tktile/menubar.py:640
 msgid "Startup splash sc&reen"
 msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:649
-#, fuzzy
 msgid "&Help"
-msgstr " Hilfe"
+msgstr "&Hilfe"
 
 #: pysollib/ui/tktile/menubar.py:651
 msgid "&Contents"
@@ -4412,80 +4834,76 @@ msgid "&How to play"
 msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:657
-#, fuzzy
 msgid "&Rules for this game"
-msgstr "Regeln dieses Spiels"
+msgstr "&Regeln dieses Spiels"
 
 #: pysollib/ui/tktile/menubar.py:660
 msgid "&License terms"
 msgstr ""
 
+#: pysollib/ui/tktile/menubar.py:666
+#, python-format
+msgid "&About %s..."
+msgstr "Ü&ber %s..."
+
 #: pysollib/ui/tktile/menubar.py:796
-#, fuzzy
 msgid "All &games..."
-msgstr "Alle Spiele..."
+msgstr "A&lle Spiele..."
 
 #: pysollib/ui/tktile/menubar.py:798
-#, fuzzy
 msgid "Playable pre&view..."
-msgstr "Spielbare Vorschau - "
+msgstr "Spielbare &Vorschau..."
 
 #: pysollib/ui/tktile/menubar.py:853
-#, fuzzy
 msgid "&Mahjongg games"
-msgstr "Mahjongg Spiele"
+msgstr "&Mahjongg Spiele"
 
 #: pysollib/ui/tktile/menubar.py:892
-#, fuzzy
 msgid "&Popular games"
-msgstr "Populäre Spiele"
+msgstr "&Populäre Spiele"
 
 #: pysollib/ui/tktile/menubar.py:900
-#, fuzzy
 msgid "&French games"
-msgstr "Französische Spiele"
+msgstr "&Französische Spiele"
 
 #: pysollib/ui/tktile/menubar.py:907
-#, fuzzy
 msgid "&Oriental games"
-msgstr "Orientalische Spiele"
+msgstr "&Orientalische Spiele"
 
 #: pysollib/ui/tktile/menubar.py:915
-#, fuzzy
 msgid "&Special games"
-msgstr "Spezialspiele"
+msgstr "&Spezialspiele"
 
 #: pysollib/ui/tktile/menubar.py:921
-#, fuzzy
 msgid "&Custom games"
-msgstr "Benutzerdef. Spiel"
+msgstr "B&enutzerdef. Spiele"
 
 #: pysollib/ui/tktile/menubar.py:929
 #, fuzzy
 msgid "&All games by name"
 msgstr "Alle Spiele"
 
-#: pysollib/ui/tktile/menubar.py:1177
+#: pysollib/ui/tktile/menubar.py:1179
 msgid "Export game error"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1178
+#: pysollib/ui/tktile/menubar.py:1180
 msgid ""
 "\n"
 "Unsupported game for export.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1214 pysollib/ui/tktile/menubar.py:1248
+#: pysollib/ui/tktile/menubar.py:1216 pysollib/ui/tktile/menubar.py:1250
 msgid "Import game error"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1215
+#: pysollib/ui/tktile/menubar.py:1217
 msgid ""
 "\n"
 "Unsupported game for import.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1676
+#: pysollib/ui/tktile/menubar.py:1678
 #, fuzzy, python-format
 msgid ""
 "\n"
@@ -4493,6 +4911,11 @@ msgid ""
 "\n"
 "%s\n"
 msgstr "Fehler während des Ladens"
+
+#: pysollib/ui/tktile/solverdialog.py:28
+#, python-format
+msgid "%(app)s - FreeCell Solver"
+msgstr ""
 
 #: pysollib/ui/tktile/solverdialog.py:44 data/pysolfc.glade:74
 #: data/pysolfc.glade:1250

--- a/po/it_pysol.po
+++ b/po/it_pysol.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: it_pysol\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-18 19:21+0300\n"
+"POT-Creation-Date: 2019-08-31 00:20+0300\n"
 "PO-Revision-Date: 2011-07-23 14:48+0200\n"
 "Last-Translator: Giuliano Colla <giuliano.colla@gmail.com>\n"
 "Language-Team: Italiano <it@li.org>\n"
@@ -23,14 +23,15 @@ msgstr ""
 "Plural-Forms:  nplurals=2; plural=(n != 1);\n"
 "X-Generator: KBabel 1.11.4\n"
 
-#: pysollib/actions.py:232 pysollib/kivy/toolbar.py:191
-#: pysollib/tile/toolbar.py:176 pysollib/tk/toolbar.py:176
+#: pysollib/actions.py:232 pysollib/kivy/menubar.py:291
+#: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
+#: pysollib/tk/toolbar.py:176
 msgid "New game"
 msgstr "Nuovo gioco"
 
 #: pysollib/actions.py:247 pysollib/kivy/menubar.py:1667
-#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1014
-#: pysollib/ui/tktile/menubar.py:1030
+#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1015
+#: pysollib/ui/tktile/menubar.py:1031
 msgid "Select game"
 msgstr "Scegliere nuovo gioco"
 
@@ -60,19 +61,19 @@ msgstr ""
 "\n"
 "Introdurre numero"
 
-#: pysollib/actions.py:293 pysollib/app.py:523 pysollib/app.py:817
-#: pysollib/game/__init__.py:1270 pysollib/game/__init__.py:2487
-#: pysollib/kivy/tkhtml.py:690 pysollib/kivy/tkstats.py:249
+#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/app.py:818
+#: pysollib/game/__init__.py:1305 pysollib/game/__init__.py:2526
+#: pysollib/kivy/tkhtml.py:691 pysollib/kivy/tkstats.py:254
 #: pysollib/kivy/tkwidget.py:97 pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/pysolgtk/tkhtml.py:542
-#: pysollib/pysolgtk/tkstats.py:556 pysollib/pysolgtk/tkwidget.py:151
+#: pysollib/pysolgtk/tkstats.py:557 pysollib/pysolgtk/tkwidget.py:151
 #: pysollib/tile/fontsdialog.py:140 pysollib/tile/fontsdialog.py:202
 #: pysollib/tile/menubar.py:111 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:545
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/soundoptionsdialog.py:188 pysollib/tile/timeoutsdialog.py:92
-#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:540
-#: pysollib/tile/tkstats.py:645 pysollib/tile/tkstats.py:726
+#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:541
+#: pysollib/tile/tkstats.py:646 pysollib/tile/tkstats.py:727
 #: pysollib/tile/tkwidget.py:138 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/playeroptionsdialog.py:64
@@ -80,10 +81,10 @@ msgstr ""
 #: pysollib/tk/selectcardset.py:506 pysollib/tk/selecttile.py:152
 #: pysollib/tk/soundoptionsdialog.py:152 pysollib/tk/soundoptionsdialog.py:193
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkstats.py:278
-#: pysollib/tk/tkstats.py:505 pysollib/tk/tkstats.py:574
-#: pysollib/tk/tkstats.py:591 pysollib/tk/tkstats.py:639
-#: pysollib/tk/tkstats.py:712 pysollib/tk/tkstats.py:796
-#: pysollib/tk/tkstats.py:963 pysollib/tk/tkwidget.py:143
+#: pysollib/tk/tkstats.py:506 pysollib/tk/tkstats.py:575
+#: pysollib/tk/tkstats.py:592 pysollib/tk/tkstats.py:640
+#: pysollib/tk/tkstats.py:713 pysollib/tk/tkstats.py:797
+#: pysollib/tk/tkstats.py:964 pysollib/tk/tkwidget.py:143
 #: pysollib/tk/tkwidget.py:351 pysollib/tk/wizarddialog.py:132
 #: pysollib/ui/tktile/colorsdialog.py:118
 #: pysollib/ui/tktile/edittextdialog.py:38
@@ -95,24 +96,24 @@ msgstr "&Ok"
 msgid "&Next number"
 msgstr "&Numero successivo"
 
-#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/game/__init__.py:1270
-#: pysollib/game/__init__.py:1939 pysollib/game/__init__.py:1957
-#: pysollib/game/__init__.py:1965 pysollib/game/__init__.py:1972
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2068
-#: pysollib/kivy/selectcardset.py:61
+#: pysollib/actions.py:293 pysollib/app.py:525 pysollib/game/__init__.py:1305
+#: pysollib/game/__init__.py:1979 pysollib/game/__init__.py:1995
+#: pysollib/game/__init__.py:2003 pysollib/game/__init__.py:2010
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2069
+#: pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/pysolgtk/selectgame.py:324
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/tile/fontsdialog.py:140
 #: pysollib/tile/fontsdialog.py:202 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:543
-#: pysollib/tile/selectgame.py:308 pysollib/tile/selectgame.py:438
+#: pysollib/tile/selectgame.py:306 pysollib/tile/selectgame.py:436
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/timeoutsdialog.py:92 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/menubar.py:89
 #: pysollib/tk/menubar.py:90 pysollib/tk/playeroptionsdialog.py:64
 #: pysollib/tk/playeroptionsdialog.py:138 pysollib/tk/selectcardset.py:313
-#: pysollib/tk/selectgame.py:310 pysollib/tk/selectgame.py:439
+#: pysollib/tk/selectgame.py:306 pysollib/tk/selectgame.py:437
 #: pysollib/tk/selecttile.py:152 pysollib/tk/soundoptionsdialog.py:152
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkwidget.py:351
 #: pysollib/tk/wizarddialog.py:132 pysollib/ui/tktile/colorsdialog.py:118
@@ -130,209 +131,245 @@ msgstr "Gioco successivo"
 
 #: pysollib/actions.py:384 pysollib/kivy/toolbar.py:206
 #: pysollib/tile/toolbar.py:191 pysollib/tk/toolbar.py:191
-msgid "Quit "
-msgstr "Abbandona "
+#, python-format
+msgid "Quit %s"
+msgstr "Abbandona %s"
 
 #: pysollib/actions.py:447
 msgid "Clear bookmarks"
 msgstr "Pulisci segnalibri"
 
 #: pysollib/actions.py:448
-msgid "Clear all bookmarks ?"
+msgid "Clear all bookmarks?"
 msgstr "Ripulire tutti i segnalibri?"
 
-#: pysollib/actions.py:459
+#: pysollib/actions.py:459 pysollib/kivy/menubar.py:293
 msgid "Restart game"
 msgstr "Ricomincia il gioco"
 
 #: pysollib/actions.py:460
-msgid "Restart this game ?"
+msgid "Restart this game?"
 msgstr "Ricomincio questo gioco?"
 
-#: pysollib/actions.py:505
+#: pysollib/actions.py:506
 #, python-format
 msgid ""
-"Comments for %s:\n"
+"Comments for %(game)s %(id)s:\n"
 "\n"
 msgstr ""
-"Commenti per %s:\n"
+"Commenti per %(game)s %(id)s:\n"
 "\n"
 
-#: pysollib/actions.py:507
-msgid "Comments for "
-msgstr "Commenti per "
+#: pysollib/actions.py:508
+#, python-format
+msgid "Comments for %(id)s"
+msgstr "Commenti per %(id)s"
 
-#: pysollib/actions.py:525 pysollib/actions.py:549
+#: pysollib/actions.py:526 pysollib/actions.py:551
 msgid "Error while writing to file"
 msgstr "Errore in scrittura del file"
 
-#: pysollib/actions.py:528 pysollib/actions.py:552
-msgid " Info"
-msgstr " Informazioni"
+#: pysollib/actions.py:529 pysollib/actions.py:554
+#, python-format
+msgid "%s Info"
+msgstr "%s Informazioni"
 
-#: pysollib/actions.py:529
+#: pysollib/actions.py:530
+#, python-format
 msgid ""
 "Comments were appended to\n"
 "\n"
+"%(filename)s"
 msgstr ""
 "Commenti aggiunti a\n"
 "\n"
+"%(filename)s"
 
-#: pysollib/actions.py:538
-msgid "Demo statistics"
-msgstr "Statistiche Demo"
-
-#: pysollib/actions.py:541
-msgid "Your statistics"
-msgstr "Le tue statistiche"
-
-#: pysollib/actions.py:553
+#: pysollib/actions.py:540
+#, fuzzy, python-format
 msgid ""
-" were appended to\n"
+"Demo statistics were appended to\n"
 "\n"
+"%(filename)s"
 msgstr ""
-" sono state aggiunte a\n"
+"Commenti aggiunti a\n"
 "\n"
+"%(filename)s"
 
-#: pysollib/actions.py:567
-msgid " Demo"
-msgstr " Demo"
+#: pysollib/actions.py:543
+#, python-format
+msgid ""
+"Your statistics were appended to\n"
+"\n"
+"%(filename)s"
+msgstr ""
+"Le tue statistiche aggiunti a\n"
+"\n"
+"%(filename)s"
 
-#: pysollib/actions.py:567
-msgid " Demo "
-msgstr " Demo "
-
-#: pysollib/actions.py:570 pysollib/actions.py:591
-msgid " for "
-msgstr " per "
-
-#: pysollib/actions.py:576 pysollib/stats.py:202
-msgid "Statistics for "
+#: pysollib/actions.py:581
+#, fuzzy, python-format
+msgid "%(app)s Demo Statistics for %(game)s"
 msgstr "Statistiche per "
 
-#: pysollib/actions.py:581 pysollib/kivy/menubar.py:1613
-#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:176
-#: pysollib/tile/selectgame.py:387 pysollib/tile/tkstats.py:51
-#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:387
-#: pysollib/tk/toolbar.py:188
-msgid "Statistics"
-msgstr "Statistiche"
+#: pysollib/actions.py:582
+#, python-format
+msgid "Statistics for %(game)s"
+msgstr "Statistiche per %(game)s"
 
-#: pysollib/actions.py:585 pysollib/tile/tkstats.py:522 data/pysolfc.glade:1404
-msgid "Full log"
-msgstr "Log completo"
+#: pysollib/actions.py:587
+#, fuzzy, python-format
+msgid "%(app)s Demo Statistics"
+msgstr "Statistiche Demo"
 
-#: pysollib/actions.py:588 pysollib/tile/tkstats.py:526 data/pysolfc.glade:1466
-msgid "Session log"
+#: pysollib/actions.py:588 pysollib/stats.py:202
+#, python-format
+msgid "Statistics for %(player)s"
+msgstr "Statistiche per %(player)s"
+
+#: pysollib/actions.py:592
+#, fuzzy, python-format
+msgid "%(app)s Demo Full log"
+msgstr "&Demo logo"
+
+#: pysollib/actions.py:593 pysollib/stats.py:235
+#, python-format
+msgid "Full log for %(player)s"
+msgstr "Log completo di %(player)s"
+
+#: pysollib/actions.py:596
+#, fuzzy, python-format
+msgid "%(app)s Demo Session log"
 msgstr "Log della sessione"
 
-#: pysollib/actions.py:595
+#: pysollib/actions.py:597 pysollib/stats.py:242
+#, python-format
+msgid "Session log for %(player)s"
+msgstr "Log della sessione di %(player)s"
+
+#. TRANSLATORS: eg. top 10 or top 5 results for a certain game
+#: pysollib/actions.py:601
+#, fuzzy, python-format
+msgid "%(app)s Demo Top %(tops)d for %(game)s"
+msgstr "Statistiche per "
+
+#: pysollib/actions.py:602
+#, python-format
+msgid "Top %(tops)d for %(game)s"
+msgstr ""
+
+#: pysollib/actions.py:606
 msgid "Game Info"
 msgstr "Informazioni"
 
-#: pysollib/actions.py:598
+#: pysollib/actions.py:609
 msgid "Statistics progression"
 msgstr "Statistiche progressive"
 
-#: pysollib/actions.py:616
+#: pysollib/actions.py:627
 msgid "Reset all statistics"
 msgstr "Pulisci tutte le statistiche"
 
-#: pysollib/actions.py:617
+#: pysollib/actions.py:628
 #, python-format
 msgid ""
 "Reset ALL statistics and logs for player\n"
-"%s ?"
+"%(player)s?"
 msgstr ""
 "Eliminare TUTTE le statistiche di\n"
-"%s ?"
+"%(player)s ?"
 
-#: pysollib/actions.py:626
+#: pysollib/actions.py:638
 msgid "Reset game statistics"
 msgstr "Pulisci le statistiche del gioco"
 
-#: pysollib/actions.py:627
+#: pysollib/actions.py:639
 #, python-format
 msgid ""
 "Reset statistics and logs for player\n"
-"%s\n"
+"%(player)s\n"
 "and game\n"
-"%s ?"
+"%(game)s?"
 msgstr ""
 "Eliminare le statistiche e i log di\n"
-"%s e del gioco\n"
-"%s ?"
+"%(player)s\n"
+"e del gioco\n"
+"%(game)s ?"
 
-#: pysollib/actions.py:692
+#: pysollib/actions.py:704
 msgid "Play demo"
 msgstr "Esegui Demo"
 
-#: pysollib/actions.py:704
+#: pysollib/actions.py:716
 msgid "Set player options"
 msgstr "Opzioni giocatore"
 
-#: pysollib/actions.py:720 data/pysolfc.glade:1986
+#: pysollib/actions.py:732 data/pysolfc.glade:1986
 msgid "Set colors"
 msgstr "Scelta dei colori"
 
-#: pysollib/actions.py:738
+#: pysollib/actions.py:750
 msgid "Set fonts"
 msgstr "Scelta dei caratteri"
 
-#: pysollib/actions.py:748 data/pysolfc.glade:1493
+#: pysollib/actions.py:760 data/pysolfc.glade:1493
 msgid "Set timeouts"
 msgstr "Scelta tempi massimi"
 
 #: pysollib/app.py:332
-msgid "can't find game: "
-msgstr "non trovo il gioco: "
+#, python-format
+msgid "can't find game: %(game)s"
+msgstr "non trovo il gioco: %(game)s"
 
-#: pysollib/app.py:525 pysollib/game/__init__.py:1939
-#: pysollib/game/__init__.py:1957 pysollib/game/__init__.py:1965
-#: pysollib/game/__init__.py:1972 pysollib/ui/tktile/menubar.py:300
+#: pysollib/app.py:526 pysollib/game/__init__.py:1979
+#: pysollib/game/__init__.py:1995 pysollib/game/__init__.py:2003
+#: pysollib/game/__init__.py:2010 pysollib/ui/tktile/menubar.py:300
 msgid "&New game"
 msgstr "&Nuovo gioco"
 
-#: pysollib/app.py:671
-#, python-format
-msgid "Loading %s %s..."
+#: pysollib/app.py:672
+#, fuzzy, python-format
+msgid "Loading cardset %s..."
 msgstr "Caricamento %s %s..."
 
-#: pysollib/app.py:713
-msgid " load error"
+#: pysollib/app.py:714
+#, fuzzy
+msgid "Cardset load error"
 msgstr " errore di caricamento"
 
-#: pysollib/app.py:714
-msgid "Error while loading "
-msgstr "Errore nel caricare "
+#: pysollib/app.py:715
+#, fuzzy
+msgid "Error while loading cardset"
+msgstr "Errore nel caricare il gioco"
 
-#: pysollib/app.py:809
-msgid "Incompatible "
+#: pysollib/app.py:810
+#, fuzzy
+msgid "Incompatible cardset"
 msgstr "Incompatibile "
 
-#: pysollib/app.py:811
-#, python-format
+#: pysollib/app.py:812
+#, fuzzy, python-format
 msgid ""
-"The currently selected %s %s\n"
+"The currently selected cardset %(cardset)s\n"
 "is not compatible with the game\n"
-"%s\n"
+"%(game)s\n"
 "\n"
-"Please select a %s type %s.\n"
+"Please select a %(correct_type)s type cardset.\n"
 msgstr ""
 "La scelta di %s %s\n"
 "non è compatibile con il gioco\n"
 "%s\n"
 "Bisogna scegliere un tipo %s %s.\n"
 
-#: pysollib/app.py:855
-#, python-format
-msgid "Please select a %s type %s"
+#: pysollib/app.py:856
+#, fuzzy, python-format
+msgid "Please select a %s type cardset"
 msgstr "Scegliere un tipo %s %s"
 
-#: pysollib/app.py:1063
+#: pysollib/app.py:1064
 #, python-format
-msgid "error loading plugin %s: %s"
-msgstr "errore nel caricare il plugin %s: %s"
+msgid "error loading plugin %(file)s: %(err)s"
+msgstr "errore nel caricare il plugin %(file)s: %(err)s"
 
 #: pysollib/gamedb.py:109
 msgid "Baker's Dozen"
@@ -543,12 +580,12 @@ msgid "Puzzle type"
 msgstr "Tipo Puzzle"
 
 #: pysollib/help.py:43
-msgid "A Python Solitaire Game Collection\n"
-msgstr "Una raccolta di solitari in Python\n"
+msgid "A Python Solitaire Game Collection"
+msgstr "Una raccolta di solitari in Python"
 
 #: pysollib/help.py:45
-msgid "A World Domination Project\n"
-msgstr "Un progetto per dominare il mondo\n"
+msgid "A World Domination Project"
+msgstr "Un progetto per dominare il mondo"
 
 #: pysollib/help.py:46
 msgid "&Nice"
@@ -568,14 +605,16 @@ msgid "Version %s"
 msgstr "Versione %s"
 
 #: pysollib/help.py:50
-msgid "About "
+#, fuzzy, python-format
+msgid "About %s"
 msgstr "Informazioni "
 
 #: pysollib/help.py:52
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "PySol Fan Club edition\n"
-"%s%s\n"
+"%(description)s\n"
+"%(versioninfo)s\n"
 "\n"
 "Copyright (C) 1998 - 2003 Markus F.X.J. Oberhumer.\n"
 "Copyright (C) 2003 Mt. Hood Playing Card Co.\n"
@@ -588,10 +627,12 @@ msgid ""
 "For more information about this application visit"
 msgstr ""
 "PySol Fan Club edition\n"
-"%s%s\n"
+"%(description)s\n"
+"%(versioninfo)s\n"
+"\n"
 "Copyright (C) 1998 - 2003 Markus F.X.J. Oberhumer.\n"
 "Copyright (C) 2003 Mt. Hood Playing Card Co.\n"
-"Copyright (C) 2005 - 2007 Skomoroh.\n"
+"Copyright (C) 2005 - 2009 Skomoroh.\n"
 "Tutti i diritti riservati.\n"
 "\n"
 "PySol è software libero distribuito alle condizioni\n"
@@ -599,14 +640,14 @@ msgstr ""
 "\n"
 "Per maggiori informazioni su questa applicazione, visitare"
 
-#: pysollib/help.py:88
+#: pysollib/help.py:90
 msgid "Credits"
 msgstr "Riconoscimenti"
 
-#: pysollib/help.py:89
+#: pysollib/help.py:91
 #, python-format
 msgid ""
-" credits go to:\n"
+"%(app)s credits go to:\n"
 "\n"
 "Volker Weidner for getting me into Solitaire\n"
 "Guido van Rossum for the initial example program\n"
@@ -615,10 +656,10 @@ msgid ""
 "The Gnome AisleRiot team for parts of the documentation\n"
 "Natascha\n"
 "\n"
-"The Python, %s, SDL & Linux crews\n"
+"The Python, %(gui_library)s, SDL & Linux crews\n"
 "for making this program possible"
 msgstr ""
-": i riconoscimenti vanno a:\n"
+"%(app)s: i riconoscimenti vanno a:\n"
 "\n"
 "Volker Weidner per avermi introdotto ai Solitari\n"
 "Guido van Rossum per il primo esempio di programma\n"
@@ -627,20 +668,27 @@ msgstr ""
 "Il gruppo Aisle Riot di Gnome per parte della documentazione\n"
 "Natascha\n"
 "\n"
-"i gruppi di Python, %s, SDL & Linux\n"
+"i gruppi di Python, %(gui_library)s, SDL & Linux\n"
 "per aver reso possibile questo programma"
 
-#: pysollib/help.py:125
-msgid " HTML Problem"
-msgstr "Problema con HTML"
+#: pysollib/help.py:127 pysollib/kivy/tkhtml.py:687
+#, python-format
+msgid "%s HTML Problem"
+msgstr "%s Problema con HTML"
 
-#: pysollib/help.py:126
-msgid "Cannot find help document\n"
-msgstr "Non trovo la documentazione di aiuto\n"
+#: pysollib/help.py:128
+#, python-format
+msgid ""
+"Cannot find help document\n"
+"%s"
+msgstr ""
+"Non trovo la documentazione di aiuto\n"
+"%s"
 
-#: pysollib/help.py:139
-msgid " Help"
-msgstr " Aiuto"
+#: pysollib/help.py:141
+#, python-format
+msgid "%s Help"
+msgstr "%s Aiuto"
 
 #: pysollib/main.py:58 pysollib/main.py:70 pysollib/main.py:304
 #, python-format
@@ -650,12 +698,12 @@ msgstr "Errore d'installazione %s"
 #: pysollib/main.py:59
 #, fuzzy, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Cardsets should be installed into:\n"
-"%s/cardsets/\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "Nessun mazzo trovato !!!\n"
 "\n"
@@ -664,7 +712,7 @@ msgstr ""
 "\n"
 "Verificare l'installazione di %s.\n"
 
-#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:312
+#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:313
 #: pysollib/ui/tktile/menubar.py:346
 msgid "&Quit"
 msgstr "&Esci"
@@ -672,28 +720,24 @@ msgstr "&Esci"
 #: pysollib/main.py:71
 #, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "Nessun mazzo trovato !!!\n"
 "\n"
 "La cartella principale è:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Verificare l'installazione di %s.\n"
+"Verificare l'installazione di %(app)s.\n"
 
 #: pysollib/main.py:96
 #, python-format
-msgid ""
-"%s\n"
-"try %s --help for more information"
-msgstr ""
-"%s\n"
-"provare %s --help per informazioni"
+msgid "try %s --help for more information"
+msgstr "provare %s --help per informazioni"
 
 #: pysollib/main.py:128
 #, python-format
@@ -753,20 +797,20 @@ msgstr "Benvenuti in %s"
 #, python-format
 msgid ""
 "\n"
-"No games were found !!!\n"
+"No games were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "\n"
 "Nessun gioco trovato !!!\n"
 "\n"
 "La cartella principale è:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Verificare l'installazione di %s.\n"
+"Verificare l'installazione di %(app)s.\n"
 
 #: pysollib/options.py:266
 msgid "Unknown"
@@ -1110,8 +1154,8 @@ msgid "Unlimited redeals."
 msgstr "Ridistribuzioni illimitate"
 
 #: pysollib/stack.py:1948
-#, python-format
-msgid "%d readeal"
+#, fuzzy, python-format
+msgid "%d redeal"
 msgid_plural "%d redeals"
 msgstr[0] "%d ridistribuzione"
 msgstr[1] "%d ridistribuzioni"
@@ -1320,66 +1364,66 @@ msgstr "Pozzo."
 msgid "Free cell."
 msgstr "Free cell."
 
-#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:421
-#: pysollib/pysolgtk/tkstats.py:458 pysollib/tile/tkstats.py:674
+#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:422
+#: pysollib/pysolgtk/tkstats.py:459 pysollib/tile/tkstats.py:675
 msgid "Game"
 msgstr "Gioco"
 
-#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:422
-#: pysollib/tile/tkstats.py:908 pysollib/tile/tkstats.py:977
-#: pysollib/tile/tkstats.py:978 pysollib/tk/tkstats.py:886
-#: pysollib/tk/tkstats.py:887 pysollib/tk/tkstats.py:934
+#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:423
+#: pysollib/tile/tkstats.py:909 pysollib/tile/tkstats.py:978
+#: pysollib/tile/tkstats.py:979 pysollib/tk/tkstats.py:887
+#: pysollib/tk/tkstats.py:888 pysollib/tk/tkstats.py:935
 msgid "Played"
 msgstr "Giocati"
 
-#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:423
-#: pysollib/tile/tkstats.py:914 pysollib/tile/tkstats.py:982
-#: pysollib/tile/tkstats.py:983 pysollib/tk/tkstats.py:891
-#: pysollib/tk/tkstats.py:892 pysollib/tk/tkstats.py:942
+#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/tile/tkstats.py:915 pysollib/tile/tkstats.py:983
+#: pysollib/tile/tkstats.py:984 pysollib/tk/tkstats.py:892
+#: pysollib/tk/tkstats.py:893 pysollib/tk/tkstats.py:943
 msgid "Won"
 msgstr "Vinti"
 
-#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:425
 msgid "Lost"
 msgstr "Persi"
 
 #: pysollib/stats.py:44 pysollib/pysolgtk/statusbar.py:98
-#: pysollib/pysolgtk/tkstats.py:425 pysollib/tile/statusbar.py:154
+#: pysollib/pysolgtk/tkstats.py:426 pysollib/tile/statusbar.py:154
 #: pysollib/tk/statusbar.py:151 data/pysolfc.glade:1133
 msgid "Playing time"
 msgstr "Tempo di gioco"
 
-#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:426
+#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:427
 #: data/pysolfc.glade:1178
 msgid "Moves"
 msgstr "Mosse"
 
-#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:427
-#: pysollib/tile/tkstats.py:920 pysollib/tile/tkstats.py:950
-#: pysollib/tile/tkstats.py:969 pysollib/tile/tkstats.py:987
-#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:878
-#: pysollib/tk/tkstats.py:896 pysollib/tk/tkstats.py:950
+#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:428
+#: pysollib/tile/tkstats.py:921 pysollib/tile/tkstats.py:951
+#: pysollib/tile/tkstats.py:970 pysollib/tile/tkstats.py:988
+#: pysollib/tk/tkstats.py:860 pysollib/tk/tkstats.py:879
+#: pysollib/tk/tkstats.py:897 pysollib/tk/tkstats.py:951
 msgid "% won"
 msgstr "% vinti"
 
 #: pysollib/stats.py:108 pysollib/pysolgtk/statusbar.py:100
-#: pysollib/pysolgtk/tkstats.py:389 pysollib/pysolgtk/tkstats.py:459
-#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:677
-#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:670
+#: pysollib/pysolgtk/tkstats.py:390 pysollib/pysolgtk/tkstats.py:460
+#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:678
+#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:671
 msgid "Game number"
 msgstr "Gioco numero"
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:390
-#: pysollib/pysolgtk/tkstats.py:460 pysollib/tile/tkstats.py:680
-#: pysollib/tk/tkstats.py:673
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:391
+#: pysollib/pysolgtk/tkstats.py:461 pysollib/tile/tkstats.py:681
+#: pysollib/tk/tkstats.py:674
 msgid "Started at"
 msgstr "Iniziato"
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:461
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:462
 msgid "Status"
 msgstr "Stato"
 
-#: pysollib/stats.py:132 pysollib/tile/tkstats.py:696
+#: pysollib/stats.py:132 pysollib/tile/tkstats.py:697
 #, python-format
 msgid "** UNKNOWN %d **"
 msgstr "** SCONOSCIUTO %d **"
@@ -1400,23 +1444,16 @@ msgstr "Non vinti"
 msgid "Perfect"
 msgstr "Perfetto"
 
-#: pysollib/stats.py:201 pysollib/stats.py:233 pysollib/stats.py:240
+#: pysollib/stats.py:201 pysollib/stats.py:234 pysollib/stats.py:241
+#: pysollib/kivy/menubar.py:443
 msgid "Demo"
 msgstr "Demo"
 
 #: pysollib/stats.py:212 pysollib/pysolgtk/tkstats.py:70
 #: pysollib/tile/tkstats.py:371 pysollib/tk/tkstats.py:413
 #, python-format
-msgid "Total (%d out of %d games)"
-msgstr "Totale (%d su %d giochi)"
-
-#: pysollib/stats.py:234
-msgid "Full log for "
-msgstr "Log completo di "
-
-#: pysollib/stats.py:241
-msgid "Session log for "
-msgstr "Log della sessione di "
+msgid "Total (%(played)d out of %(total)d games)"
+msgstr "Totale (%(played)d su %(total)d giochi)"
 
 #: pysollib/util.py:45
 msgid "Club"
@@ -1483,48 +1520,48 @@ msgid "Initial setting:"
 msgstr "Configurazione iniziale:"
 
 #: pysollib/wizardutil.py:105 pysollib/pysolgtk/selectgame.py:114
-#: pysollib/tile/selectgame.py:393 pysollib/tk/selectgame.py:395
+#: pysollib/tile/selectgame.py:391 pysollib/tk/selectgame.py:392
 msgid "Name:"
 msgstr "Nome:"
 
 #: pysollib/wizardutil.py:109 pysollib/kivy/selectgame.py:202
 #: pysollib/pysolgtk/selectgame.py:236 pysollib/pysolgtk/selectgame.py:473
-#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:563
-#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:564
+#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:561
+#: pysollib/tk/selectgame.py:179 pysollib/tk/selectgame.py:562
 msgid "Luck only"
 msgstr "Solo fortuna"
 
 #: pysollib/wizardutil.py:110 pysollib/kivy/selectgame.py:204
 #: pysollib/pysolgtk/selectgame.py:237 pysollib/pysolgtk/selectgame.py:474
-#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:564
-#: pysollib/tk/selectgame.py:183 pysollib/tk/selectgame.py:565
+#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:562
+#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:563
 msgid "Mostly luck"
 msgstr "Prevalentemente fortuna"
 
 #: pysollib/wizardutil.py:111 pysollib/wizardutil.py:115
 #: pysollib/kivy/selectgame.py:206 pysollib/pysolgtk/selectgame.py:238
 #: pysollib/pysolgtk/selectgame.py:475 pysollib/tile/selectgame.py:183
-#: pysollib/tile/selectgame.py:565 pysollib/tk/selectgame.py:185
-#: pysollib/tk/selectgame.py:566
+#: pysollib/tile/selectgame.py:563 pysollib/tk/selectgame.py:183
+#: pysollib/tk/selectgame.py:564
 msgid "Balanced"
 msgstr "Bilanciato"
 
 #: pysollib/wizardutil.py:112 pysollib/kivy/selectgame.py:208
 #: pysollib/pysolgtk/selectgame.py:239 pysollib/pysolgtk/selectgame.py:476
-#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:566
-#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:567
+#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:564
+#: pysollib/tk/selectgame.py:186 pysollib/tk/selectgame.py:565
 msgid "Mostly skill"
 msgstr "Prevalentemente abilità"
 
 #: pysollib/wizardutil.py:113 pysollib/kivy/selectgame.py:210
 #: pysollib/pysolgtk/selectgame.py:240 pysollib/pysolgtk/selectgame.py:477
-#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:567
-#: pysollib/tk/selectgame.py:190 pysollib/tk/selectgame.py:568
+#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:565
+#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:566
 msgid "Skill only"
 msgstr "Solo abilità"
 
 #: pysollib/wizardutil.py:116 pysollib/pysolgtk/selectgame.py:118
-#: pysollib/tile/selectgame.py:397 pysollib/tk/selectgame.py:399
+#: pysollib/tile/selectgame.py:395 pysollib/tk/selectgame.py:396
 msgid "Skill level:"
 msgstr "Abilità:"
 
@@ -1579,8 +1616,8 @@ msgstr "Grounds for a Divorce"
 #: pysollib/wizardutil.py:147 pysollib/wizardutil.py:185
 #: pysollib/wizardutil.py:243 pysollib/wizardutil.py:301
 #: pysollib/pysolgtk/selectgame.py:117 pysollib/tile/selectcardset.py:454
-#: pysollib/tile/selectgame.py:396 pysollib/tk/selectcardset.py:445
-#: pysollib/tk/selectgame.py:398
+#: pysollib/tile/selectgame.py:394 pysollib/tk/selectcardset.py:445
+#: pysollib/tk/selectgame.py:395
 msgid "Type:"
 msgstr "Tipi:"
 
@@ -1602,7 +1639,7 @@ msgstr "Tre ridistribuzioni"
 
 #: pysollib/wizardutil.py:155 pysollib/kivy/selectgame.py:252
 #: pysollib/pysolgtk/selectgame.py:273 pysollib/tile/selectgame.py:231
-#: pysollib/tk/selectgame.py:233
+#: pysollib/tk/selectgame.py:231
 msgid "Unlimited redeals"
 msgstr "Ridistribuzioni illimitate"
 
@@ -1672,6 +1709,7 @@ msgid "Direction:"
 msgstr "Direzione:"
 
 #: pysollib/wizardutil.py:204 pysollib/wizardutil.py:250
+#: pysollib/kivy/menubar.py:884
 msgid "None"
 msgstr "Nessuna"
 
@@ -1796,109 +1834,89 @@ msgstr "Riserve "
 msgid "Opening deal"
 msgstr "Servizio di apertura"
 
-#: pysollib/game/__init__.py:139 pysollib/game/__init__.py:145
+#: pysollib/game/__init__.py:140 pysollib/game/__init__.py:146
 msgid "Player\n"
 msgstr "Giocatore\n"
 
-#: pysollib/game/__init__.py:1266
-msgid "Discard current game ?"
+#: pysollib/game/__init__.py:1301
+msgid "Discard current game?"
 msgstr "Scartare il gioco in corso ?"
 
-#: pysollib/game/__init__.py:1887
-#, fuzzy, python-format
-msgid ""
-"\n"
-"You have reached\n"
-"# %d in the %s of playing time\n"
-"and # %d in the %s of moves."
-msgstr ""
-"\n"
-"Hai ottenuto\n"
-"il posto %d nella %s dei tempi di gioco\n"
-"e il posto %d nella %s del numero di mosse."
-
-#: pysollib/game/__init__.py:1893
-#, fuzzy, python-format
-msgid ""
-"\n"
-"You have reached\n"
-"# %d in the %s of playing time."
-msgstr ""
-"\n"
-"Hai ottenuto\n"
-"il posto %d nella %s dei tempi di gioco."
-
-#: pysollib/game/__init__.py:1898
-#, fuzzy, python-format
-msgid ""
-"\n"
-"You have reached\n"
-"# %d in the %s of moves."
-msgstr ""
-"\n"
-"Hai ottenuto\n"
-"il posto %d nella %s del numero di mosse."
-
-#: pysollib/game/__init__.py:1931 pysollib/game/__init__.py:1947
+#: pysollib/game/__init__.py:1922
 #, python-format
 msgid ""
-"Your playing time is %s\n"
-"for %d move."
-msgid_plural ""
-"Your playing time is %s\n"
-"for %d moves."
-msgstr[0] ""
-"Il tuo tempo è stato di %s\n"
-"per %d mossa."
-msgstr[1] ""
-"Il tuo tempo è stato di %s\n"
-"per %d mosse."
+"\n"
+"You have reached\n"
+"# %(timerank)d in the top %(tops)d of playing time\n"
+"and # %(movesrank)d in the top %(tops)d of moves."
+msgstr ""
+"\n"
+"Hai ottenuto\n"
+"il posto %(timerank)d nella top %(tops)d dei tempi di gioco\n"
+"e il posto %(movesrank)d nella top %(tops)d del numero di mosse."
 
-#: pysollib/game/__init__.py:1936 pysollib/game/__init__.py:1952
-#: pysollib/pysolgtk/soundoptionsdialog.py:71
+#: pysollib/game/__init__.py:1930
+#, python-format
+msgid ""
+"\n"
+"You have reached\n"
+"# %(timerank)d in the top %(tops)d of playing time."
+msgstr ""
+"\n"
+"Hai ottenuto\n"
+"il posto %(timerank)d nella top %(tops)d dei tempi di gioco."
+
+#: pysollib/game/__init__.py:1936
+#, python-format
+msgid ""
+"\n"
+"You have reached\n"
+"# %(movesrank)d in the top %(tops)s of moves."
+msgstr ""
+"\n"
+"Hai ottenuto\n"
+"il posto %(movesrank)d nella top %(tops)s del numero di mosse."
+
+#: pysollib/game/__init__.py:1971 pysollib/game/__init__.py:1987
+#, python-format
+msgid ""
+"Your playing time is %(time)s\n"
+"for %(n)d move."
+msgid_plural ""
+"Your playing time is %(time)s\n"
+"for %(n)d moves."
+msgstr[0] ""
+"Il tuo tempo è stato di %(time)s\n"
+"per %(n)d mossa."
+msgstr[1] ""
+"Il tuo tempo è stato di %(time)s\n"
+"per %(n)d mosse."
+
+#: pysollib/game/__init__.py:1975
+msgid ""
+"Congratulations, this\n"
+"was a truly perfect game!"
+msgstr ""
+"Congratulazioni, questo è stato\n"
+"un gioco veramente perfetto!"
+
+#: pysollib/game/__init__.py:1977 pysollib/game/__init__.py:1993
+#: pysollib/kivy/tkwidget.py:170 pysollib/pysolgtk/soundoptionsdialog.py:71
 #: pysollib/tile/soundoptionsdialog.py:83 pysollib/tk/soundoptionsdialog.py:85
 msgid "Game won"
 msgstr "Gioco vinto"
 
-#: pysollib/game/__init__.py:1937
-#, python-format
-msgid ""
-"\n"
-"Congratulations, this\n"
-"was a truly perfect game !\n"
-"\n"
-"%s\n"
-"%s\n"
-msgstr ""
-"\n"
-"Congratulazioni, questo è stato\n"
-"un gioco veramente perfetto!\n"
-"\n"
-"%s\n"
-"%s\n"
+#: pysollib/game/__init__.py:1991
+msgid "Congratulations, you did it!"
+msgstr "Congratulazioni, ce l'hai fatta!"
 
-#: pysollib/game/__init__.py:1954
-#, python-format
-msgid ""
-"\n"
-"Congratulations, you did it !\n"
-"\n"
-"%s\n"
-"%s\n"
-msgstr ""
-"\n"
-"Congratulazioni, ce l'hai fatta!\n"
-"\n"
-"%s\n"
-"%s\n"
-
-#: pysollib/game/__init__.py:1963 pysollib/game/__init__.py:1970
-#: pysollib/pysolgtk/soundoptionsdialog.py:69
+#: pysollib/game/__init__.py:2001 pysollib/game/__init__.py:2008
+#: pysollib/kivy/tkwidget.py:173 pysollib/pysolgtk/soundoptionsdialog.py:69
 #: pysollib/tile/soundoptionsdialog.py:81 pysollib/tk/soundoptionsdialog.py:83
 msgid "Game finished"
 msgstr "Gioco terminato"
 
-#: pysollib/game/__init__.py:1964 pysollib/game/__init__.py:2488
+#: pysollib/game/__init__.py:2002 pysollib/game/__init__.py:2527
 msgid ""
 "\n"
 "Game finished\n"
@@ -1906,7 +1924,7 @@ msgstr ""
 "\n"
 "Gioco terminato\n"
 
-#: pysollib/game/__init__.py:1971
+#: pysollib/game/__init__.py:2009
 msgid ""
 "\n"
 "Game finished, but not without my help...\n"
@@ -1914,32 +1932,32 @@ msgstr ""
 "\n"
 "Gioco terminato, ma non senza il mio aiuto...\n"
 
-#: pysollib/game/__init__.py:1972
+#: pysollib/game/__init__.py:2010
 msgid "&Restart"
 msgstr "&Ricomincia"
 
-#: pysollib/game/__init__.py:2368
+#: pysollib/game/__init__.py:2406
 #, python-format
 msgid "Score %6d"
 msgstr "Punteggio %6d"
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 msgid "&Great"
 msgstr "&Grande"
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 msgid "&Cool"
 msgstr "&Forte"
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 msgid "&Yeah"
 msgstr "&Sì!"
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 msgid "&Wow"
 msgstr "&E vai"
 
-#: pysollib/game/__init__.py:2474
+#: pysollib/game/__init__.py:2512
 #, python-format
 msgid ""
 "\n"
@@ -1954,24 +1972,25 @@ msgstr[1] ""
 "\n"
 "Gioco risolto in %d mosse.\n"
 
-#: pysollib/game/__init__.py:2478 pysollib/game/__init__.py:2492
-#: pysollib/game/__init__.py:2506
-msgid " Autopilot"
-msgstr " Autopilota"
+#: pysollib/game/__init__.py:2517 pysollib/game/__init__.py:2532
+#: pysollib/game/__init__.py:2547
+#, python-format
+msgid "%s Autopilot"
+msgstr "%s Autopilota"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Oh well"
 msgstr "&Oh bene"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&That's life"
 msgstr "Così è la vi&ta"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Hmm"
 msgstr "&Hemm"
 
-#: pysollib/game/__init__.py:2507
+#: pysollib/game/__init__.py:2548
 msgid ""
 "\n"
 "This won't come out...\n"
@@ -1979,34 +1998,34 @@ msgstr ""
 "\n"
 "Questo non riesce...\n"
 
-#: pysollib/game/__init__.py:2966
+#: pysollib/game/__init__.py:3000
 msgid "Set bookmark"
 msgstr "Metti un segnalibro"
 
-#: pysollib/game/__init__.py:2967
+#: pysollib/game/__init__.py:3001
 #, python-format
-msgid "Replace existing bookmark %d ?"
+msgid "Replace existing bookmark %d?"
 msgstr "Sostituire il segnalibro %d ?"
 
-#: pysollib/game/__init__.py:2988
+#: pysollib/game/__init__.py:3022
 msgid "Goto bookmark"
 msgstr "Va al segnalibro"
 
-#: pysollib/game/__init__.py:2989
+#: pysollib/game/__init__.py:3023
 #, python-format
-msgid "Goto bookmark %d ?"
+msgid "Goto bookmark %d?"
 msgstr "Andare al segnalibro %d ?"
 
-#: pysollib/game/__init__.py:3015
+#: pysollib/game/__init__.py:3049
 msgid "Open game"
 msgstr "Aprire il gioco"
 
-#: pysollib/game/__init__.py:3028 pysollib/game/__init__.py:3037
-#: pysollib/game/__init__.py:3043
+#: pysollib/game/__init__.py:3062 pysollib/game/__init__.py:3071
+#: pysollib/game/__init__.py:3077
 msgid "Load game error"
 msgstr "Errore nel caricare il gioco"
 
-#: pysollib/game/__init__.py:3030
+#: pysollib/game/__init__.py:3064
 msgid ""
 "Error while loading game.\n"
 "\n"
@@ -2019,11 +2038,11 @@ msgstr ""
 "ma potrebbe anche esserci un baco che potresti\n"
 "voler segnalare."
 
-#: pysollib/game/__init__.py:3038
+#: pysollib/game/__init__.py:3072
 msgid "Error while loading game"
 msgstr "Errore nel caricare il gioco"
 
-#: pysollib/game/__init__.py:3045
+#: pysollib/game/__init__.py:3079
 msgid ""
 "Internal error while loading game.\n"
 "\n"
@@ -2032,29 +2051,29 @@ msgstr ""
 "Errore interno nel caricare il gioco.\\ \n"
 "Per piacere segnala questo baco."
 
-#: pysollib/game/__init__.py:3071 pysollib/ui/tktile/menubar.py:1675
+#: pysollib/game/__init__.py:3105 pysollib/ui/tktile/menubar.py:1677
 msgid "Save game error"
 msgstr "Errore nel salvare il gioco"
 
-#: pysollib/game/__init__.py:3072
+#: pysollib/game/__init__.py:3106
 msgid "Error while saving game"
 msgstr "Errore nel salvare il gioco"
 
-#: pysollib/game/__init__.py:3091
+#: pysollib/game/__init__.py:3125
 #, python-format
 msgid "Invalid or damaged %s save file"
 msgstr "Il file %s è errato o corrotto"
 
-#: pysollib/game/__init__.py:3111
+#: pysollib/game/__init__.py:3145
 #, python-format
 msgid ""
 "Cannot load games saved with\n"
-"%s version %s"
+"%(app)s version %(ver)s"
 msgstr ""
 "Non posso caricare giochi salvati con\n"
-"la versione %s %s"
+"la versione %(app)s %(ver)s"
 
-#: pysollib/game/__init__.py:3130
+#: pysollib/game/__init__.py:3164
 #, python-format
 msgid ""
 "Cannot load this game from version %s\n"
@@ -2142,10 +2161,10 @@ msgstr "Riserva. Accetta solo i Re"
 
 #: pysollib/games/matriarchy.py:123
 #, python-format
-msgid "Round %d/%d"
-msgstr "Giro %d/%d"
+msgid "Round %(round)d/%(max_rounds)d"
+msgstr "Giro %(round)d/%(max_rounds)d"
 
-#: pysollib/games/matriarchy.py:125
+#: pysollib/games/matriarchy.py:126
 #, python-format
 msgid "Deal %d"
 msgstr "Prendi %d"
@@ -2226,6 +2245,510 @@ msgstr ""
 "Tableau. Decrescente di qualsiasi seme. Si pòssono spostare le carte "
 "visibili anche non in sequenza."
 
+#: pysollib/kivy/menubar.py:179
+msgid "File"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:183
+msgid "Games"
+msgstr "Giochi"
+
+#: pysollib/kivy/menubar.py:188 pysollib/kivy/menubar.py:1605
+#, fuzzy
+msgid "Tools"
+msgstr "Barra strumenti"
+
+#: pysollib/kivy/menubar.py:192 pysollib/kivy/menubar.py:1613
+#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:177
+#: pysollib/tile/selectgame.py:385 pysollib/tile/tkstats.py:51
+#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:384
+#: pysollib/tk/toolbar.py:188
+msgid "Statistics"
+msgstr "Statistiche"
+
+#: pysollib/kivy/menubar.py:196
+#, fuzzy
+msgid "Assist"
+msgstr "&Assistente"
+
+#: pysollib/kivy/menubar.py:201 pysollib/kivy/menubar.py:1629
+msgid "Options"
+msgstr "Opzioni"
+
+#: pysollib/kivy/menubar.py:206 pysollib/kivy/menubar.py:320
+#: pysollib/kivy/menubar.py:1637
+msgid "Help"
+msgstr "Aiuto"
+
+#: pysollib/kivy/menubar.py:227
+msgid "Recent games"
+msgstr "Giochi recenti"
+
+#: pysollib/kivy/menubar.py:240
+msgid "Favorite games"
+msgstr "Giochi preferiti"
+
+#: pysollib/kivy/menubar.py:243
+msgid "<Add>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:245
+msgid "<Remove>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:296 pysollib/kivy/toolbar.py:197
+#: pysollib/pysolgtk/soundoptionsdialog.py:63
+#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
+#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
+msgid "Undo"
+msgstr "Annulla"
+
+#: pysollib/kivy/menubar.py:298 pysollib/kivy/toolbar.py:198
+#: pysollib/pysolgtk/soundoptionsdialog.py:64
+#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
+#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
+msgid "Redo"
+msgstr "Ripristina"
+
+#: pysollib/kivy/menubar.py:300
+msgid "Redo all"
+msgstr "Ripristina tutto"
+
+#: pysollib/kivy/menubar.py:303 pysollib/kivy/menubar.py:517
+#: pysollib/pysolgtk/soundoptionsdialog.py:56
+#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
+msgid "Auto drop"
+msgstr "Auto rilascio"
+
+#: pysollib/kivy/menubar.py:305 pysollib/kivy/toolbar.py:200
+#: pysollib/tile/toolbar.py:185 pysollib/tk/toolbar.py:185
+msgid "Shuffle tiles"
+msgstr "Mescola le tessere"
+
+#: pysollib/kivy/menubar.py:307
+msgid "Deal cards"
+msgstr "Distribuisci le carte"
+
+#: pysollib/kivy/menubar.py:310 pysollib/kivy/toolbar.py:201
+#: pysollib/tile/toolbar.py:186 pysollib/tk/toolbar.py:186
+msgid "Pause"
+msgstr "Pausa"
+
+#: pysollib/kivy/menubar.py:315
+#, fuzzy
+msgid "Load game"
+msgstr "Errore nel caricare il gioco"
+
+#: pysollib/kivy/menubar.py:317 pysollib/tile/toolbar.py:180
+#: pysollib/tk/toolbar.py:180
+msgid "Save game"
+msgstr "Salva il gioco"
+
+#: pysollib/kivy/menubar.py:371
+msgid "Current game..."
+msgstr "Gioco corrente..."
+
+#: pysollib/kivy/menubar.py:434
+msgid "Hint"
+msgstr "Suggerimenti"
+
+#: pysollib/kivy/menubar.py:437
+#, fuzzy
+msgid "Highlight piles"
+msgstr "Evidenzia le pile:"
+
+#: pysollib/kivy/menubar.py:509
+msgid "Automatic play"
+msgstr "Gioco automatico"
+
+#: pysollib/kivy/menubar.py:512
+#, fuzzy
+msgid "Auto face up"
+msgstr "Auto &scopri"
+
+#: pysollib/kivy/menubar.py:522
+msgid "Auto deal"
+msgstr "Auto distrib."
+
+#: pysollib/kivy/menubar.py:529
+msgid "Quick play"
+msgstr "Gioco veloce"
+
+#: pysollib/kivy/menubar.py:537
+msgid "Assist level"
+msgstr "Livello assistenza"
+
+#: pysollib/kivy/menubar.py:540
+msgid "Enable undo"
+msgstr "Abilita annulla"
+
+#: pysollib/kivy/menubar.py:545
+msgid "Enable bookmarks"
+msgstr "Abilita segnalibri"
+
+#: pysollib/kivy/menubar.py:550
+msgid "Enable hint"
+msgstr "Abilita suggerimenti"
+
+#: pysollib/kivy/menubar.py:555
+msgid "Enable shuffle"
+msgstr "Abilita mescola"
+
+#: pysollib/kivy/menubar.py:560
+#, fuzzy
+msgid "Enable highlight piles"
+msgstr "Abilita evidenzia p&ile"
+
+#: pysollib/kivy/menubar.py:565
+#, fuzzy
+msgid "Enable highlight cards"
+msgstr "Abilita evidenzia &carte"
+
+#: pysollib/kivy/menubar.py:570
+#, fuzzy
+msgid "Enable highlight same rank"
+msgstr "Abilita evidenzia stesso valo&re"
+
+#: pysollib/kivy/menubar.py:575
+#, fuzzy
+msgid "Highlight no matching"
+msgstr "Abilita non corrispondenti"
+
+#: pysollib/kivy/menubar.py:582
+#, fuzzy
+msgid "Show removed tiles (in Mahjongg games)"
+msgstr "Mo&stra tessere tolte (in Mahjongg)"
+
+#: pysollib/kivy/menubar.py:587
+#, fuzzy
+msgid "Show hint arrow (in Shisen-Sho games)"
+msgstr "Mostra suggerimenti e frecci&a (Shisen-Sho)"
+
+#: pysollib/kivy/menubar.py:597
+#, fuzzy
+msgid "Sound"
+msgstr "&Suono"
+
+#: pysollib/kivy/menubar.py:600
+#, fuzzy
+msgid "Enable"
+msgstr "Abilita ann&ulla"
+
+#: pysollib/kivy/menubar.py:605
+msgid "Volume"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:608
+msgid "100%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:612
+msgid "75%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:616
+msgid "50%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:620
+msgid "25%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:625
+#, fuzzy
+msgid "Samples"
+msgstr "Giochi facili"
+
+#: pysollib/kivy/menubar.py:630
+msgid "are you sure"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:636
+#, fuzzy
+msgid "auto drop"
+msgstr "Auto rilascio"
+
+#: pysollib/kivy/menubar.py:642
+#, fuzzy
+msgid "auto flip"
+msgstr "Gira automatico"
+
+#: pysollib/kivy/menubar.py:648
+#, fuzzy
+msgid "auto pilot lost"
+msgstr "Autopilota perduto"
+
+#: pysollib/kivy/menubar.py:654
+#, fuzzy
+msgid "auto pilot won"
+msgstr "Vincita autopilota"
+
+#: pysollib/kivy/menubar.py:660
+#, fuzzy
+msgid "deal"
+msgstr "Ridistribuzione"
+
+#: pysollib/kivy/menubar.py:666
+#, fuzzy
+msgid "deal waste"
+msgstr "Distribuzione del pozzo"
+
+#: pysollib/kivy/menubar.py:672
+#, fuzzy
+msgid "drop pair"
+msgstr "Rilascio coppia"
+
+#: pysollib/kivy/menubar.py:678
+#, fuzzy
+msgid "drop"
+msgstr "Autoserve"
+
+#: pysollib/kivy/menubar.py:684
+#, fuzzy
+msgid "flip"
+msgstr "Gira automatico"
+
+#: pysollib/kivy/menubar.py:690
+#, fuzzy
+msgid "move"
+msgstr "Nessuna mossa"
+
+#: pysollib/kivy/menubar.py:696
+#, fuzzy
+msgid "no move"
+msgstr "Nessuna mossa"
+
+#: pysollib/kivy/menubar.py:702
+msgid "redo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:708
+#, fuzzy
+msgid "start drag"
+msgstr "Trascinamento"
+
+#: pysollib/kivy/menubar.py:714
+#, fuzzy
+msgid "turn waste"
+msgstr "Girare il pozzo"
+
+#: pysollib/kivy/menubar.py:720
+msgid "undo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:726
+#, fuzzy
+msgid "game finished"
+msgstr "Gioco terminato"
+
+#: pysollib/kivy/menubar.py:732
+#, fuzzy
+msgid "game lost"
+msgstr "Gioco perduto"
+
+#: pysollib/kivy/menubar.py:738
+#, fuzzy
+msgid "game perfect"
+msgstr "Perfetto"
+
+#: pysollib/kivy/menubar.py:744
+#, fuzzy
+msgid "game won"
+msgstr "Gioco vinto"
+
+#: pysollib/kivy/menubar.py:752
+#, fuzzy
+msgid "Cardsets"
+msgstr "Tutti i tipi"
+
+#: pysollib/kivy/menubar.py:792
+#, fuzzy
+msgid "Table"
+msgstr "Tableau"
+
+#: pysollib/kivy/menubar.py:795
+msgid "Solid colors"
+msgstr "Colori pieni"
+
+#: pysollib/kivy/menubar.py:800 pysollib/pysolgtk/selecttile.py:105
+#: pysollib/tile/selecttile.py:74 pysollib/tk/selecttile.py:73
+msgid "Blue"
+msgstr "Azzurro"
+
+#: pysollib/kivy/menubar.py:805 pysollib/pysolgtk/selecttile.py:106
+#: pysollib/tile/selecttile.py:75 pysollib/tk/selecttile.py:74
+#: pysollib/games/ultra/dashavatara.py:361 pysollib/games/ultra/mughal.py:264
+msgid "Green"
+msgstr "Verde"
+
+#: pysollib/kivy/menubar.py:810 pysollib/pysolgtk/selecttile.py:107
+#: pysollib/tile/selecttile.py:76 pysollib/tk/selecttile.py:75
+msgid "Navy"
+msgstr "Blu marino"
+
+#: pysollib/kivy/menubar.py:815 pysollib/pysolgtk/selecttile.py:108
+#: pysollib/tile/selecttile.py:77 pysollib/tk/selecttile.py:76
+#: pysollib/games/ultra/dashavatara.py:362
+msgid "Olive"
+msgstr "Oliva"
+
+#: pysollib/kivy/menubar.py:820 pysollib/pysolgtk/selecttile.py:109
+#: pysollib/tile/selecttile.py:78 pysollib/tk/selecttile.py:77
+#: pysollib/games/ultra/dashavatara.py:362 pysollib/games/ultra/mughal.py:264
+msgid "Orange"
+msgstr "Arancione"
+
+#: pysollib/kivy/menubar.py:825 pysollib/pysolgtk/selecttile.py:110
+#: pysollib/tile/selecttile.py:79 pysollib/tk/selecttile.py:78
+msgid "Teal"
+msgstr "Verde acqua"
+
+#: pysollib/kivy/menubar.py:830
+msgid "Tiles and Images"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:850
+#, fuzzy
+msgid "Card view"
+msgstr "&Vista carte"
+
+#: pysollib/kivy/menubar.py:853
+#, fuzzy
+msgid "Card shadow"
+msgstr "Om&breggia carte"
+
+#: pysollib/kivy/menubar.py:858
+#, fuzzy
+msgid "Shade legal moves"
+msgstr "Ombreggia mosse consentite"
+
+#: pysollib/kivy/menubar.py:863
+#, fuzzy
+msgid "Negative cards bottom"
+msgstr "Fondo carte in negativo"
+
+#: pysollib/kivy/menubar.py:868 pysollib/ui/tktile/menubar.py:559
+msgid "Shrink face-down cards"
+msgstr "Restringi carte nascoste"
+
+#: pysollib/kivy/menubar.py:873
+#, fuzzy
+msgid "Shade filled stacks"
+msgstr "Ombreggia pile piene"
+
+#: pysollib/kivy/menubar.py:881
+#, fuzzy
+msgid "Animations"
+msgstr "A&nimazioni"
+
+#: pysollib/kivy/menubar.py:889
+#, fuzzy
+msgid "Very fast"
+msgstr "Mol&to veloce"
+
+#: pysollib/kivy/menubar.py:894
+#, fuzzy
+msgid "Fast"
+msgstr "&Veloce"
+
+#: pysollib/kivy/menubar.py:899
+#, fuzzy
+msgid "Medium"
+msgstr "&Media"
+
+#: pysollib/kivy/menubar.py:904
+#, fuzzy
+msgid "Slow"
+msgstr "&Lenta"
+
+#: pysollib/kivy/menubar.py:909
+#, fuzzy
+msgid "Very slow"
+msgstr "Molto le&nta"
+
+#: pysollib/kivy/menubar.py:916
+#, fuzzy
+msgid "Redeal animation"
+msgstr "Animazione &ridistribuzione"
+
+#: pysollib/kivy/menubar.py:921
+#, fuzzy
+msgid "Winning animation"
+msgstr "Animazione vi&ttoria"
+
+#: pysollib/kivy/menubar.py:929
+msgid "Touch mode"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:932
+#, fuzzy
+msgid "Drag-and-Drop"
+msgstr "&Trascina e rilascia"
+
+#: pysollib/kivy/menubar.py:937
+#, fuzzy
+msgid "Point-and-Click"
+msgstr "&Punta e clicca"
+
+#: pysollib/kivy/menubar.py:971 pysollib/tile/toolbar.py:202
+#: pysollib/tk/toolbar.py:211
+msgid "Toolbar"
+msgstr "Barra strumenti"
+
+#: pysollib/kivy/menubar.py:974 pysollib/ui/tktile/menubar.py:41
+msgid "Hide"
+msgstr "Nascondi"
+
+#: pysollib/kivy/menubar.py:989 pysollib/ui/tktile/menubar.py:50
+msgid "Left"
+msgstr "Sinistra"
+
+#: pysollib/kivy/menubar.py:993 pysollib/ui/tktile/menubar.py:53
+msgid "Right"
+msgstr "Destra"
+
+#: pysollib/kivy/menubar.py:1030
+#, fuzzy
+msgid "Startup splash screen"
+msgstr "Splash sc&reen all'avvio"
+
+#: pysollib/kivy/menubar.py:1035
+msgid "Winning splash"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1058
+#, fuzzy
+msgid "Contents"
+msgstr "&Contenuti"
+
+#: pysollib/kivy/menubar.py:1062
+#, fuzzy
+msgid "How to play"
+msgstr "Co&me giocare"
+
+#: pysollib/kivy/menubar.py:1066 pysollib/kivy/toolbar.py:204
+#: pysollib/tile/toolbar.py:189 pysollib/tk/toolbar.py:189
+msgid "Rules for this game"
+msgstr "Regole di questo gioco"
+
+#: pysollib/kivy/menubar.py:1070
+#, fuzzy
+msgid "License terms"
+msgstr "Termini della &licenza"
+
+#: pysollib/kivy/menubar.py:1074
+#, fuzzy, python-format
+msgid "About %s..."
+msgstr "Informazioni "
+
+#: pysollib/kivy/menubar.py:1348
+msgid "Menu"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1576 pysollib/ui/tktile/menubar.py:971
+msgid "<none>"
+msgstr ""
+
 #: pysollib/kivy/menubar.py:1589
 msgid "Main Menu"
 msgstr ""
@@ -2234,288 +2757,331 @@ msgstr ""
 msgid "File Menu"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:1605
-#, fuzzy
-msgid "Tools"
-msgstr "Barra strumenti"
-
 #: pysollib/kivy/menubar.py:1621
 #, fuzzy
 msgid "Assists"
 msgstr "&Assistente"
 
-#: pysollib/kivy/menubar.py:1629
-#, fuzzy
-msgid "Options"
-msgstr "&Opzioni"
+#. TRANSLATORS: Usually, 'PySol files'
+#: pysollib/kivy/menubar.py:1795 pysollib/ui/tktile/menubar.py:1136
+#, fuzzy, python-format
+msgid "%s files"
+msgstr "Tutti i tempi"
 
-#: pysollib/kivy/menubar.py:1637
+#: pysollib/kivy/menubar.py:1796 pysollib/ui/tktile/menubar.py:1137
 #, fuzzy
-msgid "Help"
-msgstr " Aiuto"
+msgid "All files"
+msgstr "Tutti i tempi"
 
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2067
-#: pysollib/kivy/selectcardset.py:61 pysollib/pysolgtk/selectcardset.py:229
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2068
+#: pysollib/kivy/selectcardset.py:57 pysollib/pysolgtk/selectcardset.py:229
 #: pysollib/tk/menubar.py:89 pysollib/tk/menubar.py:90
 #: pysollib/tk/selectcardset.py:313
 msgid "&Load"
 msgstr "&Carica"
 
-#: pysollib/kivy/menubar.py:2068 pysollib/kivy/selectcardset.py:61
+#: pysollib/kivy/menubar.py:2069 pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/tile/selectcardset.py:318
 #: pysollib/tk/menubar.py:90
 msgid "&Info..."
 msgstr "&Informazioni..."
 
-#: pysollib/kivy/menubar.py:2072 pysollib/tile/menubar.py:90
-#: pysollib/tk/menubar.py:94
-msgid "Select "
-msgstr "Scelta"
+#: pysollib/kivy/menubar.py:2072 pysollib/pysolgtk/menubar.py:696
+#, fuzzy
+msgid "Select cardset"
+msgstr "Scelta nome"
 
-#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1664
+#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1666
 msgid "Solitaire Wizard"
 msgstr "Costruzione guidata"
 
 #: pysollib/kivy/selectgame.py:83 pysollib/tile/selectgame.py:84
-#: pysollib/tk/selectgame.py:85
+#: pysollib/tk/selectgame.py:84
 msgid "(no games)"
 msgstr "(nessun gioco)"
 
 #: pysollib/kivy/selectgame.py:104 pysollib/pysolgtk/selectgame.py:227
-#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:109
+#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:108
 msgid "Mahjongg Games"
 msgstr "Mahjongg"
 
 #: pysollib/kivy/selectgame.py:108 pysollib/pysolgtk/selectgame.py:233
-#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:113
+#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:112
 msgid "French games"
 msgstr "Francesi"
 
 #: pysollib/kivy/selectgame.py:111 pysollib/pysolgtk/selectgame.py:229
-#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:116
+#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:115
 msgid "Oriental Games"
 msgstr "Orientali"
 
 #: pysollib/kivy/selectgame.py:114 pysollib/pysolgtk/selectgame.py:231
-#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:119
+#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:118
 msgid "Special Games"
 msgstr "Speciali"
 
 #: pysollib/kivy/selectgame.py:117 pysollib/pysolgtk/selectgame.py:315
-#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:122
+#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:121
 msgid "Original Games"
 msgstr "Originali"
 
 #: pysollib/kivy/selectgame.py:146 pysollib/pysolgtk/selectgame.py:216
-#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:170
+#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:168
 msgid "All Games"
 msgstr "Tutti"
 
 #: pysollib/kivy/selectgame.py:157 pysollib/pysolgtk/selectgame.py:286
-#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:138
+#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:137
 msgid "by Compatibility"
 msgstr "per compatibilità"
 
 #: pysollib/kivy/selectgame.py:168 pysollib/pysolgtk/selectgame.py:293
-#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:149
-msgid "New games in v. "
+#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:147
+#, fuzzy, python-format
+msgid "New games in v. %(version)s"
 msgstr "Nuovi giochi nella v. "
 
 #: pysollib/kivy/selectgame.py:171 pysollib/pysolgtk/selectgame.py:296
-#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:152
+#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:150
 msgid "by PySol version"
 msgstr "per versione di PySol"
 
 #: pysollib/kivy/selectgame.py:183 pysollib/tile/selectgame.py:161
-#: pysollib/tk/selectgame.py:163
+#: pysollib/tk/selectgame.py:161
 msgid "by Inventors"
 msgstr "per inventore"
 
 #: pysollib/kivy/selectgame.py:191 pysollib/pysolgtk/selectgame.py:218
-#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:172
+#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:170
 msgid "Popular Games"
 msgstr "Giochi più noti"
 
 #: pysollib/kivy/selectgame.py:198 pysollib/pysolgtk/selectgame.py:217
-#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:171
+#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:169
 msgid "Alternate Names"
 msgstr "Nomi alternativi"
 
 #: pysollib/kivy/selectgame.py:201 pysollib/pysolgtk/selectgame.py:243
-#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:180
+#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:178
 msgid "by Skill Level"
 msgstr "per livello di abilità"
 
 #: pysollib/kivy/selectgame.py:213 pysollib/pysolgtk/selectgame.py:247
-#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:193
+#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:191
 msgid "by Game Feature"
 msgstr "per caratteristiche"
 
 #: pysollib/kivy/selectgame.py:214 pysollib/pysolgtk/selectgame.py:260
-#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:194
+#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:192
 msgid "by Number of Cards"
 msgstr "per numero di carte"
 
 #: pysollib/kivy/selectgame.py:215 pysollib/pysolgtk/selectgame.py:249
-#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:195
+#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:193
 msgid "32 cards"
 msgstr "32 carte"
 
 #: pysollib/kivy/selectgame.py:217 pysollib/pysolgtk/selectgame.py:250
-#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:197
+#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:195
 msgid "48 cards"
 msgstr "48 carte"
 
 #: pysollib/kivy/selectgame.py:219 pysollib/pysolgtk/selectgame.py:251
-#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:199
+#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:197
 msgid "52 cards"
 msgstr "52 carte"
 
 #: pysollib/kivy/selectgame.py:221 pysollib/pysolgtk/selectgame.py:252
-#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:201
+#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:199
 msgid "64 cards"
 msgstr "64 carte"
 
 #: pysollib/kivy/selectgame.py:223 pysollib/pysolgtk/selectgame.py:253
-#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:203
+#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:201
 msgid "78 cards"
 msgstr "78 carte"
 
 #: pysollib/kivy/selectgame.py:225 pysollib/pysolgtk/selectgame.py:254
-#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:205
+#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:203
 msgid "104 cards"
 msgstr "104 carte"
 
 #: pysollib/kivy/selectgame.py:227 pysollib/pysolgtk/selectgame.py:255
-#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:207
+#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:205
 msgid "144 cards"
 msgstr "144 carte"
 
 #: pysollib/kivy/selectgame.py:229 pysollib/pysolgtk/selectgame.py:256
-#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:210
+#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:208
 msgid "Other number"
 msgstr "Altri numeri"
 
 #: pysollib/kivy/selectgame.py:233 pysollib/pysolgtk/selectgame.py:267
-#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:214
+#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:212
 msgid "by Number of Decks"
 msgstr "per numero di mazzi"
 
 #: pysollib/kivy/selectgame.py:234 pysollib/pysolgtk/selectgame.py:262
-#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:215
+#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:213
 msgid "1 deck games"
 msgstr "1 mazzo"
 
 #: pysollib/kivy/selectgame.py:236 pysollib/pysolgtk/selectgame.py:263
-#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:217
+#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:215
 msgid "2 deck games"
 msgstr "2 mazzi"
 
 #: pysollib/kivy/selectgame.py:238 pysollib/pysolgtk/selectgame.py:264
-#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:219
+#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:217
 msgid "3 deck games"
 msgstr "3 mazzi"
 
 #: pysollib/kivy/selectgame.py:240 pysollib/pysolgtk/selectgame.py:265
-#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:221
+#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:219
 msgid "4 deck games"
 msgstr "4 mazzi"
 
 #: pysollib/kivy/selectgame.py:243 pysollib/pysolgtk/selectgame.py:278
-#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:224
+#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:222
 msgid "by Number of Redeals"
 msgstr "per numero di ridistribuzioni"
 
 #: pysollib/kivy/selectgame.py:244 pysollib/pysolgtk/selectgame.py:269
-#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:225
+#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:223
 msgid "No redeal"
 msgstr "Nessuna ridistribuzione"
 
 #: pysollib/kivy/selectgame.py:246 pysollib/pysolgtk/selectgame.py:270
-#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:227
+#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:225
 msgid "1 redeal"
 msgstr "1 ridistribuzione"
 
 #: pysollib/kivy/selectgame.py:248 pysollib/pysolgtk/selectgame.py:271
-#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:229
+#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:227
 msgid "2 redeals"
 msgstr "2 ridistribuzioni"
 
 #: pysollib/kivy/selectgame.py:250 pysollib/pysolgtk/selectgame.py:272
-#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:231
+#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:229
 msgid "3 redeals"
 msgstr "3 ridistribuzioni"
 
 #: pysollib/kivy/selectgame.py:256 pysollib/pysolgtk/selectgame.py:275
-#: pysollib/tile/selectgame.py:236 pysollib/tk/selectgame.py:238
+#: pysollib/tile/selectgame.py:234 pysollib/tk/selectgame.py:234
 msgid "Other number of redeals"
 msgstr "Altro numero di ridistribuzioni"
 
 #: pysollib/kivy/selectgame.py:264 pysollib/pysolgtk/selectgame.py:311
-#: pysollib/tile/selectgame.py:243 pysollib/tk/selectgame.py:245
+#: pysollib/tile/selectgame.py:241 pysollib/tk/selectgame.py:241
 msgid "Other Categories"
 msgstr "Altre categorie"
 
 #: pysollib/kivy/selectgame.py:265 pysollib/pysolgtk/selectgame.py:300
-#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:246
+#: pysollib/tile/selectgame.py:242 pysollib/tk/selectgame.py:242
 msgid "Games for Children (very easy)"
 msgstr "Giochi per bambini (molto facili)"
 
 #: pysollib/kivy/selectgame.py:267 pysollib/pysolgtk/selectgame.py:302
-#: pysollib/tile/selectgame.py:246 pysollib/tk/selectgame.py:248
+#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:244
 msgid "Games with Scoring"
 msgstr "Giochi con punteggio"
 
 #: pysollib/kivy/selectgame.py:269 pysollib/pysolgtk/selectgame.py:304
-#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:251
+#: pysollib/tile/selectgame.py:247 pysollib/tk/selectgame.py:247
 msgid "Games with Separate Decks"
 msgstr "Giochi con mazzi separati"
 
 #: pysollib/kivy/selectgame.py:271 pysollib/pysolgtk/selectgame.py:306
-#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:253
+#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:249
 msgid "Open Games (all cards visible)"
 msgstr "Giochi aperti (tutte le carte visibili)"
 
 #: pysollib/kivy/selectgame.py:273 pysollib/pysolgtk/selectgame.py:308
-#: pysollib/tile/selectgame.py:253 pysollib/tk/selectgame.py:255
+#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:251
 msgid "Relaxed Variants"
 msgstr "Varianti facilitate"
+
+#: pysollib/kivy/tkhtml.py:409
+#, fuzzy
+msgid "Browser"
+msgstr "Marrone"
+
+#: pysollib/kivy/tkhtml.py:434 pysollib/pysolgtk/tkhtml.py:218
+#: pysollib/tile/tkhtml.py:77 pysollib/tk/tkhtml.py:72
+msgid "Index"
+msgstr "Indice"
+
+#: pysollib/kivy/tkhtml.py:435 pysollib/pysolgtk/tkhtml.py:219
+#: pysollib/tile/tkhtml.py:81 pysollib/tk/tkhtml.py:76
+msgid "Back"
+msgstr "Indietro"
+
+#: pysollib/kivy/tkhtml.py:437 pysollib/pysolgtk/tkhtml.py:220
+#: pysollib/tile/tkhtml.py:85 pysollib/tk/tkhtml.py:80
+msgid "Forward"
+msgstr "Avanti"
+
+#: pysollib/kivy/tkhtml.py:438 pysollib/pysolgtk/tkhtml.py:221
+#: pysollib/tile/tkhtml.py:89 pysollib/tk/tkhtml.py:84
+msgid "Close"
+msgstr "Chiudi"
 
 #: pysollib/kivy/tkstats.py:148 pysollib/tile/tkstats.py:163
 #: pysollib/tk/tkstats.py:53
 msgid "Demo games"
 msgstr "Giochi demo"
 
-#: pysollib/kivy/tkstats.py:220 pysollib/pysolgtk/selectgame.py:123
-#: pysollib/tile/selectgame.py:402 pysollib/tile/tkstats.py:182
-#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:404
+#: pysollib/kivy/tkstats.py:175
+#, python-format
+msgid ""
+"Total:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+"\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:187
+#, python-format
+msgid ""
+"Current Session:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:225 pysollib/pysolgtk/selectgame.py:123
+#: pysollib/tile/selectgame.py:400 pysollib/tile/tkstats.py:182
+#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:401
 #: pysollib/tk/tkstats.py:87 pysollib/tk/tkstats.py:141 data/pysolfc.glade:241
 #: data/pysolfc.glade:519
 msgid "Won:"
 msgstr "Vinti:"
 
-#: pysollib/kivy/tkstats.py:222 pysollib/pysolgtk/selectgame.py:124
-#: pysollib/tile/selectgame.py:403 pysollib/tile/tkstats.py:183
-#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:405
+#: pysollib/kivy/tkstats.py:227 pysollib/pysolgtk/selectgame.py:124
+#: pysollib/tile/selectgame.py:401 pysollib/tile/tkstats.py:183
+#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:402
 #: pysollib/tk/tkstats.py:88 pysollib/tk/tkstats.py:143 data/pysolfc.glade:307
 #: data/pysolfc.glade:544
 msgid "Lost:"
 msgstr "Perduti:"
 
-#: pysollib/kivy/tkstats.py:224 pysollib/tile/tkstats.py:184
+#: pysollib/kivy/tkstats.py:229 pysollib/tile/tkstats.py:184
 #: pysollib/tile/tkstats.py:238 pysollib/tk/tkstats.py:89
 #: pysollib/tk/tkstats.py:145 data/pysolfc.glade:266 data/pysolfc.glade:569
 msgid "Total:"
 msgstr "Totale:"
 
-#: pysollib/kivy/tkstats.py:250 pysollib/tk/tkstats.py:279
+#: pysollib/kivy/tkstats.py:255 pysollib/tk/tkstats.py:279
 msgid "&All games..."
 msgstr "&Tutti i giochi..."
 
-#: pysollib/kivy/tkstats.py:252 pysollib/tile/tkstats.py:102
+#: pysollib/kivy/tkstats.py:257 pysollib/tile/tkstats.py:102
 #: pysollib/tk/tkstats.py:281
 msgid "&Reset..."
 msgstr "&Reset..."
+
+#: pysollib/kivy/tkwidget.py:183
+msgid "Error"
+msgstr ""
 
 #: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
 #: pysollib/tk/toolbar.py:176
@@ -2536,22 +3102,10 @@ msgstr ""
 "Ricomincia\n"
 "questo gioco"
 
-#: pysollib/kivy/toolbar.py:197 pysollib/pysolgtk/soundoptionsdialog.py:63
-#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
-#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
-msgid "Undo"
-msgstr "Annulla"
-
 #: pysollib/kivy/toolbar.py:197 pysollib/tile/toolbar.py:182
 #: pysollib/tk/toolbar.py:182
 msgid "Undo last move"
 msgstr "Annulla l'ultima mossa"
-
-#: pysollib/kivy/toolbar.py:198 pysollib/pysolgtk/soundoptionsdialog.py:64
-#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
-#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
-msgid "Redo"
-msgstr "Ripristina"
 
 #: pysollib/kivy/toolbar.py:198 pysollib/tile/toolbar.py:183
 #: pysollib/tk/toolbar.py:183
@@ -2573,16 +3127,6 @@ msgstr "Auto serve"
 msgid "Shuffle"
 msgstr "Mescola"
 
-#: pysollib/kivy/toolbar.py:200 pysollib/tile/toolbar.py:185
-#: pysollib/tk/toolbar.py:185
-msgid "Shuffle tiles"
-msgstr "Mescola le tessere"
-
-#: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
-#: pysollib/tk/toolbar.py:186
-msgid "Pause"
-msgstr "Pausa"
-
 #: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
 #: pysollib/tk/toolbar.py:186
 msgid "Pause game"
@@ -2592,11 +3136,6 @@ msgstr "Pausa il gioco"
 #: pysollib/tk/toolbar.py:189
 msgid "Rules"
 msgstr "Regole"
-
-#: pysollib/kivy/toolbar.py:204 pysollib/tile/toolbar.py:189
-#: pysollib/tk/toolbar.py:189
-msgid "Rules for this game"
-msgstr "Regole di questo gioco"
 
 #: pysollib/kivy/toolbar.py:206 pysollib/tile/toolbar.py:191
 #: pysollib/tk/toolbar.py:191
@@ -2613,28 +3152,21 @@ msgid "Empty"
 msgstr ""
 
 #: pysollib/pysolgtk/menubar.py:596
-#, fuzzy
 msgid "Open Game"
 msgstr "Aprire il gioco"
 
 #: pysollib/pysolgtk/menubar.py:623
-#, fuzzy
 msgid "Save Game"
 msgstr "Salva il gioco"
 
-#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1298
+#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1300
 #: data/pysolfc.glade:4127
 msgid "Sound settings"
 msgstr "Impostazioni suono"
 
-#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1521
+#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1523
 msgid "Select table background"
 msgstr "Scelta dello sfondo"
-
-#: pysollib/pysolgtk/menubar.py:696
-#, fuzzy
-msgid "Select cardset"
-msgstr "Scelta nome"
 
 #: pysollib/pysolgtk/playeroptionsdialog.py:62
 #: pysollib/tile/playeroptionsdialog.py:61
@@ -2712,114 +3244,82 @@ msgstr "per nazionalità"
 msgid "by Date"
 msgstr "per data"
 
-#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:384
-#: pysollib/tk/selectgame.py:386
+#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:382
+#: pysollib/tk/selectgame.py:383
 msgid "About game"
 msgstr "Caratteristiche"
 
-#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:394
-#: pysollib/tk/selectgame.py:396
+#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:392
+#: pysollib/tk/selectgame.py:393
 msgid "Alternate names:"
 msgstr "Nomi alternativi:"
 
-#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:395
-#: pysollib/tk/selectgame.py:397
+#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:393
+#: pysollib/tk/selectgame.py:394
 msgid "Category:"
 msgstr "Categoria:"
 
-#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:398
-#: pysollib/tk/selectgame.py:400
+#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:396
+#: pysollib/tk/selectgame.py:397
 msgid "Decks:"
 msgstr "Mazzi:"
 
-#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:399
-#: pysollib/tk/selectgame.py:401
+#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:397
+#: pysollib/tk/selectgame.py:398
 msgid "Redeals:"
 msgstr "Ridistribuzioni:"
 
-#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:401
-#: pysollib/tk/selectgame.py:403
+#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:399
+#: pysollib/tk/selectgame.py:400
 msgid "Played:"
 msgstr "Giocati:"
 
-#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:404
-#: pysollib/tile/tkstats.py:777 pysollib/tk/selectgame.py:406
-#: pysollib/tk/tkstats.py:740 data/pysolfc.glade:717
+#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:402
+#: pysollib/tile/tkstats.py:778 pysollib/tk/selectgame.py:403
+#: pysollib/tk/tkstats.py:741 data/pysolfc.glade:717
 msgid "Playing time:"
 msgstr "Tempo di gioco:"
 
-#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:405
-#: pysollib/tile/tkstats.py:784 pysollib/tk/selectgame.py:407
-#: pysollib/tk/tkstats.py:747 data/pysolfc.glade:813
+#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:403
+#: pysollib/tile/tkstats.py:785 pysollib/tk/selectgame.py:404
+#: pysollib/tk/tkstats.py:748 data/pysolfc.glade:813
 msgid "Moves:"
 msgstr "Mosse:"
 
-#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:406
-#: pysollib/tk/selectgame.py:408
+#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:404
+#: pysollib/tk/selectgame.py:405
 msgid "% won:"
 msgstr "% vittorie:"
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:438
-#: pysollib/tk/selectgame.py:439 pysollib/ui/tktile/menubar.py:352
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:436
+#: pysollib/tk/selectgame.py:437 pysollib/ui/tktile/menubar.py:352
 msgid "&Select"
 msgstr "&Scegli"
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:437
-#: pysollib/tk/selectgame.py:439
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:435
+#: pysollib/tk/selectgame.py:436
 msgid "&Rules"
 msgstr "&Regole"
 
-#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:518
-#: pysollib/tk/selectgame.py:519
-msgid "Playable Preview - "
-msgstr "Anteprima giocabile -"
+#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:516
+#: pysollib/tk/selectgame.py:517
+#, python-format
+msgid "Playable Preview - %(game)s"
+msgstr "Anteprima giocabile - %(game)s"
 
-#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:571
-#: pysollib/tk/selectgame.py:572
+#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:569
+#: pysollib/tk/selectgame.py:570
 msgid "variable"
 msgstr "variabile"
 
-#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:573
-#: pysollib/tk/selectgame.py:574
+#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:571
+#: pysollib/tk/selectgame.py:572
 msgid "unlimited"
 msgstr "illimitato"
 
 #: pysollib/pysolgtk/selecttile.py:104
-#, fuzzy
 msgid "Solid color"
-msgstr "Colori pieni"
-
-#: pysollib/pysolgtk/selecttile.py:105 pysollib/tile/selecttile.py:74
-#: pysollib/tk/selecttile.py:73
-msgid "Blue"
-msgstr "Azzurro"
-
-#: pysollib/pysolgtk/selecttile.py:106 pysollib/tile/selecttile.py:75
-#: pysollib/tk/selecttile.py:74 pysollib/games/ultra/dashavatara.py:361
-#: pysollib/games/ultra/mughal.py:264
-msgid "Green"
-msgstr "Verde"
-
-#: pysollib/pysolgtk/selecttile.py:107 pysollib/tile/selecttile.py:76
-#: pysollib/tk/selecttile.py:75
-msgid "Navy"
-msgstr "Blu marino"
-
-#: pysollib/pysolgtk/selecttile.py:108 pysollib/tile/selecttile.py:77
-#: pysollib/tk/selecttile.py:76 pysollib/games/ultra/dashavatara.py:362
-msgid "Olive"
-msgstr "Oliva"
-
-#: pysollib/pysolgtk/selecttile.py:109 pysollib/tile/selecttile.py:78
-#: pysollib/tk/selecttile.py:77 pysollib/games/ultra/dashavatara.py:362
-#: pysollib/games/ultra/mughal.py:264
-msgid "Orange"
-msgstr "Arancione"
-
-#: pysollib/pysolgtk/selecttile.py:110 pysollib/tile/selecttile.py:79
-#: pysollib/tk/selecttile.py:78
-msgid "Teal"
-msgstr "Verde acqua"
+msgstr "Colore pieno"
 
 #: pysollib/pysolgtk/selecttile.py:121 pysollib/tile/selecttile.py:82
 #: pysollib/tk/selecttile.py:81
@@ -2876,11 +3376,6 @@ msgstr "Rilascio"
 msgid "Drop pair"
 msgstr "Rilascio coppia"
 
-#: pysollib/pysolgtk/soundoptionsdialog.py:56
-#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
-msgid "Auto drop"
-msgstr "Auto rilascio"
-
 #: pysollib/pysolgtk/soundoptionsdialog.py:58
 #: pysollib/tile/soundoptionsdialog.py:70 pysollib/tk/soundoptionsdialog.py:72
 msgid "Flip"
@@ -2931,80 +3426,60 @@ msgstr "Mosse/Mosse totali"
 msgid "Games played: won/lost"
 msgstr "Giocati: vinti/perduti"
 
-#: pysollib/pysolgtk/tkhtml.py:218 pysollib/tile/tkhtml.py:77
-#: pysollib/tk/tkhtml.py:72
-msgid "Index"
-msgstr "Indice"
-
-#: pysollib/pysolgtk/tkhtml.py:219 pysollib/tile/tkhtml.py:81
-#: pysollib/tk/tkhtml.py:76
-msgid "Back"
-msgstr "Indietro"
-
-#: pysollib/pysolgtk/tkhtml.py:220 pysollib/tile/tkhtml.py:85
-#: pysollib/tk/tkhtml.py:80
-msgid "Forward"
-msgstr "Avanti"
-
-#: pysollib/pysolgtk/tkhtml.py:221 pysollib/tile/tkhtml.py:89
-#: pysollib/tk/tkhtml.py:84
-msgid "Close"
-msgstr "Chiudi"
-
 #: pysollib/pysolgtk/tkhtml.py:437 pysollib/ui/tktile/tkhtml.py:314
 #, python-format
 msgid ""
-"HTML limitation:\n"
-"The %s protocol is not supported yet.\n"
+"%(app)s HTML limitation:\n"
+"The %(protocol)s protocol is not supported yet.\n"
 "\n"
 "Please use your standard web browser\n"
 "to open the following URL:\n"
-"%s\n"
+"%(url)s\n"
 msgstr ""
-"Limitazione HTML:\n"
-"Il protocollo %s non è ancora supportato.\n"
+"Limitazione HTML %(app)s:\n"
+"Il protocollo %(protocol)s non è ancora supportato.\n"
 "\n"
 "Usare un web browser standard\n"
 "per aprire questo URL:\n"
-"%s\n"
+"%(url)s\n"
 
 #: pysollib/pysolgtk/tkhtml.py:464 pysollib/pysolgtk/tkhtml.py:469
 #: pysollib/ui/tktile/tkhtml.py:342 pysollib/ui/tktile/tkhtml.py:348
 msgid "Unable to service request:\n"
 msgstr "Impossibile onorare la richiesta:\n"
 
-#: pysollib/pysolgtk/tkstats.py:328 pysollib/tile/tkstats.py:290
+#: pysollib/pysolgtk/tkstats.py:329 pysollib/tile/tkstats.py:290
 #: pysollib/tk/tkstats.py:266
 msgid "No games"
 msgstr "Nessun gioco"
 
-#: pysollib/pysolgtk/tkstats.py:388 pysollib/tile/tkstats.py:670
-#: pysollib/tk/tkstats.py:667
+#: pysollib/pysolgtk/tkstats.py:389 pysollib/tile/tkstats.py:671
+#: pysollib/tk/tkstats.py:668
 msgid "N"
 msgstr "N"
 
-#: pysollib/pysolgtk/tkstats.py:391 pysollib/tile/tkstats.py:683
-#: pysollib/tk/tkstats.py:676
+#: pysollib/pysolgtk/tkstats.py:392 pysollib/tile/tkstats.py:684
+#: pysollib/tk/tkstats.py:677
 msgid "Result"
 msgstr "Risultato"
 
-#: pysollib/pysolgtk/tkstats.py:526 pysollib/tile/tkstats.py:613
-#: pysollib/tk/tkstats.py:608
+#: pysollib/pysolgtk/tkstats.py:527 pysollib/tile/tkstats.py:614
+#: pysollib/tk/tkstats.py:609
 msgid "Highlight piles: "
 msgstr "Evidenzia pile: "
 
-#: pysollib/pysolgtk/tkstats.py:527 pysollib/tile/tkstats.py:614
-#: pysollib/tk/tkstats.py:609
+#: pysollib/pysolgtk/tkstats.py:528 pysollib/tile/tkstats.py:615
+#: pysollib/tk/tkstats.py:610
 msgid "Highlight cards: "
 msgstr "Evidenzia carte: "
 
-#: pysollib/pysolgtk/tkstats.py:528 pysollib/tile/tkstats.py:615
-#: pysollib/tk/tkstats.py:610
+#: pysollib/pysolgtk/tkstats.py:529 pysollib/tile/tkstats.py:616
+#: pysollib/tk/tkstats.py:611
 msgid "Highlight same rank: "
 msgstr "Evidenzia stesso valore: "
 
-#: pysollib/pysolgtk/tkstats.py:532 pysollib/tile/tkstats.py:619
-#: pysollib/tk/tkstats.py:614
+#: pysollib/pysolgtk/tkstats.py:533 pysollib/tile/tkstats.py:620
+#: pysollib/tk/tkstats.py:615
 msgid ""
 "\n"
 "Redeals: "
@@ -3012,8 +3487,8 @@ msgstr ""
 "\n"
 "Ridistribuzioni: "
 
-#: pysollib/pysolgtk/tkstats.py:533 pysollib/tile/tkstats.py:620
-#: pysollib/tk/tkstats.py:615
+#: pysollib/pysolgtk/tkstats.py:534 pysollib/tile/tkstats.py:621
+#: pysollib/tk/tkstats.py:616
 msgid ""
 "\n"
 "Cards in Talon: "
@@ -3021,8 +3496,8 @@ msgstr ""
 "\n"
 "Carte nel tallone: "
 
-#: pysollib/pysolgtk/tkstats.py:535 pysollib/tile/tkstats.py:622
-#: pysollib/tk/tkstats.py:617
+#: pysollib/pysolgtk/tkstats.py:536 pysollib/tile/tkstats.py:623
+#: pysollib/tk/tkstats.py:618
 msgid ""
 "\n"
 "Cards in Waste: "
@@ -3030,8 +3505,8 @@ msgstr ""
 "\n"
 "Carte nel pozzo: "
 
-#: pysollib/pysolgtk/tkstats.py:537 pysollib/tile/tkstats.py:624
-#: pysollib/tk/tkstats.py:619
+#: pysollib/pysolgtk/tkstats.py:538 pysollib/tile/tkstats.py:625
+#: pysollib/tk/tkstats.py:620
 msgid ""
 "\n"
 "Cards in Foundations: "
@@ -3039,58 +3514,58 @@ msgstr ""
 "\n"
 "Carte nelle case: "
 
-#: pysollib/pysolgtk/tkstats.py:542 pysollib/tile/tkstats.py:629
-#: pysollib/tk/tkstats.py:625
+#: pysollib/pysolgtk/tkstats.py:543 pysollib/tile/tkstats.py:630
+#: pysollib/tk/tkstats.py:626
 msgid "Game status"
 msgstr "Stato del gioco"
 
-#: pysollib/pysolgtk/tkstats.py:545 pysollib/tile/tkstats.py:632
-#: pysollib/tk/tkstats.py:628
+#: pysollib/pysolgtk/tkstats.py:546 pysollib/tile/tkstats.py:633
+#: pysollib/tk/tkstats.py:629
 msgid "Playing time: "
 msgstr "Tempo di gioco: "
 
-#: pysollib/pysolgtk/tkstats.py:546 pysollib/tile/tkstats.py:633
-#: pysollib/tk/tkstats.py:629
+#: pysollib/pysolgtk/tkstats.py:547 pysollib/tile/tkstats.py:634
+#: pysollib/tk/tkstats.py:630
 msgid "Started at: "
 msgstr "Iniziato: "
 
-#: pysollib/pysolgtk/tkstats.py:547 pysollib/tile/tkstats.py:634
-#: pysollib/tk/tkstats.py:630
+#: pysollib/pysolgtk/tkstats.py:548 pysollib/tile/tkstats.py:635
+#: pysollib/tk/tkstats.py:631
 msgid "Moves: "
 msgstr "Mosse: "
 
-#: pysollib/pysolgtk/tkstats.py:548 pysollib/tile/tkstats.py:635
-#: pysollib/tk/tkstats.py:631
+#: pysollib/pysolgtk/tkstats.py:549 pysollib/tile/tkstats.py:636
+#: pysollib/tk/tkstats.py:632
 msgid "Undo moves: "
 msgstr "Mosse annullate: "
 
-#: pysollib/pysolgtk/tkstats.py:549 pysollib/tile/tkstats.py:636
-#: pysollib/tk/tkstats.py:632
+#: pysollib/pysolgtk/tkstats.py:550 pysollib/tile/tkstats.py:637
+#: pysollib/tk/tkstats.py:633
 msgid "Bookmark moves: "
 msgstr "Mosse segnalibro: "
 
-#: pysollib/pysolgtk/tkstats.py:550 pysollib/tile/tkstats.py:637
-#: pysollib/tk/tkstats.py:633
+#: pysollib/pysolgtk/tkstats.py:551 pysollib/tile/tkstats.py:638
+#: pysollib/tk/tkstats.py:634
 msgid "Demo moves: "
 msgstr "Mosse demo: "
 
-#: pysollib/pysolgtk/tkstats.py:551 pysollib/tile/tkstats.py:638
-#: pysollib/tk/tkstats.py:634
+#: pysollib/pysolgtk/tkstats.py:552 pysollib/tile/tkstats.py:639
+#: pysollib/tk/tkstats.py:635
 msgid "Total player moves: "
 msgstr "Totale mosse giocate: "
 
-#: pysollib/pysolgtk/tkstats.py:552 pysollib/tile/tkstats.py:639
-#: pysollib/tk/tkstats.py:635
+#: pysollib/pysolgtk/tkstats.py:553 pysollib/tile/tkstats.py:640
+#: pysollib/tk/tkstats.py:636
 msgid "Total moves in this game: "
 msgstr "Mosse totali in questo gioco: "
 
-#: pysollib/pysolgtk/tkstats.py:553 pysollib/tile/tkstats.py:640
-#: pysollib/tk/tkstats.py:636
+#: pysollib/pysolgtk/tkstats.py:554 pysollib/tile/tkstats.py:641
+#: pysollib/tk/tkstats.py:637
 msgid "Hints: "
 msgstr "Suggerimenti: "
 
-#: pysollib/pysolgtk/tkstats.py:557 pysollib/tile/tkstats.py:643
-#: pysollib/tk/tkstats.py:640 pysollib/ui/tktile/menubar.py:420
+#: pysollib/pysolgtk/tkstats.py:558 pysollib/tile/tkstats.py:644
+#: pysollib/tk/tkstats.py:641 pysollib/ui/tktile/menubar.py:420
 msgid "&Statistics..."
 msgstr "&Statistiche..."
 
@@ -3160,17 +3635,22 @@ msgstr "Cambia..."
 msgid "Select font"
 msgstr "Scelta carattere"
 
+#: pysollib/tile/menubar.py:90 pysollib/tk/menubar.py:94
+msgid "Select "
+msgstr "Scelta"
+
 #: pysollib/tile/menubar.py:106
 msgid "Change theme"
 msgstr "Cambiare il tema"
 
 #: pysollib/tile/menubar.py:107
+#, python-format
 msgid ""
-"This settings will take effect\n"
-"the next time you restart "
+"These settings will take effect\n"
+"the next time you restart %(app)s"
 msgstr ""
 "L'impostazione avrà effetto\n"
-"al prossimo avvio "
+"al prossimo avvio %(app)s"
 
 #: pysollib/tile/menubar.py:114
 msgid "Set t&heme"
@@ -3267,7 +3747,7 @@ msgstr ""
 msgid "&Save"
 msgstr "&Salva"
 
-#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:177
+#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:176
 msgid "Custom Games"
 msgstr "Giochi Personali"
 
@@ -3377,14 +3857,14 @@ msgstr "Evidenzia carte:"
 msgid "Highlight same rank:"
 msgstr "Evidenzia stesso valore:"
 
-#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:740
-#: pysollib/tile/tkstats.py:887 pysollib/tk/tkstats.py:909
+#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:741
+#: pysollib/tile/tkstats.py:888 pysollib/tk/tkstats.py:910
 #: data/pysolfc.glade:660
 msgid "Current game"
 msgstr "Gioco attuale"
 
-#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:748
-#: pysollib/tile/tkstats.py:883 pysollib/tk/tkstats.py:903
+#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:749
+#: pysollib/tile/tkstats.py:884 pysollib/tk/tkstats.py:904
 #: data/pysolfc.glade:1342
 msgid "All games"
 msgstr "Tutti i giochi"
@@ -3407,75 +3887,83 @@ msgstr "Totale"
 msgid "Current session"
 msgstr "Questa sessione"
 
-#: pysollib/tile/tkstats.py:510
+#: pysollib/tile/tkstats.py:511
 msgid "Log"
 msgstr "Log"
 
-#: pysollib/tile/tkstats.py:541 pysollib/tk/tkstats.py:506
-#: pysollib/tk/tkstats.py:575 pysollib/tk/tkstats.py:592
+#: pysollib/tile/tkstats.py:523 data/pysolfc.glade:1404
+msgid "Full log"
+msgstr "Log completo"
+
+#: pysollib/tile/tkstats.py:527 data/pysolfc.glade:1466
+msgid "Session log"
+msgstr "Log della sessione"
+
+#: pysollib/tile/tkstats.py:542 pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:576 pysollib/tk/tkstats.py:593
 msgid "&Save to file"
 msgstr "&Salva su file"
 
-#: pysollib/tile/tkstats.py:745 pysollib/tk/tkstats.py:785
+#: pysollib/tile/tkstats.py:746 pysollib/tk/tkstats.py:786
 msgid "No TOP for this game"
 msgstr "Nessun TOP per questo gioco"
 
-#: pysollib/tile/tkstats.py:753
+#: pysollib/tile/tkstats.py:754
 msgid "No TOP for all games"
 msgstr "Nessun TOP per tutti i giochi"
 
-#: pysollib/tile/tkstats.py:765 pysollib/tk/tkstats.py:732
+#: pysollib/tile/tkstats.py:766 pysollib/tk/tkstats.py:733
 #: data/pysolfc.glade:1005
 msgid "Minimum"
 msgstr "Minimo"
 
-#: pysollib/tile/tkstats.py:767 pysollib/tk/tkstats.py:733
+#: pysollib/tile/tkstats.py:768 pysollib/tk/tkstats.py:734
 #: data/pysolfc.glade:1028
 msgid "Maximum"
 msgstr "Massimo"
 
-#: pysollib/tile/tkstats.py:769 pysollib/tk/tkstats.py:734
+#: pysollib/tile/tkstats.py:770 pysollib/tk/tkstats.py:735
 #: data/pysolfc.glade:1051
 msgid "Average"
 msgstr "Media"
 
-#: pysollib/tile/tkstats.py:791 pysollib/tk/tkstats.py:754
+#: pysollib/tile/tkstats.py:792 pysollib/tk/tkstats.py:755
 #: data/pysolfc.glade:909
 msgid "Total moves:"
 msgstr "Mosse totali:"
 
-#: pysollib/tile/tkstats.py:891 pysollib/tk/tkstats.py:915
+#: pysollib/tile/tkstats.py:892 pysollib/tk/tkstats.py:916
 msgid "Statistics for"
 msgstr "Statistiche per"
 
-#: pysollib/tile/tkstats.py:896 pysollib/tk/tkstats.py:920
+#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
 msgid "Last 7 days"
 msgstr "Ultimi 7 giorni"
 
-#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
+#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
 msgid "Last month"
 msgstr "Ultimo mese"
 
-#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
+#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
 msgid "Last year"
 msgstr "Ultimo anno"
 
-#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
+#: pysollib/tile/tkstats.py:900 pysollib/tk/tkstats.py:924
 msgid "All time"
 msgstr "Tutti i tempi"
 
-#: pysollib/tile/tkstats.py:904 pysollib/tk/tkstats.py:930
+#: pysollib/tile/tkstats.py:905 pysollib/tk/tkstats.py:931
 msgid "Show graphs"
 msgstr "Mostra grafici"
 
-#: pysollib/tile/tkstats.py:948 pysollib/tile/tkstats.py:964
-#: pysollib/tile/tkstats.py:1002 pysollib/tk/tkstats.py:857
-#: pysollib/tk/tkstats.py:873 pysollib/tk/tkstats.py:977
+#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:965
+#: pysollib/tile/tkstats.py:1003 pysollib/tk/tkstats.py:858
+#: pysollib/tk/tkstats.py:874 pysollib/tk/tkstats.py:978
 msgid "Games/day"
 msgstr "Giochi/giorno"
 
-#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:1004
-#: pysollib/tk/tkstats.py:858 pysollib/tk/tkstats.py:979
+#: pysollib/tile/tkstats.py:950 pysollib/tile/tkstats.py:1005
+#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:980
 msgid "Games/week"
 msgstr "Giochi/settimana"
 
@@ -3495,17 +3983,9 @@ msgstr ""
 msgid "Save"
 msgstr "Salva"
 
-#: pysollib/tile/toolbar.py:180 pysollib/tk/toolbar.py:180
-msgid "Save game"
-msgstr "Salva il gioco"
-
 #: pysollib/tile/toolbar.py:188 pysollib/tk/toolbar.py:188
 msgid "View statistics"
 msgstr "Statistiche"
-
-#: pysollib/tile/toolbar.py:202 pysollib/tk/toolbar.py:211
-msgid "Toolbar"
-msgstr "Barra strumenti"
 
 #: pysollib/tile/toolbar.py:209 pysollib/tk/toolbar.py:206
 msgid "Player"
@@ -3527,15 +4007,15 @@ msgstr "Scelta nome"
 msgid "Enable samles"
 msgstr "Abilita esempi"
 
-#: pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:508
 msgid "&Reset all..."
 msgstr "&Ripulisci tutto..."
 
-#: pysollib/tk/tkstats.py:574
+#: pysollib/tk/tkstats.py:575
 msgid "Session &log..."
 msgstr "Sto&rico sessione..."
 
-#: pysollib/tk/tkstats.py:591
+#: pysollib/tk/tkstats.py:592
 msgid "&Full log..."
 msgstr "Storico &completo..."
 
@@ -3972,10 +4452,6 @@ msgstr "Trova carta"
 msgid "Compound"
 msgstr "Composto"
 
-#: pysollib/ui/tktile/menubar.py:41
-msgid "Hide"
-msgstr "Nascondi"
-
 #: pysollib/ui/tktile/menubar.py:44
 msgid "Top"
 msgstr "Cima"
@@ -3984,21 +4460,14 @@ msgstr "Cima"
 msgid "Bottom"
 msgstr "Fondo"
 
-#: pysollib/ui/tktile/menubar.py:50
-msgid "Left"
-msgstr "Sinistra"
-
-#: pysollib/ui/tktile/menubar.py:53
-msgid "Right"
-msgstr "Destra"
-
 #: pysollib/ui/tktile/menubar.py:64
 msgid "Visible buttons"
 msgstr "Bottoni visibili"
 
-#: pysollib/ui/tktile/menubar.py:296 pysollib/ui/tktile/menubar.py:666
-msgid "&About "
-msgstr "&A proposito"
+#: pysollib/ui/tktile/menubar.py:296
+#, fuzzy, python-format
+msgid "&About %s"
+msgstr "Informazioni "
 
 #: pysollib/ui/tktile/menubar.py:298
 msgid "&File"
@@ -4175,7 +4644,6 @@ msgid "&Piles description"
 msgstr "Descrizione &pile"
 
 #: pysollib/ui/tktile/menubar.py:459
-#, fuzzy
 msgid "&Options"
 msgstr "&Opzioni"
 
@@ -4296,10 +4764,6 @@ msgstr "Ombreggia mosse consentite"
 #: pysollib/ui/tktile/menubar.py:555
 msgid "&Negative cards bottom"
 msgstr "Fondo carte in negativo"
-
-#: pysollib/ui/tktile/menubar.py:559
-msgid "Shrink face-down cards"
-msgstr "Restringi carte nascoste"
 
 #: pysollib/ui/tktile/menubar.py:563
 msgid "Shade &filled stacks"
@@ -4425,6 +4889,11 @@ msgstr "&Regole di questo gioco"
 msgid "&License terms"
 msgstr "Termini della &licenza"
 
+#: pysollib/ui/tktile/menubar.py:666
+#, fuzzy, python-format
+msgid "&About %s..."
+msgstr "Informazioni "
+
 #: pysollib/ui/tktile/menubar.py:796
 msgid "All &games..."
 msgstr "Tutti i &giochi"
@@ -4462,29 +4931,29 @@ msgstr "Giochi &personali"
 msgid "&All games by name"
 msgstr "&Tutti per nome"
 
-#: pysollib/ui/tktile/menubar.py:1177
+#: pysollib/ui/tktile/menubar.py:1179
 #, fuzzy
 msgid "Export game error"
 msgstr "Errore nel caricare il gioco"
 
-#: pysollib/ui/tktile/menubar.py:1178
+#: pysollib/ui/tktile/menubar.py:1180
 msgid ""
 "\n"
 "Unsupported game for export.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1214 pysollib/ui/tktile/menubar.py:1248
+#: pysollib/ui/tktile/menubar.py:1216 pysollib/ui/tktile/menubar.py:1250
 #, fuzzy
 msgid "Import game error"
 msgstr "Errore nel caricare il gioco"
 
-#: pysollib/ui/tktile/menubar.py:1215
+#: pysollib/ui/tktile/menubar.py:1217
 msgid ""
 "\n"
 "Unsupported game for import.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1676
+#: pysollib/ui/tktile/menubar.py:1678
 #, python-format
 msgid ""
 "\n"
@@ -4496,6 +4965,11 @@ msgstr ""
 "Errore nel salvataggio del gioco.\n"
 "\n"
 "%s\n"
+
+#: pysollib/ui/tktile/solverdialog.py:28
+#, python-format
+msgid "%(app)s - FreeCell Solver"
+msgstr ""
 
 #: pysollib/ui/tktile/solverdialog.py:44 data/pysolfc.glade:74
 #: data/pysolfc.glade:1250
@@ -4538,7 +5012,7 @@ msgstr[0] "Il gioco è risolvibile in %d mossa."
 msgstr[1] "Il gioco è risolvibile in %d mosse."
 
 #: pysollib/ui/tktile/solverdialog.py:189
-#, fuzzy, python-format
+#, python-format
 msgid "This game is solvable in %d move."
 msgid_plural "This game is solvable in %d moves."
 msgstr[0] "Il gioco è risolvibile in %d mossa."
@@ -4584,6 +5058,31 @@ msgstr "Mosse totali"
 msgid "Set font"
 msgstr "Scegli carattere"
 
+#~ msgid "Statistics for "
+#~ msgstr "Statistiche per "
+
+#~ msgid "Full log for "
+#~ msgstr "Log completo di "
+
+#~ msgid "Session log for "
+#~ msgstr "Log della sessione di "
+
+#~ msgid "Error while loading "
+#~ msgstr "Errore nel caricare "
+
+#~ msgid " HTML Problem"
+#~ msgstr "Problema con HTML"
+
+#~ msgid "Your statistics"
+#~ msgstr "Le tue statistiche"
+
+#~ msgid ""
+#~ " were appended to\n"
+#~ "\n"
+#~ msgstr ""
+#~ " sono state aggiunte a\n"
+#~ "\n"
+
 #~ msgid "Solving method:"
 #~ msgstr "Metodo di risoluzione:"
 
@@ -4592,9 +5091,6 @@ msgstr "Scegli carattere"
 
 #~ msgid "&Statistics"
 #~ msgstr "&Statistiche"
-
-#~ msgid "Current game..."
-#~ msgstr "Gioco corrente..."
 
 #~ msgid "All games..."
 #~ msgstr "Tutti i giochi..."

--- a/po/pl_pysol.po
+++ b/po/pl_pysol.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-18 19:21+0300\n"
+"POT-Creation-Date: 2019-08-31 00:20+0300\n"
 "PO-Revision-Date: 2010-12-12 15:43+0100\n"
 "Last-Translator: Jerzy Trzeciak <artusek@wp.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -19,14 +19,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: pysollib/actions.py:232 pysollib/kivy/toolbar.py:191
-#: pysollib/tile/toolbar.py:176 pysollib/tk/toolbar.py:176
+#: pysollib/actions.py:232 pysollib/kivy/menubar.py:291
+#: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
+#: pysollib/tk/toolbar.py:176
 msgid "New game"
 msgstr "Nowa gra"
 
 #: pysollib/actions.py:247 pysollib/kivy/menubar.py:1667
-#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1014
-#: pysollib/ui/tktile/menubar.py:1030
+#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1015
+#: pysollib/ui/tktile/menubar.py:1031
 msgid "Select game"
 msgstr "Wybierz grę"
 
@@ -56,19 +57,19 @@ msgstr ""
 "\n"
 "Podaj nowy numer gry"
 
-#: pysollib/actions.py:293 pysollib/app.py:523 pysollib/app.py:817
-#: pysollib/game/__init__.py:1270 pysollib/game/__init__.py:2487
-#: pysollib/kivy/tkhtml.py:690 pysollib/kivy/tkstats.py:249
+#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/app.py:818
+#: pysollib/game/__init__.py:1305 pysollib/game/__init__.py:2526
+#: pysollib/kivy/tkhtml.py:691 pysollib/kivy/tkstats.py:254
 #: pysollib/kivy/tkwidget.py:97 pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/pysolgtk/tkhtml.py:542
-#: pysollib/pysolgtk/tkstats.py:556 pysollib/pysolgtk/tkwidget.py:151
+#: pysollib/pysolgtk/tkstats.py:557 pysollib/pysolgtk/tkwidget.py:151
 #: pysollib/tile/fontsdialog.py:140 pysollib/tile/fontsdialog.py:202
 #: pysollib/tile/menubar.py:111 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:545
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/soundoptionsdialog.py:188 pysollib/tile/timeoutsdialog.py:92
-#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:540
-#: pysollib/tile/tkstats.py:645 pysollib/tile/tkstats.py:726
+#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:541
+#: pysollib/tile/tkstats.py:646 pysollib/tile/tkstats.py:727
 #: pysollib/tile/tkwidget.py:138 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/playeroptionsdialog.py:64
@@ -76,10 +77,10 @@ msgstr ""
 #: pysollib/tk/selectcardset.py:506 pysollib/tk/selecttile.py:152
 #: pysollib/tk/soundoptionsdialog.py:152 pysollib/tk/soundoptionsdialog.py:193
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkstats.py:278
-#: pysollib/tk/tkstats.py:505 pysollib/tk/tkstats.py:574
-#: pysollib/tk/tkstats.py:591 pysollib/tk/tkstats.py:639
-#: pysollib/tk/tkstats.py:712 pysollib/tk/tkstats.py:796
-#: pysollib/tk/tkstats.py:963 pysollib/tk/tkwidget.py:143
+#: pysollib/tk/tkstats.py:506 pysollib/tk/tkstats.py:575
+#: pysollib/tk/tkstats.py:592 pysollib/tk/tkstats.py:640
+#: pysollib/tk/tkstats.py:713 pysollib/tk/tkstats.py:797
+#: pysollib/tk/tkstats.py:964 pysollib/tk/tkwidget.py:143
 #: pysollib/tk/tkwidget.py:351 pysollib/tk/wizarddialog.py:132
 #: pysollib/ui/tktile/colorsdialog.py:118
 #: pysollib/ui/tktile/edittextdialog.py:38
@@ -91,24 +92,24 @@ msgstr "&OK"
 msgid "&Next number"
 msgstr "&Następny numer"
 
-#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/game/__init__.py:1270
-#: pysollib/game/__init__.py:1939 pysollib/game/__init__.py:1957
-#: pysollib/game/__init__.py:1965 pysollib/game/__init__.py:1972
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2068
-#: pysollib/kivy/selectcardset.py:61
+#: pysollib/actions.py:293 pysollib/app.py:525 pysollib/game/__init__.py:1305
+#: pysollib/game/__init__.py:1979 pysollib/game/__init__.py:1995
+#: pysollib/game/__init__.py:2003 pysollib/game/__init__.py:2010
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2069
+#: pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/pysolgtk/selectgame.py:324
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/tile/fontsdialog.py:140
 #: pysollib/tile/fontsdialog.py:202 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:543
-#: pysollib/tile/selectgame.py:308 pysollib/tile/selectgame.py:438
+#: pysollib/tile/selectgame.py:306 pysollib/tile/selectgame.py:436
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/timeoutsdialog.py:92 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/menubar.py:89
 #: pysollib/tk/menubar.py:90 pysollib/tk/playeroptionsdialog.py:64
 #: pysollib/tk/playeroptionsdialog.py:138 pysollib/tk/selectcardset.py:313
-#: pysollib/tk/selectgame.py:310 pysollib/tk/selectgame.py:439
+#: pysollib/tk/selectgame.py:306 pysollib/tk/selectgame.py:437
 #: pysollib/tk/selecttile.py:152 pysollib/tk/soundoptionsdialog.py:152
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkwidget.py:351
 #: pysollib/tk/wizarddialog.py:132 pysollib/ui/tktile/colorsdialog.py:118
@@ -126,195 +127,228 @@ msgstr "Wybierz następną grę"
 
 #: pysollib/actions.py:384 pysollib/kivy/toolbar.py:206
 #: pysollib/tile/toolbar.py:191 pysollib/tk/toolbar.py:191
-msgid "Quit "
-msgstr "Zakończ "
+#, python-format
+msgid "Quit %s"
+msgstr "Zakończ %s"
 
 #: pysollib/actions.py:447
 msgid "Clear bookmarks"
 msgstr "Wyczyść zakładki"
 
 #: pysollib/actions.py:448
-msgid "Clear all bookmarks ?"
+msgid "Clear all bookmarks?"
 msgstr "Wyczyścić wszystkie zakładki?"
 
-#: pysollib/actions.py:459
+#: pysollib/actions.py:459 pysollib/kivy/menubar.py:293
 msgid "Restart game"
 msgstr "Uruchom grę ponownie"
 
 #: pysollib/actions.py:460
-msgid "Restart this game ?"
+msgid "Restart this game?"
 msgstr "Uruchomić grę ponownie?"
 
-#: pysollib/actions.py:505
-#, python-format
+#: pysollib/actions.py:506
+#, fuzzy, python-format
 msgid ""
-"Comments for %s:\n"
+"Comments for %(game)s %(id)s:\n"
 "\n"
 msgstr ""
 "Komentarze dla %s:\n"
 "\n"
 
-#: pysollib/actions.py:507
-msgid "Comments for "
-msgstr "Komentarze dla "
+#: pysollib/actions.py:508
+#, fuzzy, python-format
+msgid "Comments for %(id)s"
+msgstr "Komentarze dla %s"
 
-#: pysollib/actions.py:525 pysollib/actions.py:549
+#: pysollib/actions.py:526 pysollib/actions.py:551
 msgid "Error while writing to file"
 msgstr "Błąd zapisywania do pliku"
 
-#: pysollib/actions.py:528 pysollib/actions.py:552
-msgid " Info"
-msgstr " Info"
+#: pysollib/actions.py:529 pysollib/actions.py:554
+#, python-format
+msgid "%s Info"
+msgstr "%s Info"
 
-#: pysollib/actions.py:529
+#: pysollib/actions.py:530
+#, python-format
 msgid ""
 "Comments were appended to\n"
 "\n"
+"%(filename)s"
+msgstr ""
+"Komentarze zostały dołączone do\n"
+"\n"
+"%(filename)s"
+
+#: pysollib/actions.py:540
+#, fuzzy, python-format
+msgid ""
+"Demo statistics were appended to\n"
+"\n"
+"%(filename)s"
 msgstr ""
 "Komentarze zostały dołączone do\n"
 "\n"
 
-#: pysollib/actions.py:538
-msgid "Demo statistics"
-msgstr "Demo statystyk"
-
-#: pysollib/actions.py:541
-msgid "Your statistics"
-msgstr "Twoje statystyki"
-
-#: pysollib/actions.py:553
+#: pysollib/actions.py:543
+#, fuzzy, python-format
 msgid ""
-" were appended to\n"
+"Your statistics were appended to\n"
 "\n"
+"%(filename)s"
 msgstr ""
-" zostały dołączone do\n"
+"Komentarze zostały dołączone do\n"
 "\n"
 
-#: pysollib/actions.py:567
-msgid " Demo"
-msgstr " Demo"
-
-#: pysollib/actions.py:567
-msgid " Demo "
-msgstr " Demo "
-
-#: pysollib/actions.py:570 pysollib/actions.py:591
-msgid " for "
-msgstr " dla "
-
-#: pysollib/actions.py:576 pysollib/stats.py:202
-msgid "Statistics for "
+#: pysollib/actions.py:581
+#, fuzzy, python-format
+msgid "%(app)s Demo Statistics for %(game)s"
 msgstr "Statystyki dla "
 
-#: pysollib/actions.py:581 pysollib/kivy/menubar.py:1613
-#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:176
-#: pysollib/tile/selectgame.py:387 pysollib/tile/tkstats.py:51
-#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:387
-#: pysollib/tk/toolbar.py:188
-msgid "Statistics"
-msgstr "Statystyki"
+#: pysollib/actions.py:582
+#, fuzzy, python-format
+msgid "Statistics for %(game)s"
+msgstr "Statystyki dla "
 
-#: pysollib/actions.py:585 pysollib/tile/tkstats.py:522 data/pysolfc.glade:1404
-msgid "Full log"
-msgstr "Kompletny log"
+#: pysollib/actions.py:587
+#, fuzzy, python-format
+msgid "%(app)s Demo Statistics"
+msgstr "Demo statystyk"
 
-#: pysollib/actions.py:588 pysollib/tile/tkstats.py:526 data/pysolfc.glade:1466
-msgid "Session log"
+#: pysollib/actions.py:588 pysollib/stats.py:202
+#, fuzzy, python-format
+msgid "Statistics for %(player)s"
+msgstr "Statystyki dla "
+
+#: pysollib/actions.py:592
+#, fuzzy, python-format
+msgid "%(app)s Demo Full log"
+msgstr "&Demo logo"
+
+#: pysollib/actions.py:593 pysollib/stats.py:235
+#, fuzzy, python-format
+msgid "Full log for %(player)s"
+msgstr "Kompletny log dla "
+
+#: pysollib/actions.py:596
+#, fuzzy, python-format
+msgid "%(app)s Demo Session log"
 msgstr "Log sesji"
 
-#: pysollib/actions.py:595
+#: pysollib/actions.py:597 pysollib/stats.py:242
+#, fuzzy, python-format
+msgid "Session log for %(player)s"
+msgstr "Lod sesji dla "
+
+#. TRANSLATORS: eg. top 10 or top 5 results for a certain game
+#: pysollib/actions.py:601
+#, fuzzy, python-format
+msgid "%(app)s Demo Top %(tops)d for %(game)s"
+msgstr "Statystyki dla "
+
+#: pysollib/actions.py:602
+#, python-format
+msgid "Top %(tops)d for %(game)s"
+msgstr ""
+
+#: pysollib/actions.py:606
 msgid "Game Info"
 msgstr "Informacja o grze"
 
-#: pysollib/actions.py:598
+#: pysollib/actions.py:609
 msgid "Statistics progression"
 msgstr "Postęp statystycznie"
 
-#: pysollib/actions.py:616
+#: pysollib/actions.py:627
 msgid "Reset all statistics"
 msgstr "Wyzeruj wszystkie statystyki"
 
-#: pysollib/actions.py:617
+#: pysollib/actions.py:628
 #, python-format
 msgid ""
 "Reset ALL statistics and logs for player\n"
-"%s ?"
+"%(player)s?"
 msgstr ""
 "Wyzerować wszystkie statystyki i logi dla gracza\n"
-"%s?"
+"%(player)s?"
 
-#: pysollib/actions.py:626
+#: pysollib/actions.py:638
 msgid "Reset game statistics"
 msgstr "Wyzeruj statystyki gry"
 
-#: pysollib/actions.py:627
+#: pysollib/actions.py:639
 #, python-format
 msgid ""
 "Reset statistics and logs for player\n"
-"%s\n"
+"%(player)s\n"
 "and game\n"
-"%s ?"
+"%(game)s?"
 msgstr ""
 "Wyzerować statystyki i logi gracza\n"
-"%s\n"
+"%(player)s\n"
 "w grze\n"
-"%s ?"
+"%(game)s?"
 
-#: pysollib/actions.py:692
+#: pysollib/actions.py:704
 msgid "Play demo"
 msgstr "Odtwórz demo"
 
-#: pysollib/actions.py:704
+#: pysollib/actions.py:716
 msgid "Set player options"
 msgstr "Ustaw opcje gracza"
 
-#: pysollib/actions.py:720 data/pysolfc.glade:1986
+#: pysollib/actions.py:732 data/pysolfc.glade:1986
 msgid "Set colors"
 msgstr "Ustaw kolory"
 
-#: pysollib/actions.py:738
+#: pysollib/actions.py:750
 msgid "Set fonts"
 msgstr "Ustaw czcionki"
 
-#: pysollib/actions.py:748 data/pysolfc.glade:1493
+#: pysollib/actions.py:760 data/pysolfc.glade:1493
 msgid "Set timeouts"
 msgstr "Ustaw limity czasu"
 
 #: pysollib/app.py:332
-msgid "can't find game: "
-msgstr "nie można odnaleźć gry: "
+#, python-format
+msgid "can't find game: %(game)s"
+msgstr "nie można odnaleźć gry: %(game)s"
 
-#: pysollib/app.py:525 pysollib/game/__init__.py:1939
-#: pysollib/game/__init__.py:1957 pysollib/game/__init__.py:1965
-#: pysollib/game/__init__.py:1972 pysollib/ui/tktile/menubar.py:300
+#: pysollib/app.py:526 pysollib/game/__init__.py:1979
+#: pysollib/game/__init__.py:1995 pysollib/game/__init__.py:2003
+#: pysollib/game/__init__.py:2010 pysollib/ui/tktile/menubar.py:300
 msgid "&New game"
 msgstr "&Nowa gra"
 
-#: pysollib/app.py:671
-#, python-format
-msgid "Loading %s %s..."
+#: pysollib/app.py:672
+#, fuzzy, python-format
+msgid "Loading cardset %s..."
 msgstr "Wczytywanie %s %s..."
 
-#: pysollib/app.py:713
-msgid " load error"
+#: pysollib/app.py:714
+#, fuzzy
+msgid "Cardset load error"
 msgstr " błąd wczytywania"
 
-#: pysollib/app.py:714
-msgid "Error while loading "
-msgstr "Błąd podczas wczytywania"
+#: pysollib/app.py:715
+#, fuzzy
+msgid "Error while loading cardset"
+msgstr "Błąd podczaas wczytywania gry"
 
-#: pysollib/app.py:809
-msgid "Incompatible "
+#: pysollib/app.py:810
+#, fuzzy
+msgid "Incompatible cardset"
 msgstr "Niekompatybilny "
 
-#: pysollib/app.py:811
-#, python-format
+#: pysollib/app.py:812
+#, fuzzy, python-format
 msgid ""
-"The currently selected %s %s\n"
+"The currently selected cardset %(cardset)s\n"
 "is not compatible with the game\n"
-"%s\n"
+"%(game)s\n"
 "\n"
-"Please select a %s type %s.\n"
+"Please select a %(correct_type)s type cardset.\n"
 msgstr ""
 "Aktualnie wybrany %s %s\n"
 "nie jest kompatybilny z grą\n"
@@ -322,14 +356,14 @@ msgstr ""
 "\n"
 "Proszę wybrać %s typu %s.\n"
 
-#: pysollib/app.py:855
-#, python-format
-msgid "Please select a %s type %s"
+#: pysollib/app.py:856
+#, fuzzy, python-format
+msgid "Please select a %s type cardset"
 msgstr "Proszę wybrać %s typu %s"
 
-#: pysollib/app.py:1063
-#, python-format
-msgid "error loading plugin %s: %s"
+#: pysollib/app.py:1064
+#, fuzzy, python-format
+msgid "error loading plugin %(file)s: %(err)s"
 msgstr "błąd wczytania wtyczki %s: %s"
 
 #: pysollib/gamedb.py:109
@@ -541,24 +575,24 @@ msgid "Puzzle type"
 msgstr "Gry typu Puzzle"
 
 #: pysollib/help.py:43
-msgid "A Python Solitaire Game Collection\n"
-msgstr "Kolekcja gier Python Solitaire\n"
+msgid "A Python Solitaire Game Collection"
+msgstr "Kolekcja gier Python Solitaire"
 
 #: pysollib/help.py:45
-msgid "A World Domination Project\n"
+msgid "A World Domination Project"
 msgstr ""
 
 #: pysollib/help.py:46
 msgid "&Nice"
-msgstr "Ładnie"
+msgstr "Ład&nie"
 
 #: pysollib/help.py:46
 msgid "&Credits..."
-msgstr "Podziękowania..."
+msgstr "&Podziękowania..."
 
 #: pysollib/help.py:48
 msgid "&Enjoy"
-msgstr "Baw się dobrze"
+msgstr "&Baw się dobrze"
 
 #: pysollib/help.py:49
 #, python-format
@@ -566,14 +600,16 @@ msgid "Version %s"
 msgstr "Wersja %s"
 
 #: pysollib/help.py:50
-msgid "About "
-msgstr "O programie"
+#, python-format
+msgid "About %s"
+msgstr "O programie %s"
 
 #: pysollib/help.py:52
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "PySol Fan Club edition\n"
-"%s%s\n"
+"%(description)s\n"
+"%(versioninfo)s\n"
 "\n"
 "Copyright (C) 1998 - 2003 Markus F.X.J. Oberhumer.\n"
 "Copyright (C) 2003 Mt. Hood Playing Card Co.\n"
@@ -586,11 +622,12 @@ msgid ""
 "For more information about this application visit"
 msgstr ""
 "Edycja PySol Fan Club\n"
-"%s%s\n"
+"%(description)s\n"
+"%(versioninfo)s\n"
 "\n"
 "Copyright (C) 1998 - 2003 Markus F.X.J. Oberhumer.\n"
 "Copyright (C) 2003 Mt. Hood Playing Card Co.\n"
-"Copyright (C) 2005 - 2007 Skomoroh.\n"
+"Copyright (C) 2005 - 2009 Skomoroh.\n"
 "All Rights Reserved.\n"
 "\n"
 "PySol jest wolnym oprogramowaniem rozprowadzanym\n"
@@ -598,14 +635,14 @@ msgstr ""
 "\n"
 "W celu uzyskania dodatkowych informacji odwiedź"
 
-#: pysollib/help.py:88
+#: pysollib/help.py:90
 msgid "Credits"
 msgstr "Podziękowania"
 
-#: pysollib/help.py:89
-#, python-format
+#: pysollib/help.py:91
+#, fuzzy, python-format
 msgid ""
-" credits go to:\n"
+"%(app)s credits go to:\n"
 "\n"
 "Volker Weidner for getting me into Solitaire\n"
 "Guido van Rossum for the initial example program\n"
@@ -614,7 +651,7 @@ msgid ""
 "The Gnome AisleRiot team for parts of the documentation\n"
 "Natascha\n"
 "\n"
-"The Python, %s, SDL & Linux crews\n"
+"The Python, %(gui_library)s, SDL & Linux crews\n"
 "for making this program possible"
 msgstr ""
 " podziękowania dla:\n"
@@ -626,19 +663,24 @@ msgstr ""
 "Zespół Gnome AisleRiot za częściową dokumentację\n"
 "Natascha\n"
 "\n"
-"programiści Python, %s, SDL i Linux \n"
+"programiści Python, %(gui_library)s, SDL i Linux \n"
 "za to, że ten program mógł powstać"
 
-#: pysollib/help.py:125
-msgid " HTML Problem"
+#: pysollib/help.py:127 pysollib/kivy/tkhtml.py:687
+#, fuzzy, python-format
+msgid "%s HTML Problem"
 msgstr "Problem z HTML"
 
-#: pysollib/help.py:126
-msgid "Cannot find help document\n"
+#: pysollib/help.py:128
+#, fuzzy, python-format
+msgid ""
+"Cannot find help document\n"
+"%s"
 msgstr "Nie można odnaleźć dokumentacji pomocy\n"
 
-#: pysollib/help.py:139
-msgid " Help"
+#: pysollib/help.py:141
+#, fuzzy, python-format
+msgid "%s Help"
 msgstr "Pomoc"
 
 #: pysollib/main.py:58 pysollib/main.py:70 pysollib/main.py:304
@@ -649,12 +691,12 @@ msgstr "bład instalacji %s"
 #: pysollib/main.py:59
 #, fuzzy, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Cardsets should be installed into:\n"
-"%s/cardsets/\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "Nie znaleziono zestawów kart !!!\n"
 "\n"
@@ -663,7 +705,7 @@ msgstr ""
 "\n"
 "Proszę sprawdzić poprawność instalacji %s.\n"
 
-#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:312
+#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:313
 #: pysollib/ui/tktile/menubar.py:346
 msgid "&Quit"
 msgstr "Zakończ"
@@ -671,28 +713,24 @@ msgstr "Zakończ"
 #: pysollib/main.py:71
 #, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "Nie znaleziono zestawów kart !!!\n"
 "\n"
 "Katalog z podstawowymi danymi znajduje się w:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Proszę sprawdzić poprawność instalacji %s.\n"
+"Proszę sprawdzić poprawność instalacji %(app)s.\n"
 
 #: pysollib/main.py:96
 #, python-format
-msgid ""
-"%s\n"
-"try %s --help for more information"
-msgstr ""
-"%s\n"
-"spróbuj %s --help dla uzyskania więcej informacji"
+msgid "try %s --help for more information"
+msgstr "spróbuj %s --help dla uzyskania więcej informacji"
 
 #: pysollib/main.py:128
 #, python-format
@@ -749,15 +787,15 @@ msgid "Welcome to %s"
 msgstr "Witamy w %s"
 
 #: pysollib/main.py:305
-#, python-format
+#, fuzzy, python-format
 msgid ""
 "\n"
-"No games were found !!!\n"
+"No games were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "\n"
 "Gry nie zostały znalezione !!!\n"
@@ -1111,8 +1149,8 @@ msgid "Unlimited redeals."
 msgstr "Nieograniczona liczba rozdań."
 
 #: pysollib/stack.py:1948
-#, python-format
-msgid "%d readeal"
+#, fuzzy, python-format
+msgid "%d redeal"
 msgid_plural "%d redeals"
 msgstr[0] "%d rozdanie"
 msgstr[1] "%d rozdania"
@@ -1322,66 +1360,66 @@ msgstr "Zrzut."
 msgid "Free cell."
 msgstr "Wolne miejsce."
 
-#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:421
-#: pysollib/pysolgtk/tkstats.py:458 pysollib/tile/tkstats.py:674
+#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:422
+#: pysollib/pysolgtk/tkstats.py:459 pysollib/tile/tkstats.py:675
 msgid "Game"
 msgstr "Gra"
 
-#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:422
-#: pysollib/tile/tkstats.py:908 pysollib/tile/tkstats.py:977
-#: pysollib/tile/tkstats.py:978 pysollib/tk/tkstats.py:886
-#: pysollib/tk/tkstats.py:887 pysollib/tk/tkstats.py:934
+#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:423
+#: pysollib/tile/tkstats.py:909 pysollib/tile/tkstats.py:978
+#: pysollib/tile/tkstats.py:979 pysollib/tk/tkstats.py:887
+#: pysollib/tk/tkstats.py:888 pysollib/tk/tkstats.py:935
 msgid "Played"
 msgstr "Rozegrane"
 
-#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:423
-#: pysollib/tile/tkstats.py:914 pysollib/tile/tkstats.py:982
-#: pysollib/tile/tkstats.py:983 pysollib/tk/tkstats.py:891
-#: pysollib/tk/tkstats.py:892 pysollib/tk/tkstats.py:942
+#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/tile/tkstats.py:915 pysollib/tile/tkstats.py:983
+#: pysollib/tile/tkstats.py:984 pysollib/tk/tkstats.py:892
+#: pysollib/tk/tkstats.py:893 pysollib/tk/tkstats.py:943
 msgid "Won"
 msgstr "Wygrane"
 
-#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:425
 msgid "Lost"
 msgstr "Przegrane"
 
 #: pysollib/stats.py:44 pysollib/pysolgtk/statusbar.py:98
-#: pysollib/pysolgtk/tkstats.py:425 pysollib/tile/statusbar.py:154
+#: pysollib/pysolgtk/tkstats.py:426 pysollib/tile/statusbar.py:154
 #: pysollib/tk/statusbar.py:151 data/pysolfc.glade:1133
 msgid "Playing time"
 msgstr "Czas gry"
 
-#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:426
+#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:427
 #: data/pysolfc.glade:1178
 msgid "Moves"
 msgstr "Ruchy"
 
-#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:427
-#: pysollib/tile/tkstats.py:920 pysollib/tile/tkstats.py:950
-#: pysollib/tile/tkstats.py:969 pysollib/tile/tkstats.py:987
-#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:878
-#: pysollib/tk/tkstats.py:896 pysollib/tk/tkstats.py:950
+#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:428
+#: pysollib/tile/tkstats.py:921 pysollib/tile/tkstats.py:951
+#: pysollib/tile/tkstats.py:970 pysollib/tile/tkstats.py:988
+#: pysollib/tk/tkstats.py:860 pysollib/tk/tkstats.py:879
+#: pysollib/tk/tkstats.py:897 pysollib/tk/tkstats.py:951
 msgid "% won"
 msgstr "% wygranych"
 
 #: pysollib/stats.py:108 pysollib/pysolgtk/statusbar.py:100
-#: pysollib/pysolgtk/tkstats.py:389 pysollib/pysolgtk/tkstats.py:459
-#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:677
-#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:670
+#: pysollib/pysolgtk/tkstats.py:390 pysollib/pysolgtk/tkstats.py:460
+#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:678
+#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:671
 msgid "Game number"
 msgstr "Numer gry"
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:390
-#: pysollib/pysolgtk/tkstats.py:460 pysollib/tile/tkstats.py:680
-#: pysollib/tk/tkstats.py:673
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:391
+#: pysollib/pysolgtk/tkstats.py:461 pysollib/tile/tkstats.py:681
+#: pysollib/tk/tkstats.py:674
 msgid "Started at"
 msgstr "Rozpoczęta w dniu"
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:461
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:462
 msgid "Status"
 msgstr "Stan"
 
-#: pysollib/stats.py:132 pysollib/tile/tkstats.py:696
+#: pysollib/stats.py:132 pysollib/tile/tkstats.py:697
 #, python-format
 msgid "** UNKNOWN %d **"
 msgstr "** NIEZNANY %d ** "
@@ -1402,23 +1440,16 @@ msgstr "Nie wygrane"
 msgid "Perfect"
 msgstr "Perfekcyjnie"
 
-#: pysollib/stats.py:201 pysollib/stats.py:233 pysollib/stats.py:240
+#: pysollib/stats.py:201 pysollib/stats.py:234 pysollib/stats.py:241
+#: pysollib/kivy/menubar.py:443
 msgid "Demo"
 msgstr "Demo"
 
 #: pysollib/stats.py:212 pysollib/pysolgtk/tkstats.py:70
 #: pysollib/tile/tkstats.py:371 pysollib/tk/tkstats.py:413
-#, python-format
-msgid "Total (%d out of %d games)"
+#, fuzzy, python-format
+msgid "Total (%(played)d out of %(total)d games)"
 msgstr "Ogółem (%d z %d gier)"
-
-#: pysollib/stats.py:234
-msgid "Full log for "
-msgstr "Kompletny log dla "
-
-#: pysollib/stats.py:241
-msgid "Session log for "
-msgstr "Lod sesji dla "
 
 #: pysollib/util.py:45
 msgid "Club"
@@ -1485,48 +1516,48 @@ msgid "Initial setting:"
 msgstr "Ustawienia początkowe:"
 
 #: pysollib/wizardutil.py:105 pysollib/pysolgtk/selectgame.py:114
-#: pysollib/tile/selectgame.py:393 pysollib/tk/selectgame.py:395
+#: pysollib/tile/selectgame.py:391 pysollib/tk/selectgame.py:392
 msgid "Name:"
 msgstr "Nazwa:"
 
 #: pysollib/wizardutil.py:109 pysollib/kivy/selectgame.py:202
 #: pysollib/pysolgtk/selectgame.py:236 pysollib/pysolgtk/selectgame.py:473
-#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:563
-#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:564
+#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:561
+#: pysollib/tk/selectgame.py:179 pysollib/tk/selectgame.py:562
 msgid "Luck only"
 msgstr "Potrzeba dużo szczęścia"
 
 #: pysollib/wizardutil.py:110 pysollib/kivy/selectgame.py:204
 #: pysollib/pysolgtk/selectgame.py:237 pysollib/pysolgtk/selectgame.py:474
-#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:564
-#: pysollib/tk/selectgame.py:183 pysollib/tk/selectgame.py:565
+#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:562
+#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:563
 msgid "Mostly luck"
 msgstr "Szczęście się przydaje"
 
 #: pysollib/wizardutil.py:111 pysollib/wizardutil.py:115
 #: pysollib/kivy/selectgame.py:206 pysollib/pysolgtk/selectgame.py:238
 #: pysollib/pysolgtk/selectgame.py:475 pysollib/tile/selectgame.py:183
-#: pysollib/tile/selectgame.py:565 pysollib/tk/selectgame.py:185
-#: pysollib/tk/selectgame.py:566
+#: pysollib/tile/selectgame.py:563 pysollib/tk/selectgame.py:183
+#: pysollib/tk/selectgame.py:564
 msgid "Balanced"
 msgstr "Umiarkowanie trudne"
 
 #: pysollib/wizardutil.py:112 pysollib/kivy/selectgame.py:208
 #: pysollib/pysolgtk/selectgame.py:239 pysollib/pysolgtk/selectgame.py:476
-#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:566
-#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:567
+#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:564
+#: pysollib/tk/selectgame.py:186 pysollib/tk/selectgame.py:565
 msgid "Mostly skill"
 msgstr "Dla średniozaawansowanych"
 
 #: pysollib/wizardutil.py:113 pysollib/kivy/selectgame.py:210
 #: pysollib/pysolgtk/selectgame.py:240 pysollib/pysolgtk/selectgame.py:477
-#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:567
-#: pysollib/tk/selectgame.py:190 pysollib/tk/selectgame.py:568
+#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:565
+#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:566
 msgid "Skill only"
 msgstr "Tylko dla orłów"
 
 #: pysollib/wizardutil.py:116 pysollib/pysolgtk/selectgame.py:118
-#: pysollib/tile/selectgame.py:397 pysollib/tk/selectgame.py:399
+#: pysollib/tile/selectgame.py:395 pysollib/tk/selectgame.py:396
 msgid "Skill level:"
 msgstr "Poziom umiejętności:"
 
@@ -1581,8 +1612,8 @@ msgstr ""
 #: pysollib/wizardutil.py:147 pysollib/wizardutil.py:185
 #: pysollib/wizardutil.py:243 pysollib/wizardutil.py:301
 #: pysollib/pysolgtk/selectgame.py:117 pysollib/tile/selectcardset.py:454
-#: pysollib/tile/selectgame.py:396 pysollib/tk/selectcardset.py:445
-#: pysollib/tk/selectgame.py:398
+#: pysollib/tile/selectgame.py:394 pysollib/tk/selectcardset.py:445
+#: pysollib/tk/selectgame.py:395
 msgid "Type:"
 msgstr "Typ:"
 
@@ -1604,7 +1635,7 @@ msgstr "Trzy dodatkowe rozdania"
 
 #: pysollib/wizardutil.py:155 pysollib/kivy/selectgame.py:252
 #: pysollib/pysolgtk/selectgame.py:273 pysollib/tile/selectgame.py:231
-#: pysollib/tk/selectgame.py:233
+#: pysollib/tk/selectgame.py:231
 msgid "Unlimited redeals"
 msgstr "Bez limitu rozdań"
 
@@ -1675,6 +1706,7 @@ msgid "Direction:"
 msgstr "Kierunek:"
 
 #: pysollib/wizardutil.py:204 pysollib/wizardutil.py:250
+#: pysollib/kivy/menubar.py:884
 msgid "None"
 msgstr "Brak"
 
@@ -1800,57 +1832,58 @@ msgstr "Stos rezerwowy"
 msgid "Opening deal"
 msgstr "Rozdanie początkowe"
 
-#: pysollib/game/__init__.py:139 pysollib/game/__init__.py:145
+#: pysollib/game/__init__.py:140 pysollib/game/__init__.py:146
 msgid "Player\n"
 msgstr "Gracz\n"
 
-#: pysollib/game/__init__.py:1266
-msgid "Discard current game ?"
+#: pysollib/game/__init__.py:1301
+#, fuzzy
+msgid "Discard current game?"
 msgstr "Zakończyć bieżącą grę?"
 
-#: pysollib/game/__init__.py:1887
+#: pysollib/game/__init__.py:1922
 #, fuzzy, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of playing time\n"
-"and # %d in the %s of moves."
+"# %(timerank)d in the top %(tops)d of playing time\n"
+"and # %(movesrank)d in the top %(tops)d of moves."
 msgstr ""
 "\n"
 "Jesteś na miejscu\n"
 "#%d w %s w czasie gry\n"
 "i #%d w %s w ilości ruchów."
 
-#: pysollib/game/__init__.py:1893
+#: pysollib/game/__init__.py:1930
 #, fuzzy, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of playing time."
+"# %(timerank)d in the top %(tops)d of playing time."
 msgstr ""
 "\n"
 "Jesteś na miejscu\n"
 "#%d w %s w czasie gry."
 
-#: pysollib/game/__init__.py:1898
+#: pysollib/game/__init__.py:1936
 #, fuzzy, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of moves."
+"# %(movesrank)d in the top %(tops)s of moves."
 msgstr ""
 "\n"
 "Jesteś na miejscu\n"
 "#d w %s w ilości ruchów."
 
-#: pysollib/game/__init__.py:1931 pysollib/game/__init__.py:1947
-#, python-format
+#: pysollib/game/__init__.py:1971 pysollib/game/__init__.py:1987
+#, fuzzy, python-format
 msgid ""
-"Your playing time is %s\n"
-"for %d move."
+"Your playing time is %(time)s\n"
+"for %(n)d move."
 msgid_plural ""
-"Your playing time is %s\n"
-"for %d moves."
+"Your playing time is %(time)s\n"
+"for %(n)d moves."
 msgstr[0] ""
 "Twój czas gry wynosi %s,\n"
 "wykonany został %d ruch."
@@ -1861,21 +1894,11 @@ msgstr[2] ""
 "Twój czas gry wynosi %s\n"
 "wykonanych zostało %d ruchów."
 
-#: pysollib/game/__init__.py:1936 pysollib/game/__init__.py:1952
-#: pysollib/pysolgtk/soundoptionsdialog.py:71
-#: pysollib/tile/soundoptionsdialog.py:83 pysollib/tk/soundoptionsdialog.py:85
-msgid "Game won"
-msgstr "Wygrana"
-
-#: pysollib/game/__init__.py:1937
-#, python-format
+#: pysollib/game/__init__.py:1975
+#, fuzzy
 msgid ""
-"\n"
 "Congratulations, this\n"
-"was a truly perfect game !\n"
-"\n"
-"%s\n"
-"%s\n"
+"was a truly perfect game!"
 msgstr ""
 "\n"
 "Gratulacje,\n"
@@ -1884,14 +1907,15 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: pysollib/game/__init__.py:1954
-#, python-format
-msgid ""
-"\n"
-"Congratulations, you did it !\n"
-"\n"
-"%s\n"
-"%s\n"
+#: pysollib/game/__init__.py:1977 pysollib/game/__init__.py:1993
+#: pysollib/kivy/tkwidget.py:170 pysollib/pysolgtk/soundoptionsdialog.py:71
+#: pysollib/tile/soundoptionsdialog.py:83 pysollib/tk/soundoptionsdialog.py:85
+msgid "Game won"
+msgstr "Wygrana"
+
+#: pysollib/game/__init__.py:1991
+#, fuzzy
+msgid "Congratulations, you did it!"
 msgstr ""
 "\n"
 "Gratulacje, dokonałeś tego!\n"
@@ -1899,13 +1923,13 @@ msgstr ""
 "%s\n"
 "%s\n"
 
-#: pysollib/game/__init__.py:1963 pysollib/game/__init__.py:1970
-#: pysollib/pysolgtk/soundoptionsdialog.py:69
+#: pysollib/game/__init__.py:2001 pysollib/game/__init__.py:2008
+#: pysollib/kivy/tkwidget.py:173 pysollib/pysolgtk/soundoptionsdialog.py:69
 #: pysollib/tile/soundoptionsdialog.py:81 pysollib/tk/soundoptionsdialog.py:83
 msgid "Game finished"
 msgstr "Gra zakończona"
 
-#: pysollib/game/__init__.py:1964 pysollib/game/__init__.py:2488
+#: pysollib/game/__init__.py:2002 pysollib/game/__init__.py:2527
 msgid ""
 "\n"
 "Game finished\n"
@@ -1913,7 +1937,7 @@ msgstr ""
 "\n"
 "Gra zakończona\n"
 
-#: pysollib/game/__init__.py:1971
+#: pysollib/game/__init__.py:2009
 msgid ""
 "\n"
 "Game finished, but not without my help...\n"
@@ -1921,36 +1945,36 @@ msgstr ""
 "\n"
 "Gra zakończona, ale nie bez mojej pomocy...\n"
 
-#: pysollib/game/__init__.py:1972
+#: pysollib/game/__init__.py:2010
 msgid "&Restart"
 msgstr "U&ruchom ponownie"
 
-#: pysollib/game/__init__.py:2368
+#: pysollib/game/__init__.py:2406
 #, python-format
 msgid "Score %6d"
 msgstr "Wynik %6d"
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 #, fuzzy
 msgid "&Great"
 msgstr "&Great"
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 #, fuzzy
 msgid "&Cool"
 msgstr "&Cool"
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 #, fuzzy
 msgid "&Yeah"
 msgstr "&Yeah"
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 #, fuzzy
 msgid "&Wow"
 msgstr "&Wow"
 
-#: pysollib/game/__init__.py:2474
+#: pysollib/game/__init__.py:2512
 #, python-format
 msgid ""
 "\n"
@@ -1968,24 +1992,25 @@ msgstr[2] ""
 "\n"
 "Gra rozwiązana w %d ruchach.\n"
 
-#: pysollib/game/__init__.py:2478 pysollib/game/__init__.py:2492
-#: pysollib/game/__init__.py:2506
-msgid " Autopilot"
+#: pysollib/game/__init__.py:2517 pysollib/game/__init__.py:2532
+#: pysollib/game/__init__.py:2547
+#, fuzzy, python-format
+msgid "%s Autopilot"
 msgstr " Autopilot"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Oh well"
 msgstr "&O tak"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&That's life"
 msgstr "&Samo życie"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Hmm"
 msgstr "&Hmm"
 
-#: pysollib/game/__init__.py:2507
+#: pysollib/game/__init__.py:2548
 msgid ""
 "\n"
 "This won't come out...\n"
@@ -1993,34 +2018,34 @@ msgstr ""
 "\n"
 "To się nie uda...\n"
 
-#: pysollib/game/__init__.py:2966
+#: pysollib/game/__init__.py:3000
 msgid "Set bookmark"
 msgstr "Ustaw zakładkę"
 
-#: pysollib/game/__init__.py:2967
-#, python-format
-msgid "Replace existing bookmark %d ?"
+#: pysollib/game/__init__.py:3001
+#, fuzzy, python-format
+msgid "Replace existing bookmark %d?"
 msgstr "Zastąpić istniejącą zakładkę %d ?"
 
-#: pysollib/game/__init__.py:2988
+#: pysollib/game/__init__.py:3022
 msgid "Goto bookmark"
 msgstr "Idź do zakładki"
 
-#: pysollib/game/__init__.py:2989
-#, python-format
-msgid "Goto bookmark %d ?"
+#: pysollib/game/__init__.py:3023
+#, fuzzy, python-format
+msgid "Goto bookmark %d?"
 msgstr "Przejść do zakładki %d ?"
 
-#: pysollib/game/__init__.py:3015
+#: pysollib/game/__init__.py:3049
 msgid "Open game"
 msgstr "Otwórz grę"
 
-#: pysollib/game/__init__.py:3028 pysollib/game/__init__.py:3037
-#: pysollib/game/__init__.py:3043
+#: pysollib/game/__init__.py:3062 pysollib/game/__init__.py:3071
+#: pysollib/game/__init__.py:3077
 msgid "Load game error"
 msgstr "Błąd wczytywania gry"
 
-#: pysollib/game/__init__.py:3030
+#: pysollib/game/__init__.py:3064
 msgid ""
 "Error while loading game.\n"
 "\n"
@@ -2031,11 +2056,11 @@ msgstr ""
 "Prawdopodobnie gra jest uszkodzona,\n"
 "lecz może to być również błąd, który warto zgłosić."
 
-#: pysollib/game/__init__.py:3038
+#: pysollib/game/__init__.py:3072
 msgid "Error while loading game"
 msgstr "Błąd podczaas wczytywania gry"
 
-#: pysollib/game/__init__.py:3045
+#: pysollib/game/__init__.py:3079
 msgid ""
 "Internal error while loading game.\n"
 "\n"
@@ -2045,29 +2070,29 @@ msgstr ""
 "\n"
 "Proszę wysłać raport o błędzie."
 
-#: pysollib/game/__init__.py:3071 pysollib/ui/tktile/menubar.py:1675
+#: pysollib/game/__init__.py:3105 pysollib/ui/tktile/menubar.py:1677
 msgid "Save game error"
 msgstr "Błąd zapisywania gry"
 
-#: pysollib/game/__init__.py:3072
+#: pysollib/game/__init__.py:3106
 msgid "Error while saving game"
 msgstr "Błąd podczas zapisywania gry"
 
-#: pysollib/game/__init__.py:3091
+#: pysollib/game/__init__.py:3125
 #, python-format
 msgid "Invalid or damaged %s save file"
 msgstr "Nieprawidłowy lub uszkodzony pik zapisanej gry %s"
 
-#: pysollib/game/__init__.py:3111
-#, python-format
+#: pysollib/game/__init__.py:3145
+#, fuzzy, python-format
 msgid ""
 "Cannot load games saved with\n"
-"%s version %s"
+"%(app)s version %(ver)s"
 msgstr ""
 "Nie można wczytać gier zapisanych\n"
 "%s w wersji %s"
 
-#: pysollib/game/__init__.py:3130
+#: pysollib/game/__init__.py:3164
 #, python-format
 msgid ""
 "Cannot load this game from version %s\n"
@@ -2155,10 +2180,10 @@ msgstr "Stos rezerwowy. Tylko Króle są dozwolone."
 
 #: pysollib/games/matriarchy.py:123
 #, python-format
-msgid "Round %d/%d"
-msgstr "Runda %d/%d"
+msgid "Round %(round)d/%(max_rounds)d"
+msgstr ""
 
-#: pysollib/games/matriarchy.py:125
+#: pysollib/games/matriarchy.py:126
 #, python-format
 msgid "Deal %d"
 msgstr "Rozdanie %d"
@@ -2239,6 +2264,525 @@ msgstr ""
 "Stół gry. Układaj w dół niezależnie od koloru. Można przenosić odkryte karty "
 "niezależnie od sekwensu."
 
+#: pysollib/kivy/menubar.py:179
+#, fuzzy
+msgid "File"
+msgstr "Plik"
+
+#: pysollib/kivy/menubar.py:183
+#, fuzzy
+msgid "Games"
+msgstr "Gra"
+
+#: pysollib/kivy/menubar.py:188 pysollib/kivy/menubar.py:1605
+#, fuzzy
+msgid "Tools"
+msgstr "Pasek narzedziowy"
+
+#: pysollib/kivy/menubar.py:192 pysollib/kivy/menubar.py:1613
+#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:177
+#: pysollib/tile/selectgame.py:385 pysollib/tile/tkstats.py:51
+#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:384
+#: pysollib/tk/toolbar.py:188
+msgid "Statistics"
+msgstr "Statystyki"
+
+#: pysollib/kivy/menubar.py:196
+#, fuzzy
+msgid "Assist"
+msgstr "&Asysta"
+
+#: pysollib/kivy/menubar.py:201 pysollib/kivy/menubar.py:1629
+#, fuzzy
+msgid "Options"
+msgstr "&Opcje"
+
+#: pysollib/kivy/menubar.py:206 pysollib/kivy/menubar.py:320
+#: pysollib/kivy/menubar.py:1637
+#, fuzzy
+msgid "Help"
+msgstr "Pomoc"
+
+#: pysollib/kivy/menubar.py:227
+#, fuzzy
+msgid "Recent games"
+msgstr "Ostatni&e gry"
+
+#: pysollib/kivy/menubar.py:240
+#, fuzzy
+msgid "Favorite games"
+msgstr "Ulubione gry"
+
+#: pysollib/kivy/menubar.py:243
+msgid "<Add>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:245
+msgid "<Remove>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:296 pysollib/kivy/toolbar.py:197
+#: pysollib/pysolgtk/soundoptionsdialog.py:63
+#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
+#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
+msgid "Undo"
+msgstr "Cofnij"
+
+#: pysollib/kivy/menubar.py:298 pysollib/kivy/toolbar.py:198
+#: pysollib/pysolgtk/soundoptionsdialog.py:64
+#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
+#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
+msgid "Redo"
+msgstr "Powtórz"
+
+#: pysollib/kivy/menubar.py:300
+#, fuzzy
+msgid "Redo all"
+msgstr "Powtórz wszystko"
+
+#: pysollib/kivy/menubar.py:303 pysollib/kivy/menubar.py:517
+#: pysollib/pysolgtk/soundoptionsdialog.py:56
+#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
+msgid "Auto drop"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:305 pysollib/kivy/toolbar.py:200
+#: pysollib/tile/toolbar.py:185 pysollib/tk/toolbar.py:185
+msgid "Shuffle tiles"
+msgstr "Przemieszaj klocki"
+
+#: pysollib/kivy/menubar.py:307
+#, fuzzy
+msgid "Deal cards"
+msgstr "Przełóż karty"
+
+#: pysollib/kivy/menubar.py:310 pysollib/kivy/toolbar.py:201
+#: pysollib/tile/toolbar.py:186 pysollib/tk/toolbar.py:186
+msgid "Pause"
+msgstr "Pauza"
+
+#: pysollib/kivy/menubar.py:315
+#, fuzzy
+msgid "Load game"
+msgstr "Błąd wczytywania gry"
+
+#: pysollib/kivy/menubar.py:317 pysollib/tile/toolbar.py:180
+#: pysollib/tk/toolbar.py:180
+msgid "Save game"
+msgstr "Zapisz grę"
+
+#: pysollib/kivy/menubar.py:371
+#, fuzzy
+msgid "Current game..."
+msgstr "Bieżąca gra..."
+
+#: pysollib/kivy/menubar.py:434
+#, fuzzy
+msgid "Hint"
+msgstr "Podpowiedź:"
+
+#: pysollib/kivy/menubar.py:437
+#, fuzzy
+msgid "Highlight piles"
+msgstr "Podświetlanie stosów:"
+
+#: pysollib/kivy/menubar.py:509
+#, fuzzy
+msgid "Automatic play"
+msgstr "Gra &automatyczna"
+
+#: pysollib/kivy/menubar.py:512
+#, fuzzy
+msgid "Auto face up"
+msgstr "Odkrywaj automatycznie"
+
+#: pysollib/kivy/menubar.py:522
+#, fuzzy
+msgid "Auto deal"
+msgstr "Przekładaj automatycznie"
+
+#: pysollib/kivy/menubar.py:529
+#, fuzzy
+msgid "Quick play"
+msgstr "Szybka gra"
+
+#: pysollib/kivy/menubar.py:537
+#, fuzzy
+msgid "Assist level"
+msgstr "Poziom asysty"
+
+#: pysollib/kivy/menubar.py:540
+#, fuzzy
+msgid "Enable undo"
+msgstr "Włącz cofanie"
+
+#: pysollib/kivy/menubar.py:545
+#, fuzzy
+msgid "Enable bookmarks"
+msgstr "Włącz zakładki"
+
+#: pysollib/kivy/menubar.py:550
+#, fuzzy
+msgid "Enable hint"
+msgstr "Włacz podpowiedzi"
+
+#: pysollib/kivy/menubar.py:555
+#, fuzzy
+msgid "Enable shuffle"
+msgstr "Włącz tasowanie"
+
+#: pysollib/kivy/menubar.py:560
+#, fuzzy
+msgid "Enable highlight piles"
+msgstr "Włącz podśw&ietlanie stosów"
+
+#: pysollib/kivy/menubar.py:565
+#, fuzzy
+msgid "Enable highlight cards"
+msgstr "Włącz podświetlanie kart"
+
+#: pysollib/kivy/menubar.py:570
+#, fuzzy
+msgid "Enable highlight same rank"
+msgstr "Podświetlaj karty o jednakowej sile"
+
+#: pysollib/kivy/menubar.py:575
+#, fuzzy
+msgid "Highlight no matching"
+msgstr "Podświetlaj brak dopasowa&nia"
+
+#: pysollib/kivy/menubar.py:582
+#, fuzzy
+msgid "Show removed tiles (in Mahjongg games)"
+msgstr "Pokaż u&sunięte klocki (w grach Mahjongg)"
+
+#: pysollib/kivy/menubar.py:587
+#, fuzzy
+msgid "Show hint arrow (in Shisen-Sho games)"
+msgstr "Pok&aż strzałkę podpowiedzi (w grach Shisen-Sho)"
+
+#: pysollib/kivy/menubar.py:597
+#, fuzzy
+msgid "Sound"
+msgstr "Dźwięk..."
+
+#: pysollib/kivy/menubar.py:600
+#, fuzzy
+msgid "Enable"
+msgstr "Włącz cofanie"
+
+#: pysollib/kivy/menubar.py:605
+msgid "Volume"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:608
+msgid "100%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:612
+msgid "75%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:616
+msgid "50%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:620
+msgid "25%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:625
+#, fuzzy
+msgid "Samples"
+msgstr "Proste gry"
+
+#: pysollib/kivy/menubar.py:630
+msgid "are you sure"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:636
+#, fuzzy
+msgid "auto drop"
+msgstr "Przenieś &automatycznie"
+
+#: pysollib/kivy/menubar.py:642
+msgid "auto flip"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:648
+#, fuzzy
+msgid "auto pilot lost"
+msgstr "Autopilot przegrał"
+
+#: pysollib/kivy/menubar.py:654
+#, fuzzy
+msgid "auto pilot won"
+msgstr "Autopilot wygrał"
+
+#: pysollib/kivy/menubar.py:660
+#, fuzzy
+msgid "deal"
+msgstr "Rozdaj ponownie"
+
+#: pysollib/kivy/menubar.py:666
+#, fuzzy
+msgid "deal waste"
+msgstr "Przełóż do zrzutu"
+
+#: pysollib/kivy/menubar.py:672
+msgid "drop pair"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:678
+#, fuzzy
+msgid "drop"
+msgstr "Przenieś automatycznie"
+
+#: pysollib/kivy/menubar.py:684
+msgid "flip"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:690
+#, fuzzy
+msgid "move"
+msgstr "Brak ruchu"
+
+#: pysollib/kivy/menubar.py:696
+#, fuzzy
+msgid "no move"
+msgstr "Brak ruchu"
+
+#: pysollib/kivy/menubar.py:702
+msgid "redo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:708
+#, fuzzy
+msgid "start drag"
+msgstr "Uruchom grę ponownie"
+
+#: pysollib/kivy/menubar.py:714
+#, fuzzy
+msgid "turn waste"
+msgstr "Przełóż do zrzutu"
+
+#: pysollib/kivy/menubar.py:720
+msgid "undo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:726
+#, fuzzy
+msgid "game finished"
+msgstr "Gra zakończona"
+
+#: pysollib/kivy/menubar.py:732
+#, fuzzy
+msgid "game lost"
+msgstr "Gra przegrana"
+
+#: pysollib/kivy/menubar.py:738
+#, fuzzy
+msgid "game perfect"
+msgstr "Perfekcyjnie"
+
+#: pysollib/kivy/menubar.py:744
+#, fuzzy
+msgid "game won"
+msgstr "Wygrana"
+
+#: pysollib/kivy/menubar.py:752
+#, fuzzy
+msgid "Cardsets"
+msgstr "Wszystkie zestawy kart"
+
+#: pysollib/kivy/menubar.py:792
+#, fuzzy
+msgid "Table"
+msgstr "Stół gry"
+
+#: pysollib/kivy/menubar.py:795
+#, fuzzy
+msgid "Solid colors"
+msgstr "Kolory jednorodne"
+
+#: pysollib/kivy/menubar.py:800 pysollib/pysolgtk/selecttile.py:105
+#: pysollib/tile/selecttile.py:74 pysollib/tk/selecttile.py:73
+msgid "Blue"
+msgstr "Niebieski"
+
+#: pysollib/kivy/menubar.py:805 pysollib/pysolgtk/selecttile.py:106
+#: pysollib/tile/selecttile.py:75 pysollib/tk/selecttile.py:74
+#: pysollib/games/ultra/dashavatara.py:361 pysollib/games/ultra/mughal.py:264
+msgid "Green"
+msgstr "Zielony"
+
+#: pysollib/kivy/menubar.py:810 pysollib/pysolgtk/selecttile.py:107
+#: pysollib/tile/selecttile.py:76 pysollib/tk/selecttile.py:75
+msgid "Navy"
+msgstr "Granatowy"
+
+#: pysollib/kivy/menubar.py:815 pysollib/pysolgtk/selecttile.py:108
+#: pysollib/tile/selecttile.py:77 pysollib/tk/selecttile.py:76
+#: pysollib/games/ultra/dashavatara.py:362
+msgid "Olive"
+msgstr "Oliwkowy"
+
+#: pysollib/kivy/menubar.py:820 pysollib/pysolgtk/selecttile.py:109
+#: pysollib/tile/selecttile.py:78 pysollib/tk/selecttile.py:77
+#: pysollib/games/ultra/dashavatara.py:362 pysollib/games/ultra/mughal.py:264
+msgid "Orange"
+msgstr "Pomarańczowy"
+
+#: pysollib/kivy/menubar.py:825 pysollib/pysolgtk/selecttile.py:110
+#: pysollib/tile/selecttile.py:79 pysollib/tk/selecttile.py:78
+msgid "Teal"
+msgstr "Niebiesko-zielony"
+
+#: pysollib/kivy/menubar.py:830
+msgid "Tiles and Images"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:850
+#, fuzzy
+msgid "Card view"
+msgstr "Widok kart"
+
+#: pysollib/kivy/menubar.py:853
+#, fuzzy
+msgid "Card shadow"
+msgstr "Cień karty"
+
+#: pysollib/kivy/menubar.py:858
+#, fuzzy
+msgid "Shade legal moves"
+msgstr "Cieniuj dozwo&lone ruchy"
+
+#: pysollib/kivy/menubar.py:863
+msgid "Negative cards bottom"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:868 pysollib/ui/tktile/menubar.py:559
+msgid "Shrink face-down cards"
+msgstr "Pomniejszaj karty obrócone tyłem"
+
+#: pysollib/kivy/menubar.py:873
+#, fuzzy
+msgid "Shade filled stacks"
+msgstr "Cieniuj wypełnione stosy"
+
+#: pysollib/kivy/menubar.py:881
+#, fuzzy
+msgid "Animations"
+msgstr "A&nimacje"
+
+#: pysollib/kivy/menubar.py:889
+#, fuzzy
+msgid "Very fast"
+msgstr "Bardzo szybko"
+
+#: pysollib/kivy/menubar.py:894
+#, fuzzy
+msgid "Fast"
+msgstr "Szybko"
+
+#: pysollib/kivy/menubar.py:899
+#, fuzzy
+msgid "Medium"
+msgstr "Średnio szybko"
+
+#: pysollib/kivy/menubar.py:904
+#, fuzzy
+msgid "Slow"
+msgstr "Powoli"
+
+#: pysollib/kivy/menubar.py:909
+#, fuzzy
+msgid "Very slow"
+msgstr "Bardzo powoli"
+
+#: pysollib/kivy/menubar.py:916
+#, fuzzy
+msgid "Redeal animation"
+msgstr "Animacja &rozdawania"
+
+#: pysollib/kivy/menubar.py:921
+#, fuzzy
+msgid "Winning animation"
+msgstr "Animacja &wygranej"
+
+#: pysollib/kivy/menubar.py:929
+msgid "Touch mode"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:932
+#, fuzzy
+msgid "Drag-and-Drop"
+msgstr "Przeciągnij i upuść"
+
+#: pysollib/kivy/menubar.py:937
+#, fuzzy
+msgid "Point-and-Click"
+msgstr "Wskaż i kliknij"
+
+#: pysollib/kivy/menubar.py:971 pysollib/tile/toolbar.py:202
+#: pysollib/tk/toolbar.py:211
+msgid "Toolbar"
+msgstr "Pasek narzedziowy"
+
+#: pysollib/kivy/menubar.py:974 pysollib/ui/tktile/menubar.py:41
+msgid "Hide"
+msgstr "Ukryj"
+
+#: pysollib/kivy/menubar.py:989 pysollib/ui/tktile/menubar.py:50
+msgid "Left"
+msgstr "Lewa strona"
+
+#: pysollib/kivy/menubar.py:993 pysollib/ui/tktile/menubar.py:53
+msgid "Right"
+msgstr "Prawa strona"
+
+#: pysollib/kivy/menubar.py:1030
+#, fuzzy
+msgid "Startup splash screen"
+msgstr "Ek&ran powitalny"
+
+#: pysollib/kivy/menubar.py:1035
+msgid "Winning splash"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1058
+#, fuzzy
+msgid "Contents"
+msgstr "Zawartość"
+
+#: pysollib/kivy/menubar.py:1062
+#, fuzzy
+msgid "How to play"
+msgstr "Jak grać"
+
+#: pysollib/kivy/menubar.py:1066 pysollib/kivy/toolbar.py:204
+#: pysollib/tile/toolbar.py:189 pysollib/tk/toolbar.py:189
+msgid "Rules for this game"
+msgstr "Zasady tej gry"
+
+#: pysollib/kivy/menubar.py:1070
+#, fuzzy
+msgid "License terms"
+msgstr "Warunki &licencji"
+
+#: pysollib/kivy/menubar.py:1074
+#, fuzzy, python-format
+msgid "About %s..."
+msgstr "O programie"
+
+#: pysollib/kivy/menubar.py:1348
+msgid "Menu"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1576 pysollib/ui/tktile/menubar.py:971
+msgid "<none>"
+msgstr ""
+
 #: pysollib/kivy/menubar.py:1589
 msgid "Main Menu"
 msgstr ""
@@ -2247,289 +2791,332 @@ msgstr ""
 msgid "File Menu"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:1605
-#, fuzzy
-msgid "Tools"
-msgstr "Pasek narzedziowy"
-
 #: pysollib/kivy/menubar.py:1621
 #, fuzzy
 msgid "Assists"
 msgstr "&Asysta"
 
-#: pysollib/kivy/menubar.py:1629
-#, fuzzy
-msgid "Options"
-msgstr "&Opcje"
+#. TRANSLATORS: Usually, 'PySol files'
+#: pysollib/kivy/menubar.py:1795 pysollib/ui/tktile/menubar.py:1136
+#, fuzzy, python-format
+msgid "%s files"
+msgstr "Od początku"
 
-#: pysollib/kivy/menubar.py:1637
+#: pysollib/kivy/menubar.py:1796 pysollib/ui/tktile/menubar.py:1137
 #, fuzzy
-msgid "Help"
-msgstr "Pomoc"
+msgid "All files"
+msgstr "Od początku"
 
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2067
-#: pysollib/kivy/selectcardset.py:61 pysollib/pysolgtk/selectcardset.py:229
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2068
+#: pysollib/kivy/selectcardset.py:57 pysollib/pysolgtk/selectcardset.py:229
 #: pysollib/tk/menubar.py:89 pysollib/tk/menubar.py:90
 #: pysollib/tk/selectcardset.py:313
 msgid "&Load"
 msgstr "Wczytaj"
 
-#: pysollib/kivy/menubar.py:2068 pysollib/kivy/selectcardset.py:61
+#: pysollib/kivy/menubar.py:2069 pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/tile/selectcardset.py:318
 #: pysollib/tk/menubar.py:90
 msgid "&Info..."
 msgstr "&Info..."
 
-#: pysollib/kivy/menubar.py:2072 pysollib/tile/menubar.py:90
-#: pysollib/tk/menubar.py:94
-msgid "Select "
-msgstr "Wybierz "
+#: pysollib/kivy/menubar.py:2072 pysollib/pysolgtk/menubar.py:696
+#, fuzzy
+msgid "Select cardset"
+msgstr "Wybierz nazwę"
 
-#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1664
+#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1666
 msgid "Solitaire Wizard"
 msgstr "Kreator gier Solitaire"
 
 #: pysollib/kivy/selectgame.py:83 pysollib/tile/selectgame.py:84
-#: pysollib/tk/selectgame.py:85
+#: pysollib/tk/selectgame.py:84
 msgid "(no games)"
 msgstr "(brak gier)"
 
 #: pysollib/kivy/selectgame.py:104 pysollib/pysolgtk/selectgame.py:227
-#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:109
+#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:108
 msgid "Mahjongg Games"
 msgstr "Gry Mahjongg"
 
 #: pysollib/kivy/selectgame.py:108 pysollib/pysolgtk/selectgame.py:233
-#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:113
+#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:112
 msgid "French games"
 msgstr "Gry francuskie"
 
 #: pysollib/kivy/selectgame.py:111 pysollib/pysolgtk/selectgame.py:229
-#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:116
+#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:115
 msgid "Oriental Games"
 msgstr "Gry orientalne"
 
 #: pysollib/kivy/selectgame.py:114 pysollib/pysolgtk/selectgame.py:231
-#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:119
+#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:118
 msgid "Special Games"
 msgstr "Gry specjalne"
 
 #: pysollib/kivy/selectgame.py:117 pysollib/pysolgtk/selectgame.py:315
-#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:122
+#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:121
 msgid "Original Games"
 msgstr "Gry orginalne"
 
 #: pysollib/kivy/selectgame.py:146 pysollib/pysolgtk/selectgame.py:216
-#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:170
+#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:168
 msgid "All Games"
 msgstr "Wszystkie gry"
 
 #: pysollib/kivy/selectgame.py:157 pysollib/pysolgtk/selectgame.py:286
-#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:138
+#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:137
 msgid "by Compatibility"
 msgstr "według kompatybilności"
 
 #: pysollib/kivy/selectgame.py:168 pysollib/pysolgtk/selectgame.py:293
-#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:149
-msgid "New games in v. "
+#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:147
+#, fuzzy, python-format
+msgid "New games in v. %(version)s"
 msgstr "Nowe gry w wersji "
 
 #: pysollib/kivy/selectgame.py:171 pysollib/pysolgtk/selectgame.py:296
-#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:152
+#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:150
 msgid "by PySol version"
 msgstr "według wersji PySol"
 
 #: pysollib/kivy/selectgame.py:183 pysollib/tile/selectgame.py:161
-#: pysollib/tk/selectgame.py:163
+#: pysollib/tk/selectgame.py:161
 msgid "by Inventors"
 msgstr "według twórców"
 
 #: pysollib/kivy/selectgame.py:191 pysollib/pysolgtk/selectgame.py:218
-#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:172
+#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:170
 msgid "Popular Games"
 msgstr "Popularne gry"
 
 #: pysollib/kivy/selectgame.py:198 pysollib/pysolgtk/selectgame.py:217
-#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:171
+#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:169
 #, fuzzy
 msgid "Alternate Names"
 msgstr "Inne nazwy"
 
 #: pysollib/kivy/selectgame.py:201 pysollib/pysolgtk/selectgame.py:243
-#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:180
+#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:178
 msgid "by Skill Level"
 msgstr "według stopnia zaawansowania"
 
 #: pysollib/kivy/selectgame.py:213 pysollib/pysolgtk/selectgame.py:247
-#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:193
+#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:191
 msgid "by Game Feature"
 msgstr "według właściwości gry"
 
 #: pysollib/kivy/selectgame.py:214 pysollib/pysolgtk/selectgame.py:260
-#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:194
+#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:192
 msgid "by Number of Cards"
 msgstr "według liczby kart"
 
 #: pysollib/kivy/selectgame.py:215 pysollib/pysolgtk/selectgame.py:249
-#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:195
+#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:193
 msgid "32 cards"
 msgstr "32 karty"
 
 #: pysollib/kivy/selectgame.py:217 pysollib/pysolgtk/selectgame.py:250
-#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:197
+#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:195
 msgid "48 cards"
 msgstr "48 kart"
 
 #: pysollib/kivy/selectgame.py:219 pysollib/pysolgtk/selectgame.py:251
-#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:199
+#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:197
 msgid "52 cards"
 msgstr "52 karty"
 
 #: pysollib/kivy/selectgame.py:221 pysollib/pysolgtk/selectgame.py:252
-#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:201
+#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:199
 msgid "64 cards"
 msgstr "64 karty"
 
 #: pysollib/kivy/selectgame.py:223 pysollib/pysolgtk/selectgame.py:253
-#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:203
+#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:201
 msgid "78 cards"
 msgstr "78 kart"
 
 #: pysollib/kivy/selectgame.py:225 pysollib/pysolgtk/selectgame.py:254
-#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:205
+#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:203
 msgid "104 cards"
 msgstr "104 karty"
 
 #: pysollib/kivy/selectgame.py:227 pysollib/pysolgtk/selectgame.py:255
-#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:207
+#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:205
 msgid "144 cards"
 msgstr "144 karty"
 
 #: pysollib/kivy/selectgame.py:229 pysollib/pysolgtk/selectgame.py:256
-#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:210
+#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:208
 msgid "Other number"
 msgstr "Inna liczba"
 
 #: pysollib/kivy/selectgame.py:233 pysollib/pysolgtk/selectgame.py:267
-#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:214
+#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:212
 msgid "by Number of Decks"
 msgstr "według liczby talii"
 
 #: pysollib/kivy/selectgame.py:234 pysollib/pysolgtk/selectgame.py:262
-#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:215
+#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:213
 msgid "1 deck games"
 msgstr "Gry jedną talią"
 
 #: pysollib/kivy/selectgame.py:236 pysollib/pysolgtk/selectgame.py:263
-#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:217
+#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:215
 msgid "2 deck games"
 msgstr "Gry dwoma taliami"
 
 #: pysollib/kivy/selectgame.py:238 pysollib/pysolgtk/selectgame.py:264
-#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:219
+#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:217
 msgid "3 deck games"
 msgstr "Gry trzema taliami"
 
 #: pysollib/kivy/selectgame.py:240 pysollib/pysolgtk/selectgame.py:265
-#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:221
+#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:219
 msgid "4 deck games"
 msgstr "Gry czterema taliami"
 
 #: pysollib/kivy/selectgame.py:243 pysollib/pysolgtk/selectgame.py:278
-#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:224
+#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:222
 msgid "by Number of Redeals"
 msgstr "według liczby rozdań"
 
 #: pysollib/kivy/selectgame.py:244 pysollib/pysolgtk/selectgame.py:269
-#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:225
+#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:223
 msgid "No redeal"
 msgstr "Bez dodatkowych rozdań"
 
 #: pysollib/kivy/selectgame.py:246 pysollib/pysolgtk/selectgame.py:270
-#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:227
+#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:225
 msgid "1 redeal"
 msgstr "1 dodatkowe rozdanie"
 
 #: pysollib/kivy/selectgame.py:248 pysollib/pysolgtk/selectgame.py:271
-#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:229
+#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:227
 msgid "2 redeals"
 msgstr "2 dodatkowe rozdania"
 
 #: pysollib/kivy/selectgame.py:250 pysollib/pysolgtk/selectgame.py:272
-#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:231
+#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:229
 msgid "3 redeals"
 msgstr "3 dodatkowe rozdania"
 
 #: pysollib/kivy/selectgame.py:256 pysollib/pysolgtk/selectgame.py:275
-#: pysollib/tile/selectgame.py:236 pysollib/tk/selectgame.py:238
+#: pysollib/tile/selectgame.py:234 pysollib/tk/selectgame.py:234
 msgid "Other number of redeals"
 msgstr "Inna liczba rozdań"
 
 #: pysollib/kivy/selectgame.py:264 pysollib/pysolgtk/selectgame.py:311
-#: pysollib/tile/selectgame.py:243 pysollib/tk/selectgame.py:245
+#: pysollib/tile/selectgame.py:241 pysollib/tk/selectgame.py:241
 msgid "Other Categories"
 msgstr "Inne kategorie"
 
 #: pysollib/kivy/selectgame.py:265 pysollib/pysolgtk/selectgame.py:300
-#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:246
+#: pysollib/tile/selectgame.py:242 pysollib/tk/selectgame.py:242
 msgid "Games for Children (very easy)"
 msgstr "Gry dla dzieci (bardzo łatwe)"
 
 #: pysollib/kivy/selectgame.py:267 pysollib/pysolgtk/selectgame.py:302
-#: pysollib/tile/selectgame.py:246 pysollib/tk/selectgame.py:248
+#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:244
 msgid "Games with Scoring"
 msgstr "Gry z punktacją"
 
 #: pysollib/kivy/selectgame.py:269 pysollib/pysolgtk/selectgame.py:304
-#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:251
+#: pysollib/tile/selectgame.py:247 pysollib/tk/selectgame.py:247
 msgid "Games with Separate Decks"
 msgstr "Gry z odrębnymi taliami"
 
 #: pysollib/kivy/selectgame.py:271 pysollib/pysolgtk/selectgame.py:306
-#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:253
+#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:249
 msgid "Open Games (all cards visible)"
 msgstr "Gry otwarte (wszystkie karty są widoczne)"
 
 #: pysollib/kivy/selectgame.py:273 pysollib/pysolgtk/selectgame.py:308
-#: pysollib/tile/selectgame.py:253 pysollib/tk/selectgame.py:255
+#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:251
 msgid "Relaxed Variants"
 msgstr "Odmiany relaksowe"
+
+#: pysollib/kivy/tkhtml.py:409
+#, fuzzy
+msgid "Browser"
+msgstr "Brązowy"
+
+#: pysollib/kivy/tkhtml.py:434 pysollib/pysolgtk/tkhtml.py:218
+#: pysollib/tile/tkhtml.py:77 pysollib/tk/tkhtml.py:72
+msgid "Index"
+msgstr "Indeks"
+
+#: pysollib/kivy/tkhtml.py:435 pysollib/pysolgtk/tkhtml.py:219
+#: pysollib/tile/tkhtml.py:81 pysollib/tk/tkhtml.py:76
+msgid "Back"
+msgstr "W tył"
+
+#: pysollib/kivy/tkhtml.py:437 pysollib/pysolgtk/tkhtml.py:220
+#: pysollib/tile/tkhtml.py:85 pysollib/tk/tkhtml.py:80
+msgid "Forward"
+msgstr "W przód"
+
+#: pysollib/kivy/tkhtml.py:438 pysollib/pysolgtk/tkhtml.py:221
+#: pysollib/tile/tkhtml.py:89 pysollib/tk/tkhtml.py:84
+msgid "Close"
+msgstr "Zamknij"
 
 #: pysollib/kivy/tkstats.py:148 pysollib/tile/tkstats.py:163
 #: pysollib/tk/tkstats.py:53
 msgid "Demo games"
 msgstr "Gry demo"
 
-#: pysollib/kivy/tkstats.py:220 pysollib/pysolgtk/selectgame.py:123
-#: pysollib/tile/selectgame.py:402 pysollib/tile/tkstats.py:182
-#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:404
+#: pysollib/kivy/tkstats.py:175
+#, python-format
+msgid ""
+"Total:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+"\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:187
+#, python-format
+msgid ""
+"Current Session:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:225 pysollib/pysolgtk/selectgame.py:123
+#: pysollib/tile/selectgame.py:400 pysollib/tile/tkstats.py:182
+#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:401
 #: pysollib/tk/tkstats.py:87 pysollib/tk/tkstats.py:141 data/pysolfc.glade:241
 #: data/pysolfc.glade:519
 msgid "Won:"
 msgstr "Wygrane:"
 
-#: pysollib/kivy/tkstats.py:222 pysollib/pysolgtk/selectgame.py:124
-#: pysollib/tile/selectgame.py:403 pysollib/tile/tkstats.py:183
-#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:405
+#: pysollib/kivy/tkstats.py:227 pysollib/pysolgtk/selectgame.py:124
+#: pysollib/tile/selectgame.py:401 pysollib/tile/tkstats.py:183
+#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:402
 #: pysollib/tk/tkstats.py:88 pysollib/tk/tkstats.py:143 data/pysolfc.glade:307
 #: data/pysolfc.glade:544
 msgid "Lost:"
 msgstr "Przegrane:"
 
-#: pysollib/kivy/tkstats.py:224 pysollib/tile/tkstats.py:184
+#: pysollib/kivy/tkstats.py:229 pysollib/tile/tkstats.py:184
 #: pysollib/tile/tkstats.py:238 pysollib/tk/tkstats.py:89
 #: pysollib/tk/tkstats.py:145 data/pysolfc.glade:266 data/pysolfc.glade:569
 msgid "Total:"
 msgstr "Ogółem:"
 
-#: pysollib/kivy/tkstats.py:250 pysollib/tk/tkstats.py:279
+#: pysollib/kivy/tkstats.py:255 pysollib/tk/tkstats.py:279
 msgid "&All games..."
 msgstr "Wszystkie gry..."
 
-#: pysollib/kivy/tkstats.py:252 pysollib/tile/tkstats.py:102
+#: pysollib/kivy/tkstats.py:257 pysollib/tile/tkstats.py:102
 #: pysollib/tk/tkstats.py:281
 msgid "&Reset..."
 msgstr "&Reset..."
+
+#: pysollib/kivy/tkwidget.py:183
+msgid "Error"
+msgstr ""
 
 #: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
 #: pysollib/tk/toolbar.py:176
@@ -2550,22 +3137,10 @@ msgstr ""
 "Uruchom ponownie\n"
 "bieżącą grę"
 
-#: pysollib/kivy/toolbar.py:197 pysollib/pysolgtk/soundoptionsdialog.py:63
-#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
-#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
-msgid "Undo"
-msgstr "Cofnij"
-
 #: pysollib/kivy/toolbar.py:197 pysollib/tile/toolbar.py:182
 #: pysollib/tk/toolbar.py:182
 msgid "Undo last move"
 msgstr "Cofnij ostatni ruch"
-
-#: pysollib/kivy/toolbar.py:198 pysollib/pysolgtk/soundoptionsdialog.py:64
-#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
-#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
-msgid "Redo"
-msgstr "Powtórz"
 
 #: pysollib/kivy/toolbar.py:198 pysollib/tile/toolbar.py:183
 #: pysollib/tk/toolbar.py:183
@@ -2589,16 +3164,6 @@ msgstr "Przenieś karty automatycznie"
 msgid "Shuffle"
 msgstr "Przemieszaj"
 
-#: pysollib/kivy/toolbar.py:200 pysollib/tile/toolbar.py:185
-#: pysollib/tk/toolbar.py:185
-msgid "Shuffle tiles"
-msgstr "Przemieszaj klocki"
-
-#: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
-#: pysollib/tk/toolbar.py:186
-msgid "Pause"
-msgstr "Pauza"
-
 #: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
 #: pysollib/tk/toolbar.py:186
 msgid "Pause game"
@@ -2608,11 +3173,6 @@ msgstr "Pauzuj grę"
 #: pysollib/tk/toolbar.py:189
 msgid "Rules"
 msgstr "Zasady"
-
-#: pysollib/kivy/toolbar.py:204 pysollib/tile/toolbar.py:189
-#: pysollib/tk/toolbar.py:189
-msgid "Rules for this game"
-msgstr "Zasady tej gry"
 
 #: pysollib/kivy/toolbar.py:206 pysollib/tile/toolbar.py:191
 #: pysollib/tk/toolbar.py:191
@@ -2638,19 +3198,14 @@ msgstr "Otwórz grę"
 msgid "Save Game"
 msgstr "Zapisz grę"
 
-#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1298
+#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1300
 #: data/pysolfc.glade:4127
 msgid "Sound settings"
 msgstr "Ustawienia dźwięków"
 
-#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1521
+#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1523
 msgid "Select table background"
 msgstr "Wybierz kolor tła"
-
-#: pysollib/pysolgtk/menubar.py:696
-#, fuzzy
-msgid "Select cardset"
-msgstr "Wybierz nazwę"
 
 #: pysollib/pysolgtk/playeroptionsdialog.py:62
 #: pysollib/tile/playeroptionsdialog.py:61
@@ -2728,75 +3283,76 @@ msgstr "według narodowości"
 msgid "by Date"
 msgstr "według daty"
 
-#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:384
-#: pysollib/tk/selectgame.py:386
+#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:382
+#: pysollib/tk/selectgame.py:383
 msgid "About game"
 msgstr "O grze"
 
-#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:394
-#: pysollib/tk/selectgame.py:396
+#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:392
+#: pysollib/tk/selectgame.py:393
 msgid "Alternate names:"
 msgstr "Inne nazwy:"
 
-#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:395
-#: pysollib/tk/selectgame.py:397
+#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:393
+#: pysollib/tk/selectgame.py:394
 msgid "Category:"
 msgstr "Kategoria:"
 
-#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:398
-#: pysollib/tk/selectgame.py:400
+#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:396
+#: pysollib/tk/selectgame.py:397
 msgid "Decks:"
 msgstr "Talie:"
 
-#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:399
-#: pysollib/tk/selectgame.py:401
+#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:397
+#: pysollib/tk/selectgame.py:398
 msgid "Redeals:"
 msgstr "Ponowne rozdania:"
 
-#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:401
-#: pysollib/tk/selectgame.py:403
+#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:399
+#: pysollib/tk/selectgame.py:400
 msgid "Played:"
 msgstr "Rozegrane:"
 
-#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:404
-#: pysollib/tile/tkstats.py:777 pysollib/tk/selectgame.py:406
-#: pysollib/tk/tkstats.py:740 data/pysolfc.glade:717
+#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:402
+#: pysollib/tile/tkstats.py:778 pysollib/tk/selectgame.py:403
+#: pysollib/tk/tkstats.py:741 data/pysolfc.glade:717
 msgid "Playing time:"
 msgstr "Czas gry:"
 
-#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:405
-#: pysollib/tile/tkstats.py:784 pysollib/tk/selectgame.py:407
-#: pysollib/tk/tkstats.py:747 data/pysolfc.glade:813
+#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:403
+#: pysollib/tile/tkstats.py:785 pysollib/tk/selectgame.py:404
+#: pysollib/tk/tkstats.py:748 data/pysolfc.glade:813
 msgid "Moves:"
 msgstr "Ruchy:"
 
-#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:406
-#: pysollib/tk/selectgame.py:408
+#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:404
+#: pysollib/tk/selectgame.py:405
 msgid "% won:"
 msgstr "% wygranych:"
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:438
-#: pysollib/tk/selectgame.py:439 pysollib/ui/tktile/menubar.py:352
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:436
+#: pysollib/tk/selectgame.py:437 pysollib/ui/tktile/menubar.py:352
 msgid "&Select"
 msgstr "Wybierz"
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:437
-#: pysollib/tk/selectgame.py:439
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:435
+#: pysollib/tk/selectgame.py:436
 msgid "&Rules"
 msgstr "Zasady"
 
-#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:518
-#: pysollib/tk/selectgame.py:519
-msgid "Playable Preview - "
+#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:516
+#: pysollib/tk/selectgame.py:517
+#, fuzzy, python-format
+msgid "Playable Preview - %(game)s"
 msgstr "Podgląd z aktywną grą - "
 
-#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:571
-#: pysollib/tk/selectgame.py:572
+#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:569
+#: pysollib/tk/selectgame.py:570
 msgid "variable"
 msgstr "zmienna liczba"
 
-#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:573
-#: pysollib/tk/selectgame.py:574
+#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:571
+#: pysollib/tk/selectgame.py:572
 msgid "unlimited"
 msgstr "nieograniczona liczba"
 
@@ -2804,38 +3360,6 @@ msgstr "nieograniczona liczba"
 #, fuzzy
 msgid "Solid color"
 msgstr "Kolory jednorodne"
-
-#: pysollib/pysolgtk/selecttile.py:105 pysollib/tile/selecttile.py:74
-#: pysollib/tk/selecttile.py:73
-msgid "Blue"
-msgstr "Niebieski"
-
-#: pysollib/pysolgtk/selecttile.py:106 pysollib/tile/selecttile.py:75
-#: pysollib/tk/selecttile.py:74 pysollib/games/ultra/dashavatara.py:361
-#: pysollib/games/ultra/mughal.py:264
-msgid "Green"
-msgstr "Zielony"
-
-#: pysollib/pysolgtk/selecttile.py:107 pysollib/tile/selecttile.py:76
-#: pysollib/tk/selecttile.py:75
-msgid "Navy"
-msgstr "Granatowy"
-
-#: pysollib/pysolgtk/selecttile.py:108 pysollib/tile/selecttile.py:77
-#: pysollib/tk/selecttile.py:76 pysollib/games/ultra/dashavatara.py:362
-msgid "Olive"
-msgstr "Oliwkowy"
-
-#: pysollib/pysolgtk/selecttile.py:109 pysollib/tile/selecttile.py:78
-#: pysollib/tk/selecttile.py:77 pysollib/games/ultra/dashavatara.py:362
-#: pysollib/games/ultra/mughal.py:264
-msgid "Orange"
-msgstr "Pomarańczowy"
-
-#: pysollib/pysolgtk/selecttile.py:110 pysollib/tile/selecttile.py:79
-#: pysollib/tk/selecttile.py:78
-msgid "Teal"
-msgstr "Niebiesko-zielony"
 
 #: pysollib/pysolgtk/selecttile.py:121 pysollib/tile/selecttile.py:82
 #: pysollib/tk/selecttile.py:81
@@ -2892,11 +3416,6 @@ msgstr ""
 msgid "Drop pair"
 msgstr ""
 
-#: pysollib/pysolgtk/soundoptionsdialog.py:56
-#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
-msgid "Auto drop"
-msgstr ""
-
 #: pysollib/pysolgtk/soundoptionsdialog.py:58
 #: pysollib/tile/soundoptionsdialog.py:70 pysollib/tk/soundoptionsdialog.py:72
 msgid "Flip"
@@ -2948,35 +3467,15 @@ msgstr "Ruchy/Ruchy ogółem"
 msgid "Games played: won/lost"
 msgstr "Gry rozegrane: wygrane/przegrane"
 
-#: pysollib/pysolgtk/tkhtml.py:218 pysollib/tile/tkhtml.py:77
-#: pysollib/tk/tkhtml.py:72
-msgid "Index"
-msgstr "Indeks"
-
-#: pysollib/pysolgtk/tkhtml.py:219 pysollib/tile/tkhtml.py:81
-#: pysollib/tk/tkhtml.py:76
-msgid "Back"
-msgstr "W tył"
-
-#: pysollib/pysolgtk/tkhtml.py:220 pysollib/tile/tkhtml.py:85
-#: pysollib/tk/tkhtml.py:80
-msgid "Forward"
-msgstr "W przód"
-
-#: pysollib/pysolgtk/tkhtml.py:221 pysollib/tile/tkhtml.py:89
-#: pysollib/tk/tkhtml.py:84
-msgid "Close"
-msgstr "Zamknij"
-
 #: pysollib/pysolgtk/tkhtml.py:437 pysollib/ui/tktile/tkhtml.py:314
-#, python-format
+#, fuzzy, python-format
 msgid ""
-"HTML limitation:\n"
-"The %s protocol is not supported yet.\n"
+"%(app)s HTML limitation:\n"
+"The %(protocol)s protocol is not supported yet.\n"
 "\n"
 "Please use your standard web browser\n"
 "to open the following URL:\n"
-"%s\n"
+"%(url)s\n"
 msgstr ""
 "Ograniczenia HTML:\n"
 "Protokół %s nie jest jeszcze obsługiwany.\n"
@@ -2990,38 +3489,38 @@ msgstr ""
 msgid "Unable to service request:\n"
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:328 pysollib/tile/tkstats.py:290
+#: pysollib/pysolgtk/tkstats.py:329 pysollib/tile/tkstats.py:290
 #: pysollib/tk/tkstats.py:266
 msgid "No games"
 msgstr "Brak gier"
 
-#: pysollib/pysolgtk/tkstats.py:388 pysollib/tile/tkstats.py:670
-#: pysollib/tk/tkstats.py:667
+#: pysollib/pysolgtk/tkstats.py:389 pysollib/tile/tkstats.py:671
+#: pysollib/tk/tkstats.py:668
 msgid "N"
 msgstr "N"
 
-#: pysollib/pysolgtk/tkstats.py:391 pysollib/tile/tkstats.py:683
-#: pysollib/tk/tkstats.py:676
+#: pysollib/pysolgtk/tkstats.py:392 pysollib/tile/tkstats.py:684
+#: pysollib/tk/tkstats.py:677
 msgid "Result"
 msgstr "Wynik"
 
-#: pysollib/pysolgtk/tkstats.py:526 pysollib/tile/tkstats.py:613
-#: pysollib/tk/tkstats.py:608
+#: pysollib/pysolgtk/tkstats.py:527 pysollib/tile/tkstats.py:614
+#: pysollib/tk/tkstats.py:609
 msgid "Highlight piles: "
 msgstr "Podświetlenie stosów: "
 
-#: pysollib/pysolgtk/tkstats.py:527 pysollib/tile/tkstats.py:614
-#: pysollib/tk/tkstats.py:609
+#: pysollib/pysolgtk/tkstats.py:528 pysollib/tile/tkstats.py:615
+#: pysollib/tk/tkstats.py:610
 msgid "Highlight cards: "
 msgstr "Podświetlenie kart: "
 
-#: pysollib/pysolgtk/tkstats.py:528 pysollib/tile/tkstats.py:615
-#: pysollib/tk/tkstats.py:610
+#: pysollib/pysolgtk/tkstats.py:529 pysollib/tile/tkstats.py:616
+#: pysollib/tk/tkstats.py:611
 msgid "Highlight same rank: "
 msgstr "Podświetlenie jednakowych wartości: "
 
-#: pysollib/pysolgtk/tkstats.py:532 pysollib/tile/tkstats.py:619
-#: pysollib/tk/tkstats.py:614
+#: pysollib/pysolgtk/tkstats.py:533 pysollib/tile/tkstats.py:620
+#: pysollib/tk/tkstats.py:615
 msgid ""
 "\n"
 "Redeals: "
@@ -3029,8 +3528,8 @@ msgstr ""
 "\n"
 "Ponowne rozdania: "
 
-#: pysollib/pysolgtk/tkstats.py:533 pysollib/tile/tkstats.py:620
-#: pysollib/tk/tkstats.py:615
+#: pysollib/pysolgtk/tkstats.py:534 pysollib/tile/tkstats.py:621
+#: pysollib/tk/tkstats.py:616
 msgid ""
 "\n"
 "Cards in Talon: "
@@ -3038,8 +3537,8 @@ msgstr ""
 "\n"
 "Karty w stosie wyjściowym: "
 
-#: pysollib/pysolgtk/tkstats.py:535 pysollib/tile/tkstats.py:622
-#: pysollib/tk/tkstats.py:617
+#: pysollib/pysolgtk/tkstats.py:536 pysollib/tile/tkstats.py:623
+#: pysollib/tk/tkstats.py:618
 msgid ""
 "\n"
 "Cards in Waste: "
@@ -3047,8 +3546,8 @@ msgstr ""
 "\n"
 "Karty z zrzucie: "
 
-#: pysollib/pysolgtk/tkstats.py:537 pysollib/tile/tkstats.py:624
-#: pysollib/tk/tkstats.py:619
+#: pysollib/pysolgtk/tkstats.py:538 pysollib/tile/tkstats.py:625
+#: pysollib/tk/tkstats.py:620
 msgid ""
 "\n"
 "Cards in Foundations: "
@@ -3056,58 +3555,58 @@ msgstr ""
 "\n"
 "Karty w stosie bazowym: "
 
-#: pysollib/pysolgtk/tkstats.py:542 pysollib/tile/tkstats.py:629
-#: pysollib/tk/tkstats.py:625
+#: pysollib/pysolgtk/tkstats.py:543 pysollib/tile/tkstats.py:630
+#: pysollib/tk/tkstats.py:626
 msgid "Game status"
 msgstr "Stan gry"
 
-#: pysollib/pysolgtk/tkstats.py:545 pysollib/tile/tkstats.py:632
-#: pysollib/tk/tkstats.py:628
+#: pysollib/pysolgtk/tkstats.py:546 pysollib/tile/tkstats.py:633
+#: pysollib/tk/tkstats.py:629
 msgid "Playing time: "
 msgstr "Czas gry: "
 
-#: pysollib/pysolgtk/tkstats.py:546 pysollib/tile/tkstats.py:633
-#: pysollib/tk/tkstats.py:629
+#: pysollib/pysolgtk/tkstats.py:547 pysollib/tile/tkstats.py:634
+#: pysollib/tk/tkstats.py:630
 msgid "Started at: "
 msgstr "Rozpoczęta w dniu: "
 
-#: pysollib/pysolgtk/tkstats.py:547 pysollib/tile/tkstats.py:634
-#: pysollib/tk/tkstats.py:630
+#: pysollib/pysolgtk/tkstats.py:548 pysollib/tile/tkstats.py:635
+#: pysollib/tk/tkstats.py:631
 msgid "Moves: "
 msgstr "Ruchy: "
 
-#: pysollib/pysolgtk/tkstats.py:548 pysollib/tile/tkstats.py:635
-#: pysollib/tk/tkstats.py:631
+#: pysollib/pysolgtk/tkstats.py:549 pysollib/tile/tkstats.py:636
+#: pysollib/tk/tkstats.py:632
 msgid "Undo moves: "
 msgstr "Cofnięte ruchy: "
 
-#: pysollib/pysolgtk/tkstats.py:549 pysollib/tile/tkstats.py:636
-#: pysollib/tk/tkstats.py:632
+#: pysollib/pysolgtk/tkstats.py:550 pysollib/tile/tkstats.py:637
+#: pysollib/tk/tkstats.py:633
 msgid "Bookmark moves: "
 msgstr "Ruchy w zakładkach:"
 
-#: pysollib/pysolgtk/tkstats.py:550 pysollib/tile/tkstats.py:637
-#: pysollib/tk/tkstats.py:633
+#: pysollib/pysolgtk/tkstats.py:551 pysollib/tile/tkstats.py:638
+#: pysollib/tk/tkstats.py:634
 msgid "Demo moves: "
 msgstr "Ruchy demo:"
 
-#: pysollib/pysolgtk/tkstats.py:551 pysollib/tile/tkstats.py:638
-#: pysollib/tk/tkstats.py:634
+#: pysollib/pysolgtk/tkstats.py:552 pysollib/tile/tkstats.py:639
+#: pysollib/tk/tkstats.py:635
 msgid "Total player moves: "
 msgstr "Całkowita liczba ruchów gracza:"
 
-#: pysollib/pysolgtk/tkstats.py:552 pysollib/tile/tkstats.py:639
-#: pysollib/tk/tkstats.py:635
+#: pysollib/pysolgtk/tkstats.py:553 pysollib/tile/tkstats.py:640
+#: pysollib/tk/tkstats.py:636
 msgid "Total moves in this game: "
 msgstr "Liczba ruchów w tej grze:"
 
-#: pysollib/pysolgtk/tkstats.py:553 pysollib/tile/tkstats.py:640
-#: pysollib/tk/tkstats.py:636
+#: pysollib/pysolgtk/tkstats.py:554 pysollib/tile/tkstats.py:641
+#: pysollib/tk/tkstats.py:637
 msgid "Hints: "
 msgstr "Podpowiedzi: "
 
-#: pysollib/pysolgtk/tkstats.py:557 pysollib/tile/tkstats.py:643
-#: pysollib/tk/tkstats.py:640 pysollib/ui/tktile/menubar.py:420
+#: pysollib/pysolgtk/tkstats.py:558 pysollib/tile/tkstats.py:644
+#: pysollib/tk/tkstats.py:641 pysollib/ui/tktile/menubar.py:420
 msgid "&Statistics..."
 msgstr "&Statystyki..."
 
@@ -3177,14 +3676,19 @@ msgstr "Zmień..."
 msgid "Select font"
 msgstr "Wybierz czcionkę"
 
+#: pysollib/tile/menubar.py:90 pysollib/tk/menubar.py:94
+msgid "Select "
+msgstr "Wybierz "
+
 #: pysollib/tile/menubar.py:106
 msgid "Change theme"
 msgstr "Zmień temat"
 
 #: pysollib/tile/menubar.py:107
+#, fuzzy, python-format
 msgid ""
-"This settings will take effect\n"
-"the next time you restart "
+"These settings will take effect\n"
+"the next time you restart %(app)s"
 msgstr ""
 "Zmiany zostaną wprowadzone\n"
 "po ponownym uruchomieniu programu"
@@ -3284,7 +3788,7 @@ msgstr ""
 msgid "&Save"
 msgstr "Zapi&sz"
 
-#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:177
+#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:176
 msgid "Custom Games"
 msgstr "Własne gry"
 
@@ -3394,14 +3898,14 @@ msgstr "Podświetlanie kart:"
 msgid "Highlight same rank:"
 msgstr "Podświetlanie kart o jednakowej wartości:"
 
-#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:740
-#: pysollib/tile/tkstats.py:887 pysollib/tk/tkstats.py:909
+#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:741
+#: pysollib/tile/tkstats.py:888 pysollib/tk/tkstats.py:910
 #: data/pysolfc.glade:660
 msgid "Current game"
 msgstr "Bieżąca gra"
 
-#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:748
-#: pysollib/tile/tkstats.py:883 pysollib/tk/tkstats.py:903
+#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:749
+#: pysollib/tile/tkstats.py:884 pysollib/tk/tkstats.py:904
 #: data/pysolfc.glade:1342
 msgid "All games"
 msgstr "Wszystkie gry"
@@ -3424,75 +3928,83 @@ msgstr "Ogółem"
 msgid "Current session"
 msgstr "Bieżąca sesja"
 
-#: pysollib/tile/tkstats.py:510
+#: pysollib/tile/tkstats.py:511
 msgid "Log"
 msgstr "Log"
 
-#: pysollib/tile/tkstats.py:541 pysollib/tk/tkstats.py:506
-#: pysollib/tk/tkstats.py:575 pysollib/tk/tkstats.py:592
+#: pysollib/tile/tkstats.py:523 data/pysolfc.glade:1404
+msgid "Full log"
+msgstr "Kompletny log"
+
+#: pysollib/tile/tkstats.py:527 data/pysolfc.glade:1466
+msgid "Session log"
+msgstr "Log sesji"
+
+#: pysollib/tile/tkstats.py:542 pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:576 pysollib/tk/tkstats.py:593
 msgid "&Save to file"
 msgstr "Zapi&sz do pliku"
 
-#: pysollib/tile/tkstats.py:745 pysollib/tk/tkstats.py:785
+#: pysollib/tile/tkstats.py:746 pysollib/tk/tkstats.py:786
 msgid "No TOP for this game"
 msgstr "Ta gra nie jest jeszcze klasyfikowana w TOP 10"
 
-#: pysollib/tile/tkstats.py:753
+#: pysollib/tile/tkstats.py:754
 msgid "No TOP for all games"
 msgstr "Żadna gra nie jest klasyfikowana w TOP 10"
 
-#: pysollib/tile/tkstats.py:765 pysollib/tk/tkstats.py:732
+#: pysollib/tile/tkstats.py:766 pysollib/tk/tkstats.py:733
 #: data/pysolfc.glade:1005
 msgid "Minimum"
 msgstr "Minimum"
 
-#: pysollib/tile/tkstats.py:767 pysollib/tk/tkstats.py:733
+#: pysollib/tile/tkstats.py:768 pysollib/tk/tkstats.py:734
 #: data/pysolfc.glade:1028
 msgid "Maximum"
 msgstr "Maksimum"
 
-#: pysollib/tile/tkstats.py:769 pysollib/tk/tkstats.py:734
+#: pysollib/tile/tkstats.py:770 pysollib/tk/tkstats.py:735
 #: data/pysolfc.glade:1051
 msgid "Average"
 msgstr "Średnio"
 
-#: pysollib/tile/tkstats.py:791 pysollib/tk/tkstats.py:754
+#: pysollib/tile/tkstats.py:792 pysollib/tk/tkstats.py:755
 #: data/pysolfc.glade:909
 msgid "Total moves:"
 msgstr "Ruchy ogółem:"
 
-#: pysollib/tile/tkstats.py:891 pysollib/tk/tkstats.py:915
+#: pysollib/tile/tkstats.py:892 pysollib/tk/tkstats.py:916
 msgid "Statistics for"
 msgstr "Statystyki dla"
 
-#: pysollib/tile/tkstats.py:896 pysollib/tk/tkstats.py:920
+#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
 msgid "Last 7 days"
 msgstr "Ostatnie 7 dni"
 
-#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
+#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
 msgid "Last month"
 msgstr "Ostatni miesiąc"
 
-#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
+#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
 msgid "Last year"
 msgstr "Ostatni rok"
 
-#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
+#: pysollib/tile/tkstats.py:900 pysollib/tk/tkstats.py:924
 msgid "All time"
 msgstr "Od początku"
 
-#: pysollib/tile/tkstats.py:904 pysollib/tk/tkstats.py:930
+#: pysollib/tile/tkstats.py:905 pysollib/tk/tkstats.py:931
 msgid "Show graphs"
 msgstr "Pokaż wykresy"
 
-#: pysollib/tile/tkstats.py:948 pysollib/tile/tkstats.py:964
-#: pysollib/tile/tkstats.py:1002 pysollib/tk/tkstats.py:857
-#: pysollib/tk/tkstats.py:873 pysollib/tk/tkstats.py:977
+#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:965
+#: pysollib/tile/tkstats.py:1003 pysollib/tk/tkstats.py:858
+#: pysollib/tk/tkstats.py:874 pysollib/tk/tkstats.py:978
 msgid "Games/day"
 msgstr "Gry/dzień"
 
-#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:1004
-#: pysollib/tk/tkstats.py:858 pysollib/tk/tkstats.py:979
+#: pysollib/tile/tkstats.py:950 pysollib/tile/tkstats.py:1005
+#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:980
 msgid "Games/week"
 msgstr "Gry/tydzień"
 
@@ -3512,17 +4024,9 @@ msgstr ""
 msgid "Save"
 msgstr "Zapisz"
 
-#: pysollib/tile/toolbar.py:180 pysollib/tk/toolbar.py:180
-msgid "Save game"
-msgstr "Zapisz grę"
-
 #: pysollib/tile/toolbar.py:188 pysollib/tk/toolbar.py:188
 msgid "View statistics"
 msgstr "Pokaż statystyki"
-
-#: pysollib/tile/toolbar.py:202 pysollib/tk/toolbar.py:211
-msgid "Toolbar"
-msgstr "Pasek narzedziowy"
 
 #: pysollib/tile/toolbar.py:209 pysollib/tk/toolbar.py:206
 msgid "Player"
@@ -3544,15 +4048,15 @@ msgstr "Wybierz nazwę"
 msgid "Enable samles"
 msgstr "Włącz dźwięki"
 
-#: pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:508
 msgid "&Reset all..."
 msgstr "&Resetuj wszystko..."
 
-#: pysollib/tk/tkstats.py:574
+#: pysollib/tk/tkstats.py:575
 msgid "Session &log..."
 msgstr "&Log sesji..."
 
-#: pysollib/tk/tkstats.py:591
+#: pysollib/tk/tkstats.py:592
 msgid "&Full log..."
 msgstr "Kompletny log..."
 
@@ -4006,10 +4510,6 @@ msgstr "znajdź kartę"
 msgid "Compound"
 msgstr "Układ"
 
-#: pysollib/ui/tktile/menubar.py:41
-msgid "Hide"
-msgstr "Ukryj"
-
 #: pysollib/ui/tktile/menubar.py:44
 msgid "Top"
 msgstr "Góra"
@@ -4018,21 +4518,14 @@ msgstr "Góra"
 msgid "Bottom"
 msgstr "Dół"
 
-#: pysollib/ui/tktile/menubar.py:50
-msgid "Left"
-msgstr "Lewa strona"
-
-#: pysollib/ui/tktile/menubar.py:53
-msgid "Right"
-msgstr "Prawa strona"
-
 #: pysollib/ui/tktile/menubar.py:64
 msgid "Visible buttons"
 msgstr "Widoczne przyciski"
 
-#: pysollib/ui/tktile/menubar.py:296 pysollib/ui/tktile/menubar.py:666
-msgid "&About "
-msgstr "&O grze"
+#: pysollib/ui/tktile/menubar.py:296
+#, fuzzy, python-format
+msgid "&About %s"
+msgstr "O programie"
 
 #: pysollib/ui/tktile/menubar.py:298
 msgid "&File"
@@ -4332,10 +4825,6 @@ msgstr "Cieniuj dozwo&lone ruchy"
 msgid "&Negative cards bottom"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:559
-msgid "Shrink face-down cards"
-msgstr "Pomniejszaj karty obrócone tyłem"
-
 #: pysollib/ui/tktile/menubar.py:563
 msgid "Shade &filled stacks"
 msgstr "Cieniuj wypełnione stosy"
@@ -4460,6 +4949,11 @@ msgstr "Zasady tej g&ry"
 msgid "&License terms"
 msgstr "Warunki &licencji"
 
+#: pysollib/ui/tktile/menubar.py:666
+#, fuzzy, python-format
+msgid "&About %s..."
+msgstr "O programie"
+
 #: pysollib/ui/tktile/menubar.py:796
 msgid "All &games..."
 msgstr "Wszystkie gry..."
@@ -4497,29 +4991,29 @@ msgstr "Własne gry"
 msgid "&All games by name"
 msgstr "Gry według n&azwy"
 
-#: pysollib/ui/tktile/menubar.py:1177
+#: pysollib/ui/tktile/menubar.py:1179
 #, fuzzy
 msgid "Export game error"
 msgstr "Błąd wczytywania gry"
 
-#: pysollib/ui/tktile/menubar.py:1178
+#: pysollib/ui/tktile/menubar.py:1180
 msgid ""
 "\n"
 "Unsupported game for export.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1214 pysollib/ui/tktile/menubar.py:1248
+#: pysollib/ui/tktile/menubar.py:1216 pysollib/ui/tktile/menubar.py:1250
 #, fuzzy
 msgid "Import game error"
 msgstr "Błąd wczytywania gry"
 
-#: pysollib/ui/tktile/menubar.py:1215
+#: pysollib/ui/tktile/menubar.py:1217
 msgid ""
 "\n"
 "Unsupported game for import.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1676
+#: pysollib/ui/tktile/menubar.py:1678
 #, python-format
 msgid ""
 "\n"
@@ -4531,6 +5025,11 @@ msgstr ""
 "Błąd podczas zapisywania gry.\n"
 "\n"
 "%s\n"
+
+#: pysollib/ui/tktile/solverdialog.py:28
+#, fuzzy, python-format
+msgid "%(app)s - FreeCell Solver"
+msgstr "&Demo logo"
 
 #: pysollib/ui/tktile/solverdialog.py:44 data/pysolfc.glade:74
 #: data/pysolfc.glade:1250
@@ -4622,6 +5121,31 @@ msgstr "Ruchy ogółem"
 msgid "Set font"
 msgstr "Ustaw czcionkę"
 
+#~ msgid "Statistics for "
+#~ msgstr "Statystyki dla "
+
+#~ msgid "Full log for "
+#~ msgstr "Kompletny log dla "
+
+#~ msgid "Session log for "
+#~ msgstr "Lod sesji dla "
+
+#~ msgid "Round %d/%d"
+#~ msgstr "Runda %d/%d"
+
+#~ msgid "Error while loading "
+#~ msgstr "Błąd podczas wczytywania"
+
+#~ msgid "Your statistics"
+#~ msgstr "Twoje statystyki"
+
+#~ msgid ""
+#~ " were appended to\n"
+#~ "\n"
+#~ msgstr ""
+#~ " zostały dołączone do\n"
+#~ "\n"
+
 #~ msgid "Solving method:"
 #~ msgstr "Metoda rozwiązania:"
 
@@ -4630,9 +5154,6 @@ msgstr "Ustaw czcionkę"
 
 #~ msgid "&Statistics"
 #~ msgstr "&Statystyki"
-
-#~ msgid "Current game..."
-#~ msgstr "Bieżąca gra..."
 
 #~ msgid "All games..."
 #~ msgstr "Wszystkie gry..."

--- a/po/pysol.pot
+++ b/po/pysol.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-18 19:36+0300\n"
+"POT-Creation-Date: 2019-08-31 11:25+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,14 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: pysollib/actions.py:232 pysollib/kivy/toolbar.py:191
-#: pysollib/tile/toolbar.py:176 pysollib/tk/toolbar.py:176
+#: pysollib/actions.py:232 pysollib/kivy/menubar.py:291
+#: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
+#: pysollib/tk/toolbar.py:176
 msgid "New game"
 msgstr ""
 
 #: pysollib/actions.py:247 pysollib/kivy/menubar.py:1667
-#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1014
-#: pysollib/ui/tktile/menubar.py:1030
+#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1015
+#: pysollib/ui/tktile/menubar.py:1031
 msgid "Select game"
 msgstr ""
 
@@ -52,19 +53,19 @@ msgid ""
 "Enter new game number"
 msgstr ""
 
-#: pysollib/actions.py:293 pysollib/app.py:523 pysollib/app.py:817
-#: pysollib/game/__init__.py:1270 pysollib/game/__init__.py:2487
-#: pysollib/kivy/tkhtml.py:690 pysollib/kivy/tkstats.py:249
+#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/app.py:818
+#: pysollib/game/__init__.py:1305 pysollib/game/__init__.py:2526
+#: pysollib/kivy/tkhtml.py:691 pysollib/kivy/tkstats.py:254
 #: pysollib/kivy/tkwidget.py:97 pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/pysolgtk/tkhtml.py:542
-#: pysollib/pysolgtk/tkstats.py:556 pysollib/pysolgtk/tkwidget.py:151
+#: pysollib/pysolgtk/tkstats.py:557 pysollib/pysolgtk/tkwidget.py:151
 #: pysollib/tile/fontsdialog.py:140 pysollib/tile/fontsdialog.py:202
 #: pysollib/tile/menubar.py:111 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:545
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/soundoptionsdialog.py:188 pysollib/tile/timeoutsdialog.py:92
-#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:540
-#: pysollib/tile/tkstats.py:645 pysollib/tile/tkstats.py:726
+#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:541
+#: pysollib/tile/tkstats.py:646 pysollib/tile/tkstats.py:727
 #: pysollib/tile/tkwidget.py:138 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/playeroptionsdialog.py:64
@@ -72,10 +73,10 @@ msgstr ""
 #: pysollib/tk/selectcardset.py:506 pysollib/tk/selecttile.py:152
 #: pysollib/tk/soundoptionsdialog.py:152 pysollib/tk/soundoptionsdialog.py:193
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkstats.py:278
-#: pysollib/tk/tkstats.py:505 pysollib/tk/tkstats.py:574
-#: pysollib/tk/tkstats.py:591 pysollib/tk/tkstats.py:639
-#: pysollib/tk/tkstats.py:712 pysollib/tk/tkstats.py:796
-#: pysollib/tk/tkstats.py:963 pysollib/tk/tkwidget.py:143
+#: pysollib/tk/tkstats.py:506 pysollib/tk/tkstats.py:575
+#: pysollib/tk/tkstats.py:592 pysollib/tk/tkstats.py:640
+#: pysollib/tk/tkstats.py:713 pysollib/tk/tkstats.py:797
+#: pysollib/tk/tkstats.py:964 pysollib/tk/tkwidget.py:143
 #: pysollib/tk/tkwidget.py:351 pysollib/tk/wizarddialog.py:132
 #: pysollib/ui/tktile/colorsdialog.py:118
 #: pysollib/ui/tktile/edittextdialog.py:38
@@ -87,24 +88,24 @@ msgstr ""
 msgid "&Next number"
 msgstr ""
 
-#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/game/__init__.py:1270
-#: pysollib/game/__init__.py:1939 pysollib/game/__init__.py:1957
-#: pysollib/game/__init__.py:1965 pysollib/game/__init__.py:1972
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2068
-#: pysollib/kivy/selectcardset.py:61
+#: pysollib/actions.py:293 pysollib/app.py:525 pysollib/game/__init__.py:1305
+#: pysollib/game/__init__.py:1979 pysollib/game/__init__.py:1995
+#: pysollib/game/__init__.py:2003 pysollib/game/__init__.py:2010
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2069
+#: pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/pysolgtk/selectgame.py:324
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/tile/fontsdialog.py:140
 #: pysollib/tile/fontsdialog.py:202 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:543
-#: pysollib/tile/selectgame.py:308 pysollib/tile/selectgame.py:438
+#: pysollib/tile/selectgame.py:306 pysollib/tile/selectgame.py:436
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/timeoutsdialog.py:92 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/menubar.py:89
 #: pysollib/tk/menubar.py:90 pysollib/tk/playeroptionsdialog.py:64
 #: pysollib/tk/playeroptionsdialog.py:138 pysollib/tk/selectcardset.py:313
-#: pysollib/tk/selectgame.py:310 pysollib/tk/selectgame.py:439
+#: pysollib/tk/selectgame.py:306 pysollib/tk/selectgame.py:437
 #: pysollib/tk/selecttile.py:152 pysollib/tk/soundoptionsdialog.py:152
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkwidget.py:351
 #: pysollib/tk/wizarddialog.py:132 pysollib/ui/tktile/colorsdialog.py:118
@@ -122,7 +123,8 @@ msgstr ""
 
 #: pysollib/actions.py:384 pysollib/kivy/toolbar.py:206
 #: pysollib/tile/toolbar.py:191 pysollib/tk/toolbar.py:191
-msgid "Quit "
+#, python-format
+msgid "Quit %s"
 msgstr ""
 
 #: pysollib/actions.py:447
@@ -130,185 +132,211 @@ msgid "Clear bookmarks"
 msgstr ""
 
 #: pysollib/actions.py:448
-msgid "Clear all bookmarks ?"
+msgid "Clear all bookmarks?"
 msgstr ""
 
-#: pysollib/actions.py:459
+#: pysollib/actions.py:459 pysollib/kivy/menubar.py:293
 msgid "Restart game"
 msgstr ""
 
 #: pysollib/actions.py:460
-msgid "Restart this game ?"
+msgid "Restart this game?"
 msgstr ""
 
-#: pysollib/actions.py:505
+#: pysollib/actions.py:506
 #, python-format
 msgid ""
-"Comments for %s:\n"
+"Comments for %(game)s %(id)s:\n"
 "\n"
 msgstr ""
 
-#: pysollib/actions.py:507
-msgid "Comments for "
+#: pysollib/actions.py:508
+#, python-format
+msgid "Comments for %(id)s"
 msgstr ""
 
-#: pysollib/actions.py:525 pysollib/actions.py:549
+#: pysollib/actions.py:526 pysollib/actions.py:551
 msgid "Error while writing to file"
 msgstr ""
 
-#: pysollib/actions.py:528 pysollib/actions.py:552
-msgid " Info"
+#: pysollib/actions.py:529 pysollib/actions.py:554
+#, python-format
+msgid "%s Info"
 msgstr ""
 
-#: pysollib/actions.py:529
+#: pysollib/actions.py:530
+#, python-format
 msgid ""
 "Comments were appended to\n"
 "\n"
+"%(filename)s"
 msgstr ""
 
-#: pysollib/actions.py:538
-msgid "Demo statistics"
-msgstr ""
-
-#: pysollib/actions.py:541
-msgid "Your statistics"
-msgstr ""
-
-#: pysollib/actions.py:553
+#: pysollib/actions.py:540
+#, python-format
 msgid ""
-" were appended to\n"
+"Demo statistics were appended to\n"
 "\n"
+"%(filename)s"
 msgstr ""
 
-#: pysollib/actions.py:567
-msgid " Demo"
+#: pysollib/actions.py:543
+#, python-format
+msgid ""
+"Your statistics were appended to\n"
+"\n"
+"%(filename)s"
 msgstr ""
 
-#: pysollib/actions.py:567
-msgid " Demo "
+#: pysollib/actions.py:581
+#, python-format
+msgid "%(app)s Demo Statistics for %(game)s"
 msgstr ""
 
-#: pysollib/actions.py:570 pysollib/actions.py:591
-msgid " for "
+#: pysollib/actions.py:582
+#, python-format
+msgid "Statistics for %(game)s"
 msgstr ""
 
-#: pysollib/actions.py:576 pysollib/stats.py:202
-msgid "Statistics for "
+#: pysollib/actions.py:587
+#, python-format
+msgid "%(app)s Demo Statistics"
 msgstr ""
 
-#: pysollib/actions.py:581 pysollib/kivy/menubar.py:1613
-#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:176
-#: pysollib/tile/selectgame.py:387 pysollib/tile/tkstats.py:51
-#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:387
-#: pysollib/tk/toolbar.py:188
-msgid "Statistics"
+#: pysollib/actions.py:588 pysollib/stats.py:202
+#, python-format
+msgid "Statistics for %(player)s"
 msgstr ""
 
-#: pysollib/actions.py:585 pysollib/tile/tkstats.py:522 data/pysolfc.glade:1404
-msgid "Full log"
+#: pysollib/actions.py:592
+#, python-format
+msgid "%(app)s Demo Full log"
 msgstr ""
 
-#: pysollib/actions.py:588 pysollib/tile/tkstats.py:526 data/pysolfc.glade:1466
-msgid "Session log"
+#: pysollib/actions.py:593 pysollib/stats.py:235
+#, python-format
+msgid "Full log for %(player)s"
 msgstr ""
 
-#: pysollib/actions.py:595
+#: pysollib/actions.py:596
+#, python-format
+msgid "%(app)s Demo Session log"
+msgstr ""
+
+#: pysollib/actions.py:597 pysollib/stats.py:242
+#, python-format
+msgid "Session log for %(player)s"
+msgstr ""
+
+#. TRANSLATORS: eg. top 10 or top 5 results for a certain game
+#: pysollib/actions.py:601
+#, python-format
+msgid "%(app)s Demo Top %(tops)d for %(game)s"
+msgstr ""
+
+#: pysollib/actions.py:602
+#, python-format
+msgid "Top %(tops)d for %(game)s"
+msgstr ""
+
+#: pysollib/actions.py:606
 msgid "Game Info"
 msgstr ""
 
-#: pysollib/actions.py:598
+#: pysollib/actions.py:609
 msgid "Statistics progression"
 msgstr ""
 
-#: pysollib/actions.py:616
+#: pysollib/actions.py:627
 msgid "Reset all statistics"
 msgstr ""
 
-#: pysollib/actions.py:617
+#: pysollib/actions.py:628
 #, python-format
 msgid ""
 "Reset ALL statistics and logs for player\n"
-"%s ?"
+"%(player)s?"
 msgstr ""
 
-#: pysollib/actions.py:626
+#: pysollib/actions.py:638
 msgid "Reset game statistics"
 msgstr ""
 
-#: pysollib/actions.py:627
+#: pysollib/actions.py:639
 #, python-format
 msgid ""
 "Reset statistics and logs for player\n"
-"%s\n"
+"%(player)s\n"
 "and game\n"
-"%s ?"
-msgstr ""
-
-#: pysollib/actions.py:692
-msgid "Play demo"
+"%(game)s?"
 msgstr ""
 
 #: pysollib/actions.py:704
+msgid "Play demo"
+msgstr ""
+
+#: pysollib/actions.py:716
 msgid "Set player options"
 msgstr ""
 
-#: pysollib/actions.py:720 data/pysolfc.glade:1986
+#: pysollib/actions.py:732 data/pysolfc.glade:1986
 msgid "Set colors"
 msgstr ""
 
-#: pysollib/actions.py:738
+#: pysollib/actions.py:750
 msgid "Set fonts"
 msgstr ""
 
-#: pysollib/actions.py:748 data/pysolfc.glade:1493
+#: pysollib/actions.py:760 data/pysolfc.glade:1493
 msgid "Set timeouts"
 msgstr ""
 
 #: pysollib/app.py:332
-msgid "can't find game: "
+#, python-format
+msgid "can't find game: %(game)s"
 msgstr ""
 
-#: pysollib/app.py:525 pysollib/game/__init__.py:1939
-#: pysollib/game/__init__.py:1957 pysollib/game/__init__.py:1965
-#: pysollib/game/__init__.py:1972 pysollib/ui/tktile/menubar.py:300
+#: pysollib/app.py:526 pysollib/game/__init__.py:1979
+#: pysollib/game/__init__.py:1995 pysollib/game/__init__.py:2003
+#: pysollib/game/__init__.py:2010 pysollib/ui/tktile/menubar.py:300
 msgid "&New game"
 msgstr ""
 
-#: pysollib/app.py:671
+#: pysollib/app.py:672
 #, python-format
-msgid "Loading %s %s..."
-msgstr ""
-
-#: pysollib/app.py:713
-msgid " load error"
+msgid "Loading cardset %s..."
 msgstr ""
 
 #: pysollib/app.py:714
-msgid "Error while loading "
+msgid "Cardset load error"
 msgstr ""
 
-#: pysollib/app.py:809
-msgid "Incompatible "
+#: pysollib/app.py:715
+msgid "Error while loading cardset"
 msgstr ""
 
-#: pysollib/app.py:811
+#: pysollib/app.py:810
+msgid "Incompatible cardset"
+msgstr ""
+
+#: pysollib/app.py:812
 #, python-format
 msgid ""
-"The currently selected %s %s\n"
+"The currently selected cardset %(cardset)s\n"
 "is not compatible with the game\n"
-"%s\n"
+"%(game)s\n"
 "\n"
-"Please select a %s type %s.\n"
+"Please select a %(correct_type)s type cardset.\n"
 msgstr ""
 
-#: pysollib/app.py:855
+#: pysollib/app.py:856
 #, python-format
-msgid "Please select a %s type %s"
+msgid "Please select a %s type cardset"
 msgstr ""
 
-#: pysollib/app.py:1063
+#: pysollib/app.py:1064
 #, python-format
-msgid "error loading plugin %s: %s"
+msgid "error loading plugin %(file)s: %(err)s"
 msgstr ""
 
 #: pysollib/gamedb.py:109
@@ -520,11 +548,11 @@ msgid "Puzzle type"
 msgstr ""
 
 #: pysollib/help.py:43
-msgid "A Python Solitaire Game Collection\n"
+msgid "A Python Solitaire Game Collection"
 msgstr ""
 
 #: pysollib/help.py:45
-msgid "A World Domination Project\n"
+msgid "A World Domination Project"
 msgstr ""
 
 #: pysollib/help.py:46
@@ -545,14 +573,16 @@ msgid "Version %s"
 msgstr ""
 
 #: pysollib/help.py:50
-msgid "About "
+#, python-format
+msgid "About %s"
 msgstr ""
 
 #: pysollib/help.py:52
 #, python-format
 msgid ""
 "PySol Fan Club edition\n"
-"%s%s\n"
+"%(description)s\n"
+"%(versioninfo)s\n"
 "\n"
 "Copyright (C) 1998 - 2003 Markus F.X.J. Oberhumer.\n"
 "Copyright (C) 2003 Mt. Hood Playing Card Co.\n"
@@ -565,14 +595,14 @@ msgid ""
 "For more information about this application visit"
 msgstr ""
 
-#: pysollib/help.py:88
+#: pysollib/help.py:90
 msgid "Credits"
 msgstr ""
 
-#: pysollib/help.py:89
+#: pysollib/help.py:91
 #, python-format
 msgid ""
-" credits go to:\n"
+"%(app)s credits go to:\n"
 "\n"
 "Volker Weidner for getting me into Solitaire\n"
 "Guido van Rossum for the initial example program\n"
@@ -581,20 +611,25 @@ msgid ""
 "The Gnome AisleRiot team for parts of the documentation\n"
 "Natascha\n"
 "\n"
-"The Python, %s, SDL & Linux crews\n"
+"The Python, %(gui_library)s, SDL & Linux crews\n"
 "for making this program possible"
 msgstr ""
 
-#: pysollib/help.py:125
-msgid " HTML Problem"
+#: pysollib/help.py:127 pysollib/kivy/tkhtml.py:687
+#, python-format
+msgid "%s HTML Problem"
 msgstr ""
 
-#: pysollib/help.py:126
-msgid "Cannot find help document\n"
+#: pysollib/help.py:128
+#, python-format
+msgid ""
+"Cannot find help document\n"
+"%s"
 msgstr ""
 
-#: pysollib/help.py:139
-msgid " Help"
+#: pysollib/help.py:141
+#, python-format
+msgid "%s Help"
 msgstr ""
 
 #: pysollib/main.py:58 pysollib/main.py:70 pysollib/main.py:304
@@ -605,15 +640,15 @@ msgstr ""
 #: pysollib/main.py:59
 #, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Cardsets should be installed into:\n"
-"%s/cardsets/\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 
-#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:312
+#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:313
 #: pysollib/ui/tktile/menubar.py:346
 msgid "&Quit"
 msgstr ""
@@ -621,19 +656,17 @@ msgstr ""
 #: pysollib/main.py:71
 #, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 
 #: pysollib/main.py:96
 #, python-format
-msgid ""
-"%s\n"
-"try %s --help for more information"
+msgid "try %s --help for more information"
 msgstr ""
 
 #: pysollib/main.py:128
@@ -679,12 +712,12 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"No games were found !!!\n"
+"No games were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 
 #: pysollib/options.py:266
@@ -1030,7 +1063,7 @@ msgstr ""
 
 #: pysollib/stack.py:1948
 #, python-format
-msgid "%d readeal"
+msgid "%d redeal"
 msgid_plural "%d redeals"
 msgstr[0] ""
 msgstr[1] ""
@@ -1219,66 +1252,66 @@ msgstr ""
 msgid "Free cell."
 msgstr ""
 
-#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:421
-#: pysollib/pysolgtk/tkstats.py:458 pysollib/tile/tkstats.py:674
+#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:422
+#: pysollib/pysolgtk/tkstats.py:459 pysollib/tile/tkstats.py:675
 msgid "Game"
 msgstr ""
 
-#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:422
-#: pysollib/tile/tkstats.py:908 pysollib/tile/tkstats.py:977
-#: pysollib/tile/tkstats.py:978 pysollib/tk/tkstats.py:886
-#: pysollib/tk/tkstats.py:887 pysollib/tk/tkstats.py:934
+#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:423
+#: pysollib/tile/tkstats.py:909 pysollib/tile/tkstats.py:978
+#: pysollib/tile/tkstats.py:979 pysollib/tk/tkstats.py:887
+#: pysollib/tk/tkstats.py:888 pysollib/tk/tkstats.py:935
 msgid "Played"
 msgstr ""
 
-#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:423
-#: pysollib/tile/tkstats.py:914 pysollib/tile/tkstats.py:982
-#: pysollib/tile/tkstats.py:983 pysollib/tk/tkstats.py:891
-#: pysollib/tk/tkstats.py:892 pysollib/tk/tkstats.py:942
+#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/tile/tkstats.py:915 pysollib/tile/tkstats.py:983
+#: pysollib/tile/tkstats.py:984 pysollib/tk/tkstats.py:892
+#: pysollib/tk/tkstats.py:893 pysollib/tk/tkstats.py:943
 msgid "Won"
 msgstr ""
 
-#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:425
 msgid "Lost"
 msgstr ""
 
 #: pysollib/stats.py:44 pysollib/pysolgtk/statusbar.py:98
-#: pysollib/pysolgtk/tkstats.py:425 pysollib/tile/statusbar.py:154
+#: pysollib/pysolgtk/tkstats.py:426 pysollib/tile/statusbar.py:154
 #: pysollib/tk/statusbar.py:151 data/pysolfc.glade:1133
 msgid "Playing time"
 msgstr ""
 
-#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:426
+#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:427
 #: data/pysolfc.glade:1178
 msgid "Moves"
 msgstr ""
 
-#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:427
-#: pysollib/tile/tkstats.py:920 pysollib/tile/tkstats.py:950
-#: pysollib/tile/tkstats.py:969 pysollib/tile/tkstats.py:987
-#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:878
-#: pysollib/tk/tkstats.py:896 pysollib/tk/tkstats.py:950
+#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:428
+#: pysollib/tile/tkstats.py:921 pysollib/tile/tkstats.py:951
+#: pysollib/tile/tkstats.py:970 pysollib/tile/tkstats.py:988
+#: pysollib/tk/tkstats.py:860 pysollib/tk/tkstats.py:879
+#: pysollib/tk/tkstats.py:897 pysollib/tk/tkstats.py:951
 msgid "% won"
 msgstr ""
 
 #: pysollib/stats.py:108 pysollib/pysolgtk/statusbar.py:100
-#: pysollib/pysolgtk/tkstats.py:389 pysollib/pysolgtk/tkstats.py:459
-#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:677
-#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:670
+#: pysollib/pysolgtk/tkstats.py:390 pysollib/pysolgtk/tkstats.py:460
+#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:678
+#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:671
 msgid "Game number"
 msgstr ""
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:390
-#: pysollib/pysolgtk/tkstats.py:460 pysollib/tile/tkstats.py:680
-#: pysollib/tk/tkstats.py:673
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:391
+#: pysollib/pysolgtk/tkstats.py:461 pysollib/tile/tkstats.py:681
+#: pysollib/tk/tkstats.py:674
 msgid "Started at"
 msgstr ""
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:461
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:462
 msgid "Status"
 msgstr ""
 
-#: pysollib/stats.py:132 pysollib/tile/tkstats.py:696
+#: pysollib/stats.py:132 pysollib/tile/tkstats.py:697
 #, python-format
 msgid "** UNKNOWN %d **"
 msgstr ""
@@ -1299,22 +1332,15 @@ msgstr ""
 msgid "Perfect"
 msgstr ""
 
-#: pysollib/stats.py:201 pysollib/stats.py:233 pysollib/stats.py:240
+#: pysollib/stats.py:201 pysollib/stats.py:234 pysollib/stats.py:241
+#: pysollib/kivy/menubar.py:443
 msgid "Demo"
 msgstr ""
 
 #: pysollib/stats.py:212 pysollib/pysolgtk/tkstats.py:70
 #: pysollib/tile/tkstats.py:371 pysollib/tk/tkstats.py:413
 #, python-format
-msgid "Total (%d out of %d games)"
-msgstr ""
-
-#: pysollib/stats.py:234
-msgid "Full log for "
-msgstr ""
-
-#: pysollib/stats.py:241
-msgid "Session log for "
+msgid "Total (%(played)d out of %(total)d games)"
 msgstr ""
 
 #: pysollib/util.py:45
@@ -1382,48 +1408,48 @@ msgid "Initial setting:"
 msgstr ""
 
 #: pysollib/wizardutil.py:105 pysollib/pysolgtk/selectgame.py:114
-#: pysollib/tile/selectgame.py:393 pysollib/tk/selectgame.py:395
+#: pysollib/tile/selectgame.py:391 pysollib/tk/selectgame.py:392
 msgid "Name:"
 msgstr ""
 
 #: pysollib/wizardutil.py:109 pysollib/kivy/selectgame.py:202
 #: pysollib/pysolgtk/selectgame.py:236 pysollib/pysolgtk/selectgame.py:473
-#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:563
-#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:564
+#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:561
+#: pysollib/tk/selectgame.py:179 pysollib/tk/selectgame.py:562
 msgid "Luck only"
 msgstr ""
 
 #: pysollib/wizardutil.py:110 pysollib/kivy/selectgame.py:204
 #: pysollib/pysolgtk/selectgame.py:237 pysollib/pysolgtk/selectgame.py:474
-#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:564
-#: pysollib/tk/selectgame.py:183 pysollib/tk/selectgame.py:565
+#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:562
+#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:563
 msgid "Mostly luck"
 msgstr ""
 
 #: pysollib/wizardutil.py:111 pysollib/wizardutil.py:115
 #: pysollib/kivy/selectgame.py:206 pysollib/pysolgtk/selectgame.py:238
 #: pysollib/pysolgtk/selectgame.py:475 pysollib/tile/selectgame.py:183
-#: pysollib/tile/selectgame.py:565 pysollib/tk/selectgame.py:185
-#: pysollib/tk/selectgame.py:566
+#: pysollib/tile/selectgame.py:563 pysollib/tk/selectgame.py:183
+#: pysollib/tk/selectgame.py:564
 msgid "Balanced"
 msgstr ""
 
 #: pysollib/wizardutil.py:112 pysollib/kivy/selectgame.py:208
 #: pysollib/pysolgtk/selectgame.py:239 pysollib/pysolgtk/selectgame.py:476
-#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:566
-#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:567
+#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:564
+#: pysollib/tk/selectgame.py:186 pysollib/tk/selectgame.py:565
 msgid "Mostly skill"
 msgstr ""
 
 #: pysollib/wizardutil.py:113 pysollib/kivy/selectgame.py:210
 #: pysollib/pysolgtk/selectgame.py:240 pysollib/pysolgtk/selectgame.py:477
-#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:567
-#: pysollib/tk/selectgame.py:190 pysollib/tk/selectgame.py:568
+#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:565
+#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:566
 msgid "Skill only"
 msgstr ""
 
 #: pysollib/wizardutil.py:116 pysollib/pysolgtk/selectgame.py:118
-#: pysollib/tile/selectgame.py:397 pysollib/tk/selectgame.py:399
+#: pysollib/tile/selectgame.py:395 pysollib/tk/selectgame.py:396
 msgid "Skill level:"
 msgstr ""
 
@@ -1478,8 +1504,8 @@ msgstr ""
 #: pysollib/wizardutil.py:147 pysollib/wizardutil.py:185
 #: pysollib/wizardutil.py:243 pysollib/wizardutil.py:301
 #: pysollib/pysolgtk/selectgame.py:117 pysollib/tile/selectcardset.py:454
-#: pysollib/tile/selectgame.py:396 pysollib/tk/selectcardset.py:445
-#: pysollib/tk/selectgame.py:398
+#: pysollib/tile/selectgame.py:394 pysollib/tk/selectcardset.py:445
+#: pysollib/tk/selectgame.py:395
 msgid "Type:"
 msgstr ""
 
@@ -1501,7 +1527,7 @@ msgstr ""
 
 #: pysollib/wizardutil.py:155 pysollib/kivy/selectgame.py:252
 #: pysollib/pysolgtk/selectgame.py:273 pysollib/tile/selectgame.py:231
-#: pysollib/tk/selectgame.py:233
+#: pysollib/tk/selectgame.py:231
 msgid "Unlimited redeals"
 msgstr ""
 
@@ -1571,6 +1597,7 @@ msgid "Direction:"
 msgstr ""
 
 #: pysollib/wizardutil.py:204 pysollib/wizardutil.py:250
+#: pysollib/kivy/menubar.py:884
 msgid "None"
 msgstr ""
 
@@ -1695,121 +1722,110 @@ msgstr ""
 msgid "Opening deal"
 msgstr ""
 
-#: pysollib/game/__init__.py:139 pysollib/game/__init__.py:145
+#: pysollib/game/__init__.py:140 pysollib/game/__init__.py:146
 msgid "Player\n"
 msgstr ""
 
-#: pysollib/game/__init__.py:1266
-msgid "Discard current game ?"
+#: pysollib/game/__init__.py:1301
+msgid "Discard current game?"
 msgstr ""
 
-#: pysollib/game/__init__.py:1887
+#: pysollib/game/__init__.py:1922
 #, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of playing time\n"
-"and # %d in the %s of moves."
+"# %(timerank)d in the top %(tops)d of playing time\n"
+"and # %(movesrank)d in the top %(tops)d of moves."
 msgstr ""
 
-#: pysollib/game/__init__.py:1893
+#: pysollib/game/__init__.py:1930
 #, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of playing time."
+"# %(timerank)d in the top %(tops)d of playing time."
 msgstr ""
 
-#: pysollib/game/__init__.py:1898
+#: pysollib/game/__init__.py:1936
 #, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of moves."
+"# %(movesrank)d in the top %(tops)s of moves."
 msgstr ""
 
-#: pysollib/game/__init__.py:1931 pysollib/game/__init__.py:1947
+#: pysollib/game/__init__.py:1971 pysollib/game/__init__.py:1987
 #, python-format
 msgid ""
-"Your playing time is %s\n"
-"for %d move."
+"Your playing time is %(time)s\n"
+"for %(n)d move."
 msgid_plural ""
-"Your playing time is %s\n"
-"for %d moves."
+"Your playing time is %(time)s\n"
+"for %(n)d moves."
 msgstr[0] ""
 msgstr[1] ""
 
-#: pysollib/game/__init__.py:1936 pysollib/game/__init__.py:1952
-#: pysollib/pysolgtk/soundoptionsdialog.py:71
+#: pysollib/game/__init__.py:1975
+msgid ""
+"Congratulations, this\n"
+"was a truly perfect game!"
+msgstr ""
+
+#: pysollib/game/__init__.py:1977 pysollib/game/__init__.py:1993
+#: pysollib/kivy/tkwidget.py:170 pysollib/pysolgtk/soundoptionsdialog.py:71
 #: pysollib/tile/soundoptionsdialog.py:83 pysollib/tk/soundoptionsdialog.py:85
 msgid "Game won"
 msgstr ""
 
-#: pysollib/game/__init__.py:1937
-#, python-format
-msgid ""
-"\n"
-"Congratulations, this\n"
-"was a truly perfect game !\n"
-"\n"
-"%s\n"
-"%s\n"
+#: pysollib/game/__init__.py:1991
+msgid "Congratulations, you did it!"
 msgstr ""
 
-#: pysollib/game/__init__.py:1954
-#, python-format
-msgid ""
-"\n"
-"Congratulations, you did it !\n"
-"\n"
-"%s\n"
-"%s\n"
-msgstr ""
-
-#: pysollib/game/__init__.py:1963 pysollib/game/__init__.py:1970
-#: pysollib/pysolgtk/soundoptionsdialog.py:69
+#: pysollib/game/__init__.py:2001 pysollib/game/__init__.py:2008
+#: pysollib/kivy/tkwidget.py:173 pysollib/pysolgtk/soundoptionsdialog.py:69
 #: pysollib/tile/soundoptionsdialog.py:81 pysollib/tk/soundoptionsdialog.py:83
 msgid "Game finished"
 msgstr ""
 
-#: pysollib/game/__init__.py:1964 pysollib/game/__init__.py:2488
+#: pysollib/game/__init__.py:2002 pysollib/game/__init__.py:2527
 msgid ""
 "\n"
 "Game finished\n"
 msgstr ""
 
-#: pysollib/game/__init__.py:1971
+#: pysollib/game/__init__.py:2009
 msgid ""
 "\n"
 "Game finished, but not without my help...\n"
 msgstr ""
 
-#: pysollib/game/__init__.py:1972
+#: pysollib/game/__init__.py:2010
 msgid "&Restart"
 msgstr ""
 
-#: pysollib/game/__init__.py:2368
+#: pysollib/game/__init__.py:2406
 #, python-format
 msgid "Score %6d"
 msgstr ""
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 msgid "&Great"
 msgstr ""
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 msgid "&Cool"
 msgstr ""
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 msgid "&Yeah"
 msgstr ""
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 msgid "&Wow"
 msgstr ""
 
-#: pysollib/game/__init__.py:2474
+#: pysollib/game/__init__.py:2512
 #, python-format
 msgid ""
 "\n"
@@ -1820,57 +1836,58 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: pysollib/game/__init__.py:2478 pysollib/game/__init__.py:2492
-#: pysollib/game/__init__.py:2506
-msgid " Autopilot"
+#: pysollib/game/__init__.py:2517 pysollib/game/__init__.py:2532
+#: pysollib/game/__init__.py:2547
+#, python-format
+msgid "%s Autopilot"
 msgstr ""
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Oh well"
 msgstr ""
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&That's life"
 msgstr ""
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Hmm"
 msgstr ""
 
-#: pysollib/game/__init__.py:2507
+#: pysollib/game/__init__.py:2548
 msgid ""
 "\n"
 "This won't come out...\n"
 msgstr ""
 
-#: pysollib/game/__init__.py:2966
+#: pysollib/game/__init__.py:3000
 msgid "Set bookmark"
 msgstr ""
 
-#: pysollib/game/__init__.py:2967
+#: pysollib/game/__init__.py:3001
 #, python-format
-msgid "Replace existing bookmark %d ?"
+msgid "Replace existing bookmark %d?"
 msgstr ""
 
-#: pysollib/game/__init__.py:2988
+#: pysollib/game/__init__.py:3022
 msgid "Goto bookmark"
 msgstr ""
 
-#: pysollib/game/__init__.py:2989
+#: pysollib/game/__init__.py:3023
 #, python-format
-msgid "Goto bookmark %d ?"
+msgid "Goto bookmark %d?"
 msgstr ""
 
-#: pysollib/game/__init__.py:3015
+#: pysollib/game/__init__.py:3049
 msgid "Open game"
 msgstr ""
 
-#: pysollib/game/__init__.py:3028 pysollib/game/__init__.py:3037
-#: pysollib/game/__init__.py:3043
+#: pysollib/game/__init__.py:3062 pysollib/game/__init__.py:3071
+#: pysollib/game/__init__.py:3077
 msgid "Load game error"
 msgstr ""
 
-#: pysollib/game/__init__.py:3030
+#: pysollib/game/__init__.py:3064
 msgid ""
 "Error while loading game.\n"
 "\n"
@@ -1878,38 +1895,38 @@ msgid ""
 "but this could also be a bug you might want to report."
 msgstr ""
 
-#: pysollib/game/__init__.py:3038
+#: pysollib/game/__init__.py:3072
 msgid "Error while loading game"
 msgstr ""
 
-#: pysollib/game/__init__.py:3045
+#: pysollib/game/__init__.py:3079
 msgid ""
 "Internal error while loading game.\n"
 "\n"
 "Please report this bug."
 msgstr ""
 
-#: pysollib/game/__init__.py:3071 pysollib/ui/tktile/menubar.py:1675
+#: pysollib/game/__init__.py:3105 pysollib/ui/tktile/menubar.py:1677
 msgid "Save game error"
 msgstr ""
 
-#: pysollib/game/__init__.py:3072
+#: pysollib/game/__init__.py:3106
 msgid "Error while saving game"
 msgstr ""
 
-#: pysollib/game/__init__.py:3091
+#: pysollib/game/__init__.py:3125
 #, python-format
 msgid "Invalid or damaged %s save file"
 msgstr ""
 
-#: pysollib/game/__init__.py:3111
+#: pysollib/game/__init__.py:3145
 #, python-format
 msgid ""
 "Cannot load games saved with\n"
-"%s version %s"
+"%(app)s version %(ver)s"
 msgstr ""
 
-#: pysollib/game/__init__.py:3130
+#: pysollib/game/__init__.py:3164
 #, python-format
 msgid ""
 "Cannot load this game from version %s\n"
@@ -1988,10 +2005,10 @@ msgstr ""
 
 #: pysollib/games/matriarchy.py:123
 #, python-format
-msgid "Round %d/%d"
+msgid "Round %(round)d/%(max_rounds)d"
 msgstr ""
 
-#: pysollib/games/matriarchy.py:125
+#: pysollib/games/matriarchy.py:126
 #, python-format
 msgid "Deal %d"
 msgstr ""
@@ -2058,6 +2075,458 @@ msgid ""
 "regardless of sequence."
 msgstr ""
 
+#: pysollib/kivy/menubar.py:179
+msgid "File"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:183
+msgid "Games"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:188 pysollib/kivy/menubar.py:1605
+msgid "Tools"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:192 pysollib/kivy/menubar.py:1613
+#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:177
+#: pysollib/tile/selectgame.py:385 pysollib/tile/tkstats.py:51
+#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:384
+#: pysollib/tk/toolbar.py:188
+msgid "Statistics"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:196
+msgid "Assist"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:201 pysollib/kivy/menubar.py:1629
+msgid "Options"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:206 pysollib/kivy/menubar.py:320
+#: pysollib/kivy/menubar.py:1637
+msgid "Help"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:227
+msgid "Recent games"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:240
+msgid "Favorite games"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:243
+msgid "<Add>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:245
+msgid "<Remove>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:296 pysollib/kivy/toolbar.py:197
+#: pysollib/pysolgtk/soundoptionsdialog.py:63
+#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
+#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
+msgid "Undo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:298 pysollib/kivy/toolbar.py:198
+#: pysollib/pysolgtk/soundoptionsdialog.py:64
+#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
+#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
+msgid "Redo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:300
+msgid "Redo all"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:303 pysollib/kivy/menubar.py:517
+#: pysollib/pysolgtk/soundoptionsdialog.py:56
+#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
+msgid "Auto drop"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:305 pysollib/kivy/toolbar.py:200
+#: pysollib/tile/toolbar.py:185 pysollib/tk/toolbar.py:185
+msgid "Shuffle tiles"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:307
+msgid "Deal cards"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:310 pysollib/kivy/toolbar.py:201
+#: pysollib/tile/toolbar.py:186 pysollib/tk/toolbar.py:186
+msgid "Pause"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:315
+msgid "Load game"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:317 pysollib/tile/toolbar.py:180
+#: pysollib/tk/toolbar.py:180
+msgid "Save game"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:371
+msgid "Current game..."
+msgstr ""
+
+#: pysollib/kivy/menubar.py:434
+msgid "Hint"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:437
+msgid "Highlight piles"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:509
+msgid "Automatic play"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:512
+msgid "Auto face up"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:522
+msgid "Auto deal"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:529
+msgid "Quick play"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:537
+msgid "Assist level"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:540
+msgid "Enable undo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:545
+msgid "Enable bookmarks"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:550
+msgid "Enable hint"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:555
+msgid "Enable shuffle"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:560
+msgid "Enable highlight piles"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:565
+msgid "Enable highlight cards"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:570
+msgid "Enable highlight same rank"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:575
+msgid "Highlight no matching"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:582
+msgid "Show removed tiles (in Mahjongg games)"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:587
+msgid "Show hint arrow (in Shisen-Sho games)"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:597
+msgid "Sound"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:600
+msgid "Enable"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:605
+msgid "Volume"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:608
+msgid "100%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:612
+msgid "75%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:616
+msgid "50%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:620
+msgid "25%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:625
+msgid "Samples"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:630
+msgid "are you sure"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:636
+msgid "auto drop"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:642
+msgid "auto flip"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:648
+msgid "auto pilot lost"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:654
+msgid "auto pilot won"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:660
+msgid "deal"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:666
+msgid "deal waste"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:672
+msgid "drop pair"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:678
+msgid "drop"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:684
+msgid "flip"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:690
+msgid "move"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:696
+msgid "no move"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:702
+msgid "redo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:708
+msgid "start drag"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:714
+msgid "turn waste"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:720
+msgid "undo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:726
+msgid "game finished"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:732
+msgid "game lost"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:738
+msgid "game perfect"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:744
+msgid "game won"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:752
+msgid "Cardsets"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:792
+msgid "Table"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:795
+msgid "Solid colors"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:800 pysollib/pysolgtk/selecttile.py:105
+#: pysollib/tile/selecttile.py:74 pysollib/tk/selecttile.py:73
+msgid "Blue"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:805 pysollib/pysolgtk/selecttile.py:106
+#: pysollib/tile/selecttile.py:75 pysollib/tk/selecttile.py:74
+#: pysollib/games/ultra/dashavatara.py:361 pysollib/games/ultra/mughal.py:264
+msgid "Green"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:810 pysollib/pysolgtk/selecttile.py:107
+#: pysollib/tile/selecttile.py:76 pysollib/tk/selecttile.py:75
+msgid "Navy"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:815 pysollib/pysolgtk/selecttile.py:108
+#: pysollib/tile/selecttile.py:77 pysollib/tk/selecttile.py:76
+#: pysollib/games/ultra/dashavatara.py:362
+msgid "Olive"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:820 pysollib/pysolgtk/selecttile.py:109
+#: pysollib/tile/selecttile.py:78 pysollib/tk/selecttile.py:77
+#: pysollib/games/ultra/dashavatara.py:362 pysollib/games/ultra/mughal.py:264
+msgid "Orange"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:825 pysollib/pysolgtk/selecttile.py:110
+#: pysollib/tile/selecttile.py:79 pysollib/tk/selecttile.py:78
+msgid "Teal"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:830
+msgid "Tiles and Images"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:850
+msgid "Card view"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:853
+msgid "Card shadow"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:858
+msgid "Shade legal moves"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:863
+msgid "Negative cards bottom"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:868 pysollib/ui/tktile/menubar.py:559
+msgid "Shrink face-down cards"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:873
+msgid "Shade filled stacks"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:881
+msgid "Animations"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:889
+msgid "Very fast"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:894
+msgid "Fast"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:899
+msgid "Medium"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:904
+msgid "Slow"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:909
+msgid "Very slow"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:916
+msgid "Redeal animation"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:921
+msgid "Winning animation"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:929
+msgid "Touch mode"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:932
+msgid "Drag-and-Drop"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:937
+msgid "Point-and-Click"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:971 pysollib/tile/toolbar.py:202
+#: pysollib/tk/toolbar.py:211
+msgid "Toolbar"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:974 pysollib/ui/tktile/menubar.py:41
+msgid "Hide"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:989 pysollib/ui/tktile/menubar.py:50
+msgid "Left"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:993 pysollib/ui/tktile/menubar.py:53
+msgid "Right"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1030
+msgid "Startup splash screen"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1035
+msgid "Winning splash"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1058
+msgid "Contents"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1062
+msgid "How to play"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1066 pysollib/kivy/toolbar.py:204
+#: pysollib/tile/toolbar.py:189 pysollib/tk/toolbar.py:189
+msgid "Rules for this game"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1070
+msgid "License terms"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1074
+#, python-format
+msgid "About %s..."
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1348
+msgid "Menu"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1576 pysollib/ui/tktile/menubar.py:971
+msgid "<none>"
+msgstr ""
+
 #: pysollib/kivy/menubar.py:1589
 msgid "Main Menu"
 msgstr ""
@@ -2066,247 +2535,269 @@ msgstr ""
 msgid "File Menu"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:1605
-msgid "Tools"
-msgstr ""
-
 #: pysollib/kivy/menubar.py:1621
 msgid "Assists"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:1629
-msgid "Options"
+#. TRANSLATORS: Usually, 'PySol files'
+#: pysollib/kivy/menubar.py:1795 pysollib/ui/tktile/menubar.py:1136
+#, python-format
+msgid "%s files"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:1637
-msgid "Help"
+#: pysollib/kivy/menubar.py:1796 pysollib/ui/tktile/menubar.py:1137
+msgid "All files"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2067
-#: pysollib/kivy/selectcardset.py:61 pysollib/pysolgtk/selectcardset.py:229
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2068
+#: pysollib/kivy/selectcardset.py:57 pysollib/pysolgtk/selectcardset.py:229
 #: pysollib/tk/menubar.py:89 pysollib/tk/menubar.py:90
 #: pysollib/tk/selectcardset.py:313
 msgid "&Load"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:2068 pysollib/kivy/selectcardset.py:61
+#: pysollib/kivy/menubar.py:2069 pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/tile/selectcardset.py:318
 #: pysollib/tk/menubar.py:90
 msgid "&Info..."
 msgstr ""
 
-#: pysollib/kivy/menubar.py:2072 pysollib/tile/menubar.py:90
-#: pysollib/tk/menubar.py:94
-msgid "Select "
+#: pysollib/kivy/menubar.py:2072 pysollib/pysolgtk/menubar.py:696
+msgid "Select cardset"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1664
+#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1666
 msgid "Solitaire Wizard"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:83 pysollib/tile/selectgame.py:84
-#: pysollib/tk/selectgame.py:85
+#: pysollib/tk/selectgame.py:84
 msgid "(no games)"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:104 pysollib/pysolgtk/selectgame.py:227
-#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:109
+#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:108
 msgid "Mahjongg Games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:108 pysollib/pysolgtk/selectgame.py:233
-#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:113
+#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:112
 msgid "French games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:111 pysollib/pysolgtk/selectgame.py:229
-#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:116
+#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:115
 msgid "Oriental Games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:114 pysollib/pysolgtk/selectgame.py:231
-#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:119
+#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:118
 msgid "Special Games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:117 pysollib/pysolgtk/selectgame.py:315
-#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:122
+#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:121
 msgid "Original Games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:146 pysollib/pysolgtk/selectgame.py:216
-#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:170
+#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:168
 msgid "All Games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:157 pysollib/pysolgtk/selectgame.py:286
-#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:138
+#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:137
 msgid "by Compatibility"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:168 pysollib/pysolgtk/selectgame.py:293
-#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:149
-msgid "New games in v. "
+#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:147
+#, python-format
+msgid "New games in v. %(version)s"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:171 pysollib/pysolgtk/selectgame.py:296
-#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:152
+#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:150
 msgid "by PySol version"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:183 pysollib/tile/selectgame.py:161
-#: pysollib/tk/selectgame.py:163
+#: pysollib/tk/selectgame.py:161
 msgid "by Inventors"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:191 pysollib/pysolgtk/selectgame.py:218
-#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:172
+#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:170
 msgid "Popular Games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:198 pysollib/pysolgtk/selectgame.py:217
-#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:171
+#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:169
 msgid "Alternate Names"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:201 pysollib/pysolgtk/selectgame.py:243
-#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:180
+#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:178
 msgid "by Skill Level"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:213 pysollib/pysolgtk/selectgame.py:247
-#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:193
+#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:191
 msgid "by Game Feature"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:214 pysollib/pysolgtk/selectgame.py:260
-#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:194
+#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:192
 msgid "by Number of Cards"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:215 pysollib/pysolgtk/selectgame.py:249
-#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:195
+#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:193
 msgid "32 cards"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:217 pysollib/pysolgtk/selectgame.py:250
-#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:197
+#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:195
 msgid "48 cards"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:219 pysollib/pysolgtk/selectgame.py:251
-#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:199
+#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:197
 msgid "52 cards"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:221 pysollib/pysolgtk/selectgame.py:252
-#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:201
+#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:199
 msgid "64 cards"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:223 pysollib/pysolgtk/selectgame.py:253
-#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:203
+#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:201
 msgid "78 cards"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:225 pysollib/pysolgtk/selectgame.py:254
-#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:205
+#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:203
 msgid "104 cards"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:227 pysollib/pysolgtk/selectgame.py:255
-#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:207
+#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:205
 msgid "144 cards"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:229 pysollib/pysolgtk/selectgame.py:256
-#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:210
+#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:208
 msgid "Other number"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:233 pysollib/pysolgtk/selectgame.py:267
-#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:214
+#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:212
 msgid "by Number of Decks"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:234 pysollib/pysolgtk/selectgame.py:262
-#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:215
+#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:213
 msgid "1 deck games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:236 pysollib/pysolgtk/selectgame.py:263
-#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:217
+#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:215
 msgid "2 deck games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:238 pysollib/pysolgtk/selectgame.py:264
-#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:219
+#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:217
 msgid "3 deck games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:240 pysollib/pysolgtk/selectgame.py:265
-#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:221
+#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:219
 msgid "4 deck games"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:243 pysollib/pysolgtk/selectgame.py:278
-#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:224
+#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:222
 msgid "by Number of Redeals"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:244 pysollib/pysolgtk/selectgame.py:269
-#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:225
+#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:223
 msgid "No redeal"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:246 pysollib/pysolgtk/selectgame.py:270
-#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:227
+#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:225
 msgid "1 redeal"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:248 pysollib/pysolgtk/selectgame.py:271
-#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:229
+#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:227
 msgid "2 redeals"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:250 pysollib/pysolgtk/selectgame.py:272
-#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:231
+#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:229
 msgid "3 redeals"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:256 pysollib/pysolgtk/selectgame.py:275
-#: pysollib/tile/selectgame.py:236 pysollib/tk/selectgame.py:238
+#: pysollib/tile/selectgame.py:234 pysollib/tk/selectgame.py:234
 msgid "Other number of redeals"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:264 pysollib/pysolgtk/selectgame.py:311
-#: pysollib/tile/selectgame.py:243 pysollib/tk/selectgame.py:245
+#: pysollib/tile/selectgame.py:241 pysollib/tk/selectgame.py:241
 msgid "Other Categories"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:265 pysollib/pysolgtk/selectgame.py:300
-#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:246
+#: pysollib/tile/selectgame.py:242 pysollib/tk/selectgame.py:242
 msgid "Games for Children (very easy)"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:267 pysollib/pysolgtk/selectgame.py:302
-#: pysollib/tile/selectgame.py:246 pysollib/tk/selectgame.py:248
+#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:244
 msgid "Games with Scoring"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:269 pysollib/pysolgtk/selectgame.py:304
-#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:251
+#: pysollib/tile/selectgame.py:247 pysollib/tk/selectgame.py:247
 msgid "Games with Separate Decks"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:271 pysollib/pysolgtk/selectgame.py:306
-#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:253
+#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:249
 msgid "Open Games (all cards visible)"
 msgstr ""
 
 #: pysollib/kivy/selectgame.py:273 pysollib/pysolgtk/selectgame.py:308
-#: pysollib/tile/selectgame.py:253 pysollib/tk/selectgame.py:255
+#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:251
 msgid "Relaxed Variants"
+msgstr ""
+
+#: pysollib/kivy/tkhtml.py:409
+msgid "Browser"
+msgstr ""
+
+#: pysollib/kivy/tkhtml.py:434 pysollib/pysolgtk/tkhtml.py:218
+#: pysollib/tile/tkhtml.py:77 pysollib/tk/tkhtml.py:72
+msgid "Index"
+msgstr ""
+
+#: pysollib/kivy/tkhtml.py:435 pysollib/pysolgtk/tkhtml.py:219
+#: pysollib/tile/tkhtml.py:81 pysollib/tk/tkhtml.py:76
+msgid "Back"
+msgstr ""
+
+#: pysollib/kivy/tkhtml.py:437 pysollib/pysolgtk/tkhtml.py:220
+#: pysollib/tile/tkhtml.py:85 pysollib/tk/tkhtml.py:80
+msgid "Forward"
+msgstr ""
+
+#: pysollib/kivy/tkhtml.py:438 pysollib/pysolgtk/tkhtml.py:221
+#: pysollib/tile/tkhtml.py:89 pysollib/tk/tkhtml.py:84
+msgid "Close"
 msgstr ""
 
 #: pysollib/kivy/tkstats.py:148 pysollib/tile/tkstats.py:163
@@ -2314,35 +2805,56 @@ msgstr ""
 msgid "Demo games"
 msgstr ""
 
-#: pysollib/kivy/tkstats.py:220 pysollib/pysolgtk/selectgame.py:123
-#: pysollib/tile/selectgame.py:402 pysollib/tile/tkstats.py:182
-#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:404
+#: pysollib/kivy/tkstats.py:175
+#, python-format
+msgid ""
+"Total:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+"\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:187
+#, python-format
+msgid ""
+"Current Session:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:225 pysollib/pysolgtk/selectgame.py:123
+#: pysollib/tile/selectgame.py:400 pysollib/tile/tkstats.py:182
+#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:401
 #: pysollib/tk/tkstats.py:87 pysollib/tk/tkstats.py:141 data/pysolfc.glade:241
 #: data/pysolfc.glade:519
 msgid "Won:"
 msgstr ""
 
-#: pysollib/kivy/tkstats.py:222 pysollib/pysolgtk/selectgame.py:124
-#: pysollib/tile/selectgame.py:403 pysollib/tile/tkstats.py:183
-#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:405
+#: pysollib/kivy/tkstats.py:227 pysollib/pysolgtk/selectgame.py:124
+#: pysollib/tile/selectgame.py:401 pysollib/tile/tkstats.py:183
+#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:402
 #: pysollib/tk/tkstats.py:88 pysollib/tk/tkstats.py:143 data/pysolfc.glade:307
 #: data/pysolfc.glade:544
 msgid "Lost:"
 msgstr ""
 
-#: pysollib/kivy/tkstats.py:224 pysollib/tile/tkstats.py:184
+#: pysollib/kivy/tkstats.py:229 pysollib/tile/tkstats.py:184
 #: pysollib/tile/tkstats.py:238 pysollib/tk/tkstats.py:89
 #: pysollib/tk/tkstats.py:145 data/pysolfc.glade:266 data/pysolfc.glade:569
 msgid "Total:"
 msgstr ""
 
-#: pysollib/kivy/tkstats.py:250 pysollib/tk/tkstats.py:279
+#: pysollib/kivy/tkstats.py:255 pysollib/tk/tkstats.py:279
 msgid "&All games..."
 msgstr ""
 
-#: pysollib/kivy/tkstats.py:252 pysollib/tile/tkstats.py:102
+#: pysollib/kivy/tkstats.py:257 pysollib/tile/tkstats.py:102
 #: pysollib/tk/tkstats.py:281
 msgid "&Reset..."
+msgstr ""
+
+#: pysollib/kivy/tkwidget.py:183
+msgid "Error"
 msgstr ""
 
 #: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
@@ -2362,21 +2874,9 @@ msgid ""
 "current game"
 msgstr ""
 
-#: pysollib/kivy/toolbar.py:197 pysollib/pysolgtk/soundoptionsdialog.py:63
-#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
-#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
-msgid "Undo"
-msgstr ""
-
 #: pysollib/kivy/toolbar.py:197 pysollib/tile/toolbar.py:182
 #: pysollib/tk/toolbar.py:182
 msgid "Undo last move"
-msgstr ""
-
-#: pysollib/kivy/toolbar.py:198 pysollib/pysolgtk/soundoptionsdialog.py:64
-#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
-#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
-msgid "Redo"
 msgstr ""
 
 #: pysollib/kivy/toolbar.py:198 pysollib/tile/toolbar.py:183
@@ -2399,16 +2899,6 @@ msgstr ""
 msgid "Shuffle"
 msgstr ""
 
-#: pysollib/kivy/toolbar.py:200 pysollib/tile/toolbar.py:185
-#: pysollib/tk/toolbar.py:185
-msgid "Shuffle tiles"
-msgstr ""
-
-#: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
-#: pysollib/tk/toolbar.py:186
-msgid "Pause"
-msgstr ""
-
 #: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
 #: pysollib/tk/toolbar.py:186
 msgid "Pause game"
@@ -2417,11 +2907,6 @@ msgstr ""
 #: pysollib/kivy/toolbar.py:204 pysollib/tile/toolbar.py:189
 #: pysollib/tk/toolbar.py:189
 msgid "Rules"
-msgstr ""
-
-#: pysollib/kivy/toolbar.py:204 pysollib/tile/toolbar.py:189
-#: pysollib/tk/toolbar.py:189
-msgid "Rules for this game"
 msgstr ""
 
 #: pysollib/kivy/toolbar.py:206 pysollib/tile/toolbar.py:191
@@ -2446,17 +2931,13 @@ msgstr ""
 msgid "Save Game"
 msgstr ""
 
-#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1298
+#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1300
 #: data/pysolfc.glade:4127
 msgid "Sound settings"
 msgstr ""
 
-#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1521
+#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1523
 msgid "Select table background"
-msgstr ""
-
-#: pysollib/pysolgtk/menubar.py:696
-msgid "Select cardset"
 msgstr ""
 
 #: pysollib/pysolgtk/playeroptionsdialog.py:62
@@ -2535,112 +3016,81 @@ msgstr ""
 msgid "by Date"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:384
-#: pysollib/tk/selectgame.py:386
+#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:382
+#: pysollib/tk/selectgame.py:383
 msgid "About game"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:394
-#: pysollib/tk/selectgame.py:396
+#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:392
+#: pysollib/tk/selectgame.py:393
 msgid "Alternate names:"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:395
-#: pysollib/tk/selectgame.py:397
+#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:393
+#: pysollib/tk/selectgame.py:394
 msgid "Category:"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:398
-#: pysollib/tk/selectgame.py:400
+#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:396
+#: pysollib/tk/selectgame.py:397
 msgid "Decks:"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:399
-#: pysollib/tk/selectgame.py:401
+#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:397
+#: pysollib/tk/selectgame.py:398
 msgid "Redeals:"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:401
-#: pysollib/tk/selectgame.py:403
+#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:399
+#: pysollib/tk/selectgame.py:400
 msgid "Played:"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:404
-#: pysollib/tile/tkstats.py:777 pysollib/tk/selectgame.py:406
-#: pysollib/tk/tkstats.py:740 data/pysolfc.glade:717
+#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:402
+#: pysollib/tile/tkstats.py:778 pysollib/tk/selectgame.py:403
+#: pysollib/tk/tkstats.py:741 data/pysolfc.glade:717
 msgid "Playing time:"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:405
-#: pysollib/tile/tkstats.py:784 pysollib/tk/selectgame.py:407
-#: pysollib/tk/tkstats.py:747 data/pysolfc.glade:813
+#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:403
+#: pysollib/tile/tkstats.py:785 pysollib/tk/selectgame.py:404
+#: pysollib/tk/tkstats.py:748 data/pysolfc.glade:813
 msgid "Moves:"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:406
-#: pysollib/tk/selectgame.py:408
+#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:404
+#: pysollib/tk/selectgame.py:405
 msgid "% won:"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:438
-#: pysollib/tk/selectgame.py:439 pysollib/ui/tktile/menubar.py:352
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:436
+#: pysollib/tk/selectgame.py:437 pysollib/ui/tktile/menubar.py:352
 msgid "&Select"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:437
-#: pysollib/tk/selectgame.py:439
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:435
+#: pysollib/tk/selectgame.py:436
 msgid "&Rules"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:518
-#: pysollib/tk/selectgame.py:519
-msgid "Playable Preview - "
+#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:516
+#: pysollib/tk/selectgame.py:517
+#, python-format
+msgid "Playable Preview - %(game)s"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:571
-#: pysollib/tk/selectgame.py:572
+#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:569
+#: pysollib/tk/selectgame.py:570
 msgid "variable"
 msgstr ""
 
-#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:573
-#: pysollib/tk/selectgame.py:574
+#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:571
+#: pysollib/tk/selectgame.py:572
 msgid "unlimited"
 msgstr ""
 
 #: pysollib/pysolgtk/selecttile.py:104
 msgid "Solid color"
-msgstr ""
-
-#: pysollib/pysolgtk/selecttile.py:105 pysollib/tile/selecttile.py:74
-#: pysollib/tk/selecttile.py:73
-msgid "Blue"
-msgstr ""
-
-#: pysollib/pysolgtk/selecttile.py:106 pysollib/tile/selecttile.py:75
-#: pysollib/tk/selecttile.py:74 pysollib/games/ultra/dashavatara.py:361
-#: pysollib/games/ultra/mughal.py:264
-msgid "Green"
-msgstr ""
-
-#: pysollib/pysolgtk/selecttile.py:107 pysollib/tile/selecttile.py:76
-#: pysollib/tk/selecttile.py:75
-msgid "Navy"
-msgstr ""
-
-#: pysollib/pysolgtk/selecttile.py:108 pysollib/tile/selecttile.py:77
-#: pysollib/tk/selecttile.py:76 pysollib/games/ultra/dashavatara.py:362
-msgid "Olive"
-msgstr ""
-
-#: pysollib/pysolgtk/selecttile.py:109 pysollib/tile/selecttile.py:78
-#: pysollib/tk/selecttile.py:77 pysollib/games/ultra/dashavatara.py:362
-#: pysollib/games/ultra/mughal.py:264
-msgid "Orange"
-msgstr ""
-
-#: pysollib/pysolgtk/selecttile.py:110 pysollib/tile/selecttile.py:79
-#: pysollib/tk/selecttile.py:78
-msgid "Teal"
 msgstr ""
 
 #: pysollib/pysolgtk/selecttile.py:121 pysollib/tile/selecttile.py:82
@@ -2698,11 +3148,6 @@ msgstr ""
 msgid "Drop pair"
 msgstr ""
 
-#: pysollib/pysolgtk/soundoptionsdialog.py:56
-#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
-msgid "Auto drop"
-msgstr ""
-
 #: pysollib/pysolgtk/soundoptionsdialog.py:58
 #: pysollib/tile/soundoptionsdialog.py:70 pysollib/tk/soundoptionsdialog.py:72
 msgid "Flip"
@@ -2753,35 +3198,15 @@ msgstr ""
 msgid "Games played: won/lost"
 msgstr ""
 
-#: pysollib/pysolgtk/tkhtml.py:218 pysollib/tile/tkhtml.py:77
-#: pysollib/tk/tkhtml.py:72
-msgid "Index"
-msgstr ""
-
-#: pysollib/pysolgtk/tkhtml.py:219 pysollib/tile/tkhtml.py:81
-#: pysollib/tk/tkhtml.py:76
-msgid "Back"
-msgstr ""
-
-#: pysollib/pysolgtk/tkhtml.py:220 pysollib/tile/tkhtml.py:85
-#: pysollib/tk/tkhtml.py:80
-msgid "Forward"
-msgstr ""
-
-#: pysollib/pysolgtk/tkhtml.py:221 pysollib/tile/tkhtml.py:89
-#: pysollib/tk/tkhtml.py:84
-msgid "Close"
-msgstr ""
-
 #: pysollib/pysolgtk/tkhtml.py:437 pysollib/ui/tktile/tkhtml.py:314
 #, python-format
 msgid ""
-"HTML limitation:\n"
-"The %s protocol is not supported yet.\n"
+"%(app)s HTML limitation:\n"
+"The %(protocol)s protocol is not supported yet.\n"
 "\n"
 "Please use your standard web browser\n"
 "to open the following URL:\n"
-"%s\n"
+"%(url)s\n"
 msgstr ""
 
 #: pysollib/pysolgtk/tkhtml.py:464 pysollib/pysolgtk/tkhtml.py:469
@@ -2789,116 +3214,116 @@ msgstr ""
 msgid "Unable to service request:\n"
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:328 pysollib/tile/tkstats.py:290
+#: pysollib/pysolgtk/tkstats.py:329 pysollib/tile/tkstats.py:290
 #: pysollib/tk/tkstats.py:266
 msgid "No games"
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:388 pysollib/tile/tkstats.py:670
-#: pysollib/tk/tkstats.py:667
+#: pysollib/pysolgtk/tkstats.py:389 pysollib/tile/tkstats.py:671
+#: pysollib/tk/tkstats.py:668
 msgid "N"
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:391 pysollib/tile/tkstats.py:683
-#: pysollib/tk/tkstats.py:676
+#: pysollib/pysolgtk/tkstats.py:392 pysollib/tile/tkstats.py:684
+#: pysollib/tk/tkstats.py:677
 msgid "Result"
-msgstr ""
-
-#: pysollib/pysolgtk/tkstats.py:526 pysollib/tile/tkstats.py:613
-#: pysollib/tk/tkstats.py:608
-msgid "Highlight piles: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:527 pysollib/tile/tkstats.py:614
 #: pysollib/tk/tkstats.py:609
-msgid "Highlight cards: "
+msgid "Highlight piles: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:528 pysollib/tile/tkstats.py:615
 #: pysollib/tk/tkstats.py:610
-msgid "Highlight same rank: "
+msgid "Highlight cards: "
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:532 pysollib/tile/tkstats.py:619
-#: pysollib/tk/tkstats.py:614
-msgid ""
-"\n"
-"Redeals: "
+#: pysollib/pysolgtk/tkstats.py:529 pysollib/tile/tkstats.py:616
+#: pysollib/tk/tkstats.py:611
+msgid "Highlight same rank: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:533 pysollib/tile/tkstats.py:620
 #: pysollib/tk/tkstats.py:615
 msgid ""
 "\n"
+"Redeals: "
+msgstr ""
+
+#: pysollib/pysolgtk/tkstats.py:534 pysollib/tile/tkstats.py:621
+#: pysollib/tk/tkstats.py:616
+msgid ""
+"\n"
 "Cards in Talon: "
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:535 pysollib/tile/tkstats.py:622
-#: pysollib/tk/tkstats.py:617
+#: pysollib/pysolgtk/tkstats.py:536 pysollib/tile/tkstats.py:623
+#: pysollib/tk/tkstats.py:618
 msgid ""
 "\n"
 "Cards in Waste: "
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:537 pysollib/tile/tkstats.py:624
-#: pysollib/tk/tkstats.py:619
+#: pysollib/pysolgtk/tkstats.py:538 pysollib/tile/tkstats.py:625
+#: pysollib/tk/tkstats.py:620
 msgid ""
 "\n"
 "Cards in Foundations: "
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:542 pysollib/tile/tkstats.py:629
-#: pysollib/tk/tkstats.py:625
+#: pysollib/pysolgtk/tkstats.py:543 pysollib/tile/tkstats.py:630
+#: pysollib/tk/tkstats.py:626
 msgid "Game status"
-msgstr ""
-
-#: pysollib/pysolgtk/tkstats.py:545 pysollib/tile/tkstats.py:632
-#: pysollib/tk/tkstats.py:628
-msgid "Playing time: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:546 pysollib/tile/tkstats.py:633
 #: pysollib/tk/tkstats.py:629
-msgid "Started at: "
+msgid "Playing time: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:547 pysollib/tile/tkstats.py:634
 #: pysollib/tk/tkstats.py:630
-msgid "Moves: "
+msgid "Started at: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:548 pysollib/tile/tkstats.py:635
 #: pysollib/tk/tkstats.py:631
-msgid "Undo moves: "
+msgid "Moves: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:549 pysollib/tile/tkstats.py:636
 #: pysollib/tk/tkstats.py:632
-msgid "Bookmark moves: "
+msgid "Undo moves: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:550 pysollib/tile/tkstats.py:637
 #: pysollib/tk/tkstats.py:633
-msgid "Demo moves: "
+msgid "Bookmark moves: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:551 pysollib/tile/tkstats.py:638
 #: pysollib/tk/tkstats.py:634
-msgid "Total player moves: "
+msgid "Demo moves: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:552 pysollib/tile/tkstats.py:639
 #: pysollib/tk/tkstats.py:635
-msgid "Total moves in this game: "
+msgid "Total player moves: "
 msgstr ""
 
 #: pysollib/pysolgtk/tkstats.py:553 pysollib/tile/tkstats.py:640
 #: pysollib/tk/tkstats.py:636
+msgid "Total moves in this game: "
+msgstr ""
+
+#: pysollib/pysolgtk/tkstats.py:554 pysollib/tile/tkstats.py:641
+#: pysollib/tk/tkstats.py:637
 msgid "Hints: "
 msgstr ""
 
-#: pysollib/pysolgtk/tkstats.py:557 pysollib/tile/tkstats.py:643
-#: pysollib/tk/tkstats.py:640 pysollib/ui/tktile/menubar.py:420
+#: pysollib/pysolgtk/tkstats.py:558 pysollib/tile/tkstats.py:644
+#: pysollib/tk/tkstats.py:641 pysollib/ui/tktile/menubar.py:420
 msgid "&Statistics..."
 msgstr ""
 
@@ -2968,14 +3393,19 @@ msgstr ""
 msgid "Select font"
 msgstr ""
 
+#: pysollib/tile/menubar.py:90 pysollib/tk/menubar.py:94
+msgid "Select "
+msgstr ""
+
 #: pysollib/tile/menubar.py:106
 msgid "Change theme"
 msgstr ""
 
 #: pysollib/tile/menubar.py:107
+#, python-format
 msgid ""
-"This settings will take effect\n"
-"the next time you restart "
+"These settings will take effect\n"
+"the next time you restart %(app)s"
 msgstr ""
 
 #: pysollib/tile/menubar.py:114
@@ -3069,7 +3499,7 @@ msgstr ""
 msgid "&Save"
 msgstr ""
 
-#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:177
+#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:176
 msgid "Custom Games"
 msgstr ""
 
@@ -3177,14 +3607,14 @@ msgstr ""
 msgid "Highlight same rank:"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:740
-#: pysollib/tile/tkstats.py:887 pysollib/tk/tkstats.py:909
+#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:741
+#: pysollib/tile/tkstats.py:888 pysollib/tk/tkstats.py:910
 #: data/pysolfc.glade:660
 msgid "Current game"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:748
-#: pysollib/tile/tkstats.py:883 pysollib/tk/tkstats.py:903
+#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:749
+#: pysollib/tile/tkstats.py:884 pysollib/tk/tkstats.py:904
 #: data/pysolfc.glade:1342
 msgid "All games"
 msgstr ""
@@ -3207,75 +3637,83 @@ msgstr ""
 msgid "Current session"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:510
+#: pysollib/tile/tkstats.py:511
 msgid "Log"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:541 pysollib/tk/tkstats.py:506
-#: pysollib/tk/tkstats.py:575 pysollib/tk/tkstats.py:592
+#: pysollib/tile/tkstats.py:523 data/pysolfc.glade:1404
+msgid "Full log"
+msgstr ""
+
+#: pysollib/tile/tkstats.py:527 data/pysolfc.glade:1466
+msgid "Session log"
+msgstr ""
+
+#: pysollib/tile/tkstats.py:542 pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:576 pysollib/tk/tkstats.py:593
 msgid "&Save to file"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:745 pysollib/tk/tkstats.py:785
+#: pysollib/tile/tkstats.py:746 pysollib/tk/tkstats.py:786
 msgid "No TOP for this game"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:753
+#: pysollib/tile/tkstats.py:754
 msgid "No TOP for all games"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:765 pysollib/tk/tkstats.py:732
+#: pysollib/tile/tkstats.py:766 pysollib/tk/tkstats.py:733
 #: data/pysolfc.glade:1005
 msgid "Minimum"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:767 pysollib/tk/tkstats.py:733
+#: pysollib/tile/tkstats.py:768 pysollib/tk/tkstats.py:734
 #: data/pysolfc.glade:1028
 msgid "Maximum"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:769 pysollib/tk/tkstats.py:734
+#: pysollib/tile/tkstats.py:770 pysollib/tk/tkstats.py:735
 #: data/pysolfc.glade:1051
 msgid "Average"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:791 pysollib/tk/tkstats.py:754
+#: pysollib/tile/tkstats.py:792 pysollib/tk/tkstats.py:755
 #: data/pysolfc.glade:909
 msgid "Total moves:"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:891 pysollib/tk/tkstats.py:915
+#: pysollib/tile/tkstats.py:892 pysollib/tk/tkstats.py:916
 msgid "Statistics for"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:896 pysollib/tk/tkstats.py:920
+#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
 msgid "Last 7 days"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
+#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
 msgid "Last month"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
+#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
 msgid "Last year"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
+#: pysollib/tile/tkstats.py:900 pysollib/tk/tkstats.py:924
 msgid "All time"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:904 pysollib/tk/tkstats.py:930
+#: pysollib/tile/tkstats.py:905 pysollib/tk/tkstats.py:931
 msgid "Show graphs"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:948 pysollib/tile/tkstats.py:964
-#: pysollib/tile/tkstats.py:1002 pysollib/tk/tkstats.py:857
-#: pysollib/tk/tkstats.py:873 pysollib/tk/tkstats.py:977
+#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:965
+#: pysollib/tile/tkstats.py:1003 pysollib/tk/tkstats.py:858
+#: pysollib/tk/tkstats.py:874 pysollib/tk/tkstats.py:978
 msgid "Games/day"
 msgstr ""
 
-#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:1004
-#: pysollib/tk/tkstats.py:858 pysollib/tk/tkstats.py:979
+#: pysollib/tile/tkstats.py:950 pysollib/tile/tkstats.py:1005
+#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:980
 msgid "Games/week"
 msgstr ""
 
@@ -3293,16 +3731,8 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: pysollib/tile/toolbar.py:180 pysollib/tk/toolbar.py:180
-msgid "Save game"
-msgstr ""
-
 #: pysollib/tile/toolbar.py:188 pysollib/tk/toolbar.py:188
 msgid "View statistics"
-msgstr ""
-
-#: pysollib/tile/toolbar.py:202 pysollib/tk/toolbar.py:211
-msgid "Toolbar"
 msgstr ""
 
 #: pysollib/tile/toolbar.py:209 pysollib/tk/toolbar.py:206
@@ -3325,15 +3755,15 @@ msgstr ""
 msgid "Enable samles"
 msgstr ""
 
-#: pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:508
 msgid "&Reset all..."
 msgstr ""
 
-#: pysollib/tk/tkstats.py:574
+#: pysollib/tk/tkstats.py:575
 msgid "Session &log..."
 msgstr ""
 
-#: pysollib/tk/tkstats.py:591
+#: pysollib/tk/tkstats.py:592
 msgid "&Full log..."
 msgstr ""
 
@@ -3730,10 +4160,6 @@ msgstr ""
 msgid "Compound"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:41
-msgid "Hide"
-msgstr ""
-
 #: pysollib/ui/tktile/menubar.py:44
 msgid "Top"
 msgstr ""
@@ -3742,20 +4168,13 @@ msgstr ""
 msgid "Bottom"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:50
-msgid "Left"
-msgstr ""
-
-#: pysollib/ui/tktile/menubar.py:53
-msgid "Right"
-msgstr ""
-
 #: pysollib/ui/tktile/menubar.py:64
 msgid "Visible buttons"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:296 pysollib/ui/tktile/menubar.py:666
-msgid "&About "
+#: pysollib/ui/tktile/menubar.py:296
+#, python-format
+msgid "&About %s"
 msgstr ""
 
 #: pysollib/ui/tktile/menubar.py:298
@@ -4051,10 +4470,6 @@ msgstr ""
 msgid "&Negative cards bottom"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:559
-msgid "Shrink face-down cards"
-msgstr ""
-
 #: pysollib/ui/tktile/menubar.py:563
 msgid "Shade &filled stacks"
 msgstr ""
@@ -4179,6 +4594,11 @@ msgstr ""
 msgid "&License terms"
 msgstr ""
 
+#: pysollib/ui/tktile/menubar.py:666
+#, python-format
+msgid "&About %s..."
+msgstr ""
+
 #: pysollib/ui/tktile/menubar.py:796
 msgid "All &games..."
 msgstr ""
@@ -4215,33 +4635,38 @@ msgstr ""
 msgid "&All games by name"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1177
+#: pysollib/ui/tktile/menubar.py:1179
 msgid "Export game error"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1178
+#: pysollib/ui/tktile/menubar.py:1180
 msgid ""
 "\n"
 "Unsupported game for export.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1214 pysollib/ui/tktile/menubar.py:1248
+#: pysollib/ui/tktile/menubar.py:1216 pysollib/ui/tktile/menubar.py:1250
 msgid "Import game error"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1215
+#: pysollib/ui/tktile/menubar.py:1217
 msgid ""
 "\n"
 "Unsupported game for import.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1676
+#: pysollib/ui/tktile/menubar.py:1678
 #, python-format
 msgid ""
 "\n"
 "Error while saving game.\n"
 "\n"
 "%s\n"
+msgstr ""
+
+#: pysollib/ui/tktile/solverdialog.py:28
+#, python-format
+msgid "%(app)s - FreeCell Solver"
 msgstr ""
 
 #: pysollib/ui/tktile/solverdialog.py:44 data/pysolfc.glade:74

--- a/po/ru_pysol.po
+++ b/po/ru_pysol.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-18 19:21+0300\n"
+"POT-Creation-Date: 2019-08-31 00:20+0300\n"
 "PO-Revision-Date: 2007-09-06 15:09+0400\n"
 "Last-Translator: Skomoroh <skomoroh@gmail.com>\n"
 "Language-Team: Russian <ru@li.org>\n"
@@ -18,14 +18,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: pysollib/actions.py:232 pysollib/kivy/toolbar.py:191
-#: pysollib/tile/toolbar.py:176 pysollib/tk/toolbar.py:176
+#: pysollib/actions.py:232 pysollib/kivy/menubar.py:291
+#: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
+#: pysollib/tk/toolbar.py:176
 msgid "New game"
 msgstr "Новая игра"
 
 #: pysollib/actions.py:247 pysollib/kivy/menubar.py:1667
-#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1014
-#: pysollib/ui/tktile/menubar.py:1030
+#: pysollib/pysolgtk/menubar.py:648 pysollib/ui/tktile/menubar.py:1015
+#: pysollib/ui/tktile/menubar.py:1031
 msgid "Select game"
 msgstr "Выбрать игру"
 
@@ -55,19 +56,19 @@ msgstr ""
 "\n"
 "Введите номер новой игры"
 
-#: pysollib/actions.py:293 pysollib/app.py:523 pysollib/app.py:817
-#: pysollib/game/__init__.py:1270 pysollib/game/__init__.py:2487
-#: pysollib/kivy/tkhtml.py:690 pysollib/kivy/tkstats.py:249
+#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/app.py:818
+#: pysollib/game/__init__.py:1305 pysollib/game/__init__.py:2526
+#: pysollib/kivy/tkhtml.py:691 pysollib/kivy/tkstats.py:254
 #: pysollib/kivy/tkwidget.py:97 pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/pysolgtk/tkhtml.py:542
-#: pysollib/pysolgtk/tkstats.py:556 pysollib/pysolgtk/tkwidget.py:151
+#: pysollib/pysolgtk/tkstats.py:557 pysollib/pysolgtk/tkwidget.py:151
 #: pysollib/tile/fontsdialog.py:140 pysollib/tile/fontsdialog.py:202
 #: pysollib/tile/menubar.py:111 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:545
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/soundoptionsdialog.py:188 pysollib/tile/timeoutsdialog.py:92
-#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:540
-#: pysollib/tile/tkstats.py:645 pysollib/tile/tkstats.py:726
+#: pysollib/tile/tkstats.py:101 pysollib/tile/tkstats.py:541
+#: pysollib/tile/tkstats.py:646 pysollib/tile/tkstats.py:727
 #: pysollib/tile/tkwidget.py:138 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/playeroptionsdialog.py:64
@@ -75,10 +76,10 @@ msgstr ""
 #: pysollib/tk/selectcardset.py:506 pysollib/tk/selecttile.py:152
 #: pysollib/tk/soundoptionsdialog.py:152 pysollib/tk/soundoptionsdialog.py:193
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkstats.py:278
-#: pysollib/tk/tkstats.py:505 pysollib/tk/tkstats.py:574
-#: pysollib/tk/tkstats.py:591 pysollib/tk/tkstats.py:639
-#: pysollib/tk/tkstats.py:712 pysollib/tk/tkstats.py:796
-#: pysollib/tk/tkstats.py:963 pysollib/tk/tkwidget.py:143
+#: pysollib/tk/tkstats.py:506 pysollib/tk/tkstats.py:575
+#: pysollib/tk/tkstats.py:592 pysollib/tk/tkstats.py:640
+#: pysollib/tk/tkstats.py:713 pysollib/tk/tkstats.py:797
+#: pysollib/tk/tkstats.py:964 pysollib/tk/tkwidget.py:143
 #: pysollib/tk/tkwidget.py:351 pysollib/tk/wizarddialog.py:132
 #: pysollib/ui/tktile/colorsdialog.py:118
 #: pysollib/ui/tktile/edittextdialog.py:38
@@ -90,24 +91,24 @@ msgstr "&ОК"
 msgid "&Next number"
 msgstr "&Следующий номер"
 
-#: pysollib/actions.py:293 pysollib/app.py:524 pysollib/game/__init__.py:1270
-#: pysollib/game/__init__.py:1939 pysollib/game/__init__.py:1957
-#: pysollib/game/__init__.py:1965 pysollib/game/__init__.py:1972
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2068
-#: pysollib/kivy/selectcardset.py:61
+#: pysollib/actions.py:293 pysollib/app.py:525 pysollib/game/__init__.py:1305
+#: pysollib/game/__init__.py:1979 pysollib/game/__init__.py:1995
+#: pysollib/game/__init__.py:2003 pysollib/game/__init__.py:2010
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2069
+#: pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/playeroptionsdialog.py:79
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/pysolgtk/selectgame.py:324
 #: pysollib/pysolgtk/selecttile.py:158 pysollib/tile/fontsdialog.py:140
 #: pysollib/tile/fontsdialog.py:202 pysollib/tile/playeroptionsdialog.py:89
 #: pysollib/tile/selectcardset.py:321 pysollib/tile/selectcardset.py:543
-#: pysollib/tile/selectgame.py:308 pysollib/tile/selectgame.py:438
+#: pysollib/tile/selectgame.py:306 pysollib/tile/selectgame.py:436
 #: pysollib/tile/selecttile.py:154 pysollib/tile/soundoptionsdialog.py:149
 #: pysollib/tile/timeoutsdialog.py:92 pysollib/tile/tkwidget.py:359
 #: pysollib/tile/wizarddialog.py:143 pysollib/tk/fontsdialog.py:134
 #: pysollib/tk/fontsdialog.py:200 pysollib/tk/menubar.py:89
 #: pysollib/tk/menubar.py:90 pysollib/tk/playeroptionsdialog.py:64
 #: pysollib/tk/playeroptionsdialog.py:138 pysollib/tk/selectcardset.py:313
-#: pysollib/tk/selectgame.py:310 pysollib/tk/selectgame.py:439
+#: pysollib/tk/selectgame.py:306 pysollib/tk/selectgame.py:437
 #: pysollib/tk/selecttile.py:152 pysollib/tk/soundoptionsdialog.py:152
 #: pysollib/tk/timeoutsdialog.py:92 pysollib/tk/tkwidget.py:351
 #: pysollib/tk/wizarddialog.py:132 pysollib/ui/tktile/colorsdialog.py:118
@@ -125,195 +126,230 @@ msgstr "Выбрать следующую игру"
 
 #: pysollib/actions.py:384 pysollib/kivy/toolbar.py:206
 #: pysollib/tile/toolbar.py:191 pysollib/tk/toolbar.py:191
-msgid "Quit "
-msgstr "Выйти из "
+#, python-format
+msgid "Quit %s"
+msgstr "Выйти из %s"
 
 #: pysollib/actions.py:447
 msgid "Clear bookmarks"
 msgstr "Удалить закладки"
 
 #: pysollib/actions.py:448
-msgid "Clear all bookmarks ?"
+msgid "Clear all bookmarks?"
 msgstr "Удалить все закладки?"
 
-#: pysollib/actions.py:459
+#: pysollib/actions.py:459 pysollib/kivy/menubar.py:293
 msgid "Restart game"
 msgstr "Начать игру с начала"
 
 #: pysollib/actions.py:460
-msgid "Restart this game ?"
+msgid "Restart this game?"
 msgstr "Начать игру с начала?"
 
-#: pysollib/actions.py:505
+#: pysollib/actions.py:506
 #, python-format
 msgid ""
-"Comments for %s:\n"
+"Comments for %(game)s %(id)s:\n"
 "\n"
 msgstr ""
-"Комментарий для %s:\n"
+"Комментарий для %(game)s %(id)s:\n"
 "\n"
 
-#: pysollib/actions.py:507
-msgid "Comments for "
-msgstr "Комментарий для "
+#: pysollib/actions.py:508
+#, python-format
+msgid "Comments for %(id)s"
+msgstr "Комментарий для %(id)s"
 
-#: pysollib/actions.py:525 pysollib/actions.py:549
+#: pysollib/actions.py:526 pysollib/actions.py:551
 msgid "Error while writing to file"
 msgstr "Ошибка при записи в файл"
 
-#: pysollib/actions.py:528 pysollib/actions.py:552
-msgid " Info"
-msgstr " Информация"
+#: pysollib/actions.py:529 pysollib/actions.py:554
+#, python-format
+msgid "%s Info"
+msgstr "%s Информация"
 
-#: pysollib/actions.py:529
+#: pysollib/actions.py:530
+#, python-format
 msgid ""
 "Comments were appended to\n"
 "\n"
+"%(filename)s"
 msgstr ""
 "Комментарий добавлен в файл\n"
 "\n"
+"%(filename)s"
 
-#: pysollib/actions.py:538
-msgid "Demo statistics"
+#: pysollib/actions.py:540
+#, fuzzy, python-format
+msgid ""
+"Demo statistics were appended to\n"
+"\n"
+"%(filename)s"
+msgstr ""
+"Комментарий добавлен в файл\n"
+"\n"
+"%(filename)s"
+
+#: pysollib/actions.py:543
+#, fuzzy, python-format
+msgid ""
+"Your statistics were appended to\n"
+"\n"
+"%(filename)s"
+msgstr ""
+"Комментарий добавлен в файл\n"
+"\n"
+"%(filename)s"
+
+#: pysollib/actions.py:581
+#, fuzzy, python-format
+msgid "%(app)s Demo Statistics for %(game)s"
+msgstr "Статистика игры %(game)s"
+
+#: pysollib/actions.py:582
+#, python-format
+msgid "Statistics for %(game)s"
+msgstr "Статистика игры %(game)s"
+
+#: pysollib/actions.py:587
+#, fuzzy, python-format
+msgid "%(app)s Demo Statistics"
 msgstr "Статистика демо"
 
-#: pysollib/actions.py:541
-msgid "Your statistics"
-msgstr "Ваша статистика"
+#: pysollib/actions.py:588 pysollib/stats.py:202
+#, fuzzy, python-format
+msgid "Statistics for %(player)s"
+msgstr "Статистика игры %(game)s"
 
-#: pysollib/actions.py:553
-msgid ""
-" were appended to\n"
-"\n"
-msgstr ""
-" добавлена в файл\n"
-"\n"
+#: pysollib/actions.py:592
+#, fuzzy, python-format
+msgid "%(app)s Demo Full log"
+msgstr "Д&емо лого"
 
-#: pysollib/actions.py:567
-msgid " Demo"
-msgstr " Демо"
+#: pysollib/actions.py:593 pysollib/stats.py:235
+#, python-format
+msgid "Full log for %(player)s"
+msgstr "Полный лог для %(player)s"
 
-#: pysollib/actions.py:567
-msgid " Demo "
-msgstr " Демо "
-
-#: pysollib/actions.py:570 pysollib/actions.py:591
-msgid " for "
-msgstr " для "
-
-#: pysollib/actions.py:576 pysollib/stats.py:202
-msgid "Statistics for "
-msgstr "Статистика игры "
-
-#: pysollib/actions.py:581 pysollib/kivy/menubar.py:1613
-#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:176
-#: pysollib/tile/selectgame.py:387 pysollib/tile/tkstats.py:51
-#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:387
-#: pysollib/tk/toolbar.py:188
-msgid "Statistics"
-msgstr "Статистика"
-
-#: pysollib/actions.py:585 pysollib/tile/tkstats.py:522 data/pysolfc.glade:1404
-msgid "Full log"
-msgstr "Полный лог"
-
-#: pysollib/actions.py:588 pysollib/tile/tkstats.py:526 data/pysolfc.glade:1466
-msgid "Session log"
+#: pysollib/actions.py:596
+#, fuzzy, python-format
+msgid "%(app)s Demo Session log"
 msgstr "Лог сессии"
 
-#: pysollib/actions.py:595
+#: pysollib/actions.py:597 pysollib/stats.py:242
+#, python-format
+msgid "Session log for %(player)s"
+msgstr "Лог сессии для %(player)s"
+
+#. TRANSLATORS: eg. top 10 or top 5 results for a certain game
+#: pysollib/actions.py:601
+#, fuzzy, python-format
+msgid "%(app)s Demo Top %(tops)d for %(game)s"
+msgstr "Статистика игры %(game)s"
+
+#: pysollib/actions.py:602
+#, python-format
+msgid "Top %(tops)d for %(game)s"
+msgstr ""
+
+#: pysollib/actions.py:606
 msgid "Game Info"
 msgstr "Информация об игре"
 
-#: pysollib/actions.py:598
+#: pysollib/actions.py:609
 msgid "Statistics progression"
 msgstr "Прогресс статистики"
 
-#: pysollib/actions.py:616
+#: pysollib/actions.py:627
 msgid "Reset all statistics"
 msgstr "Очистить всю статистику"
 
-#: pysollib/actions.py:617
+#: pysollib/actions.py:628
 #, python-format
 msgid ""
 "Reset ALL statistics and logs for player\n"
-"%s ?"
+"%(player)s?"
 msgstr ""
 "Очистить всю статистику и лог для игрока\n"
-"%s?"
+"%(player)s?"
 
-#: pysollib/actions.py:626
+#: pysollib/actions.py:638
 msgid "Reset game statistics"
 msgstr "Очистить статистику игры"
 
-#: pysollib/actions.py:627
+#: pysollib/actions.py:639
 #, python-format
 msgid ""
 "Reset statistics and logs for player\n"
-"%s\n"
+"%(player)s\n"
 "and game\n"
-"%s ?"
+"%(game)s?"
 msgstr ""
 "Очистить всю статистику и лог для игрока\n"
-"%s\n"
+"%(player)s\n"
 "и игры\n"
-"%s?"
+"%(game)s?"
 
-#: pysollib/actions.py:692
+#: pysollib/actions.py:704
 msgid "Play demo"
 msgstr "Показать демо"
 
-#: pysollib/actions.py:704
+#: pysollib/actions.py:716
 msgid "Set player options"
 msgstr "Установить настройки игрока"
 
-#: pysollib/actions.py:720 data/pysolfc.glade:1986
+#: pysollib/actions.py:732 data/pysolfc.glade:1986
 msgid "Set colors"
 msgstr "Настроить цвета"
 
-#: pysollib/actions.py:738
+#: pysollib/actions.py:750
 msgid "Set fonts"
 msgstr "Настроить шрифт"
 
-#: pysollib/actions.py:748 data/pysolfc.glade:1493
+#: pysollib/actions.py:760 data/pysolfc.glade:1493
 msgid "Set timeouts"
 msgstr "Настроить таймауты"
 
 #: pysollib/app.py:332
-msgid "can't find game: "
+#, python-format
+msgid "can't find game: %(game)s"
 msgstr ""
 
-#: pysollib/app.py:525 pysollib/game/__init__.py:1939
-#: pysollib/game/__init__.py:1957 pysollib/game/__init__.py:1965
-#: pysollib/game/__init__.py:1972 pysollib/ui/tktile/menubar.py:300
+#: pysollib/app.py:526 pysollib/game/__init__.py:1979
+#: pysollib/game/__init__.py:1995 pysollib/game/__init__.py:2003
+#: pysollib/game/__init__.py:2010 pysollib/ui/tktile/menubar.py:300
 msgid "&New game"
 msgstr "&Новая игра"
 
-#: pysollib/app.py:671
-#, python-format
-msgid "Loading %s %s..."
+#: pysollib/app.py:672
+#, fuzzy, python-format
+msgid "Loading cardset %s..."
 msgstr "Загружается %s %s..."
 
-#: pysollib/app.py:713
-msgid " load error"
+#: pysollib/app.py:714
+#, fuzzy
+msgid "Cardset load error"
 msgstr " ошибка при загрузке"
 
-#: pysollib/app.py:714
-msgid "Error while loading "
-msgstr "Ошибка при загрузке"
+#: pysollib/app.py:715
+#, fuzzy
+msgid "Error while loading cardset"
+msgstr "Ошибка при загрузке игры"
 
-#: pysollib/app.py:809
-msgid "Incompatible "
+#: pysollib/app.py:810
+#, fuzzy
+msgid "Incompatible cardset"
 msgstr "Несовместимый "
 
-#: pysollib/app.py:811
-#, python-format
+#: pysollib/app.py:812
+#, fuzzy, python-format
 msgid ""
-"The currently selected %s %s\n"
+"The currently selected cardset %(cardset)s\n"
 "is not compatible with the game\n"
-"%s\n"
+"%(game)s\n"
 "\n"
-"Please select a %s type %s.\n"
+"Please select a %(correct_type)s type cardset.\n"
 msgstr ""
 "Текущий %s %s\n"
 "несовместим с игрой\n"
@@ -321,14 +357,14 @@ msgstr ""
 "\n"
 "Необходимо выбрать %s типа %s.\n"
 
-#: pysollib/app.py:855
-#, python-format
-msgid "Please select a %s type %s"
+#: pysollib/app.py:856
+#, fuzzy, python-format
+msgid "Please select a %s type cardset"
 msgstr "Выберите %s типа %s"
 
-#: pysollib/app.py:1063
+#: pysollib/app.py:1064
 #, python-format
-msgid "error loading plugin %s: %s"
+msgid "error loading plugin %(file)s: %(err)s"
 msgstr ""
 
 #: pysollib/gamedb.py:109
@@ -540,12 +576,12 @@ msgid "Puzzle type"
 msgstr "Пазлы"
 
 #: pysollib/help.py:43
-msgid "A Python Solitaire Game Collection\n"
-msgstr "Коллекция питоновских пасьянсов\n"
+msgid "A Python Solitaire Game Collection"
+msgstr "Коллекция питоновских пасьянсов"
 
 #: pysollib/help.py:45
-msgid "A World Domination Project\n"
-msgstr "Всемирный непревзойдённый проект\n"
+msgid "A World Domination Project"
+msgstr "Всемирный непревзойдённый проект"
 
 #: pysollib/help.py:46
 msgid "&Nice"
@@ -565,14 +601,16 @@ msgid "Version %s"
 msgstr "Версия %s"
 
 #: pysollib/help.py:50
-msgid "About "
-msgstr "О программе "
+#, python-format
+msgid "About %s"
+msgstr "О программе %s"
 
 #: pysollib/help.py:52
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "PySol Fan Club edition\n"
-"%s%s\n"
+"%(description)s\n"
+"%(versioninfo)s\n"
 "\n"
 "Copyright (C) 1998 - 2003 Markus F.X.J. Oberhumer.\n"
 "Copyright (C) 2003 Mt. Hood Playing Card Co.\n"
@@ -585,11 +623,12 @@ msgid ""
 "For more information about this application visit"
 msgstr ""
 "PySol Fan Club edition\n"
-"%s%s\n"
-"Copyright (C) 1998, 1999, 2000, 2001, 2002, 2003\n"
-"Markus F.X.J. Oberhumer\n"
+"%(description)s\n"
+"%(versioninfo)s\n"
+"\n"
+"Copyright (C) 1998 - 2003 Markus F.X.J. Oberhumer.\n"
 "Copyright (C) 2003 Mt. Hood Playing Card Co.\n"
-"Copyright (C) 2005 Skomoroh (Fan Club edition)\n"
+"Copyright (C) 2005 - 2009 Skomoroh.\n"
 "All Rights Reserved.\n"
 "\n"
 "PySol свободное программное обеспечение,\n"
@@ -598,14 +637,14 @@ msgstr ""
 "Для получения дополнительной информации\n"
 "об этом приложении посетите сайт"
 
-#: pysollib/help.py:88
+#: pysollib/help.py:90
 msgid "Credits"
 msgstr "Благодарности"
 
-#: pysollib/help.py:89
+#: pysollib/help.py:91
 #, python-format
 msgid ""
-" credits go to:\n"
+"%(app)s credits go to:\n"
 "\n"
 "Volker Weidner for getting me into Solitaire\n"
 "Guido van Rossum for the initial example program\n"
@@ -614,20 +653,27 @@ msgid ""
 "The Gnome AisleRiot team for parts of the documentation\n"
 "Natascha\n"
 "\n"
-"The Python, %s, SDL & Linux crews\n"
+"The Python, %(gui_library)s, SDL & Linux crews\n"
 "for making this program possible"
 msgstr ""
 
-#: pysollib/help.py:125
-msgid " HTML Problem"
-msgstr " проблема с HTML"
+#: pysollib/help.py:127 pysollib/kivy/tkhtml.py:687
+#, python-format
+msgid "%s HTML Problem"
+msgstr "%s проблема с HTML"
 
-#: pysollib/help.py:126
-msgid "Cannot find help document\n"
-msgstr "Не найден файл помощи\n"
+#: pysollib/help.py:128
+#, python-format
+msgid ""
+"Cannot find help document\n"
+"%s"
+msgstr ""
+"Не найден файл помощи\n"
+"%s"
 
-#: pysollib/help.py:139
-msgid " Help"
+#: pysollib/help.py:141
+#, fuzzy, python-format
+msgid "%s Help"
 msgstr " Помощь"
 
 #: pysollib/main.py:58 pysollib/main.py:70 pysollib/main.py:304
@@ -638,21 +684,21 @@ msgstr "%s проблема с установкой"
 #: pysollib/main.py:59
 #, fuzzy, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Cardsets should be installed into:\n"
-"%s/cardsets/\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "Не найдены наборы карт!!!\n"
 "\n"
 "Основной каталог:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Пожалуйста проверьте установку %s.\n"
+"Пожалуйста проверьте установку %(app)s.\n"
 
-#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:312
+#: pysollib/main.py:66 pysollib/main.py:78 pysollib/main.py:313
 #: pysollib/ui/tktile/menubar.py:346
 msgid "&Quit"
 msgstr "В&ыход"
@@ -660,27 +706,24 @@ msgstr "В&ыход"
 #: pysollib/main.py:71
 #, python-format
 msgid ""
-"No cardsets were found !!!\n"
+"No cardsets were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "Не найдены наборы карт!!!\n"
 "\n"
 "Основной каталог:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Пожалуйста проверьте установку %s.\n"
+"Пожалуйста проверьте установку %(app)s.\n"
 
 #: pysollib/main.py:96
 #, python-format
-msgid ""
-"%s\n"
-"try %s --help for more information"
+msgid "try %s --help for more information"
 msgstr ""
-"%s\n"
 "попробуйте %s --help для получения более подробной информации"
 
 #: pysollib/main.py:128
@@ -741,20 +784,20 @@ msgstr "Добро пожаловать в %s"
 #, python-format
 msgid ""
 "\n"
-"No games were found !!!\n"
+"No games were found!!!\n"
 "\n"
 "Main data directory is:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Please check your %s installation.\n"
+"Please check your %(app)s installation.\n"
 msgstr ""
 "\n"
 "Не найдены игры!!!\n"
 "\n"
 "Основной каталог с данными:\n"
-"%s\n"
+"%(dir)s\n"
 "\n"
-"Пожалуйста проверьте установку %s.\n"
+"Пожалуйста проверьте установку %(app)s.\n"
 
 #: pysollib/options.py:266
 msgid "Unknown"
@@ -1099,8 +1142,8 @@ msgid "Unlimited redeals."
 msgstr "Неограниченное количество пересдач."
 
 #: pysollib/stack.py:1948
-#, python-format
-msgid "%d readeal"
+#, fuzzy, python-format
+msgid "%d redeal"
 msgid_plural "%d redeals"
 msgstr[0] "%d пересдача"
 msgstr[1] "%d пересдачи"
@@ -1313,66 +1356,66 @@ msgstr "Сброс."
 msgid "Free cell."
 msgstr "Свободная ячейка."
 
-#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:421
-#: pysollib/pysolgtk/tkstats.py:458 pysollib/tile/tkstats.py:674
+#: pysollib/stats.py:40 pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:422
+#: pysollib/pysolgtk/tkstats.py:459 pysollib/tile/tkstats.py:675
 msgid "Game"
 msgstr "Игра"
 
-#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:422
-#: pysollib/tile/tkstats.py:908 pysollib/tile/tkstats.py:977
-#: pysollib/tile/tkstats.py:978 pysollib/tk/tkstats.py:886
-#: pysollib/tk/tkstats.py:887 pysollib/tk/tkstats.py:934
+#: pysollib/stats.py:41 pysollib/pysolgtk/tkstats.py:423
+#: pysollib/tile/tkstats.py:909 pysollib/tile/tkstats.py:978
+#: pysollib/tile/tkstats.py:979 pysollib/tk/tkstats.py:887
+#: pysollib/tk/tkstats.py:888 pysollib/tk/tkstats.py:935
 msgid "Played"
 msgstr "Играл"
 
-#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:423
-#: pysollib/tile/tkstats.py:914 pysollib/tile/tkstats.py:982
-#: pysollib/tile/tkstats.py:983 pysollib/tk/tkstats.py:891
-#: pysollib/tk/tkstats.py:892 pysollib/tk/tkstats.py:942
+#: pysollib/stats.py:42 pysollib/stats.py:149 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/tile/tkstats.py:915 pysollib/tile/tkstats.py:983
+#: pysollib/tile/tkstats.py:984 pysollib/tk/tkstats.py:892
+#: pysollib/tk/tkstats.py:893 pysollib/tk/tkstats.py:943
 msgid "Won"
 msgstr "Выиграл"
 
-#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:424
+#: pysollib/stats.py:43 pysollib/stats.py:148 pysollib/pysolgtk/tkstats.py:425
 msgid "Lost"
 msgstr "Проиграл"
 
 #: pysollib/stats.py:44 pysollib/pysolgtk/statusbar.py:98
-#: pysollib/pysolgtk/tkstats.py:425 pysollib/tile/statusbar.py:154
+#: pysollib/pysolgtk/tkstats.py:426 pysollib/tile/statusbar.py:154
 #: pysollib/tk/statusbar.py:151 data/pysolfc.glade:1133
 msgid "Playing time"
 msgstr "Время игры"
 
-#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:426
+#: pysollib/stats.py:45 pysollib/pysolgtk/tkstats.py:427
 #: data/pysolfc.glade:1178
 msgid "Moves"
 msgstr "Ходов"
 
-#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:427
-#: pysollib/tile/tkstats.py:920 pysollib/tile/tkstats.py:950
-#: pysollib/tile/tkstats.py:969 pysollib/tile/tkstats.py:987
-#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:878
-#: pysollib/tk/tkstats.py:896 pysollib/tk/tkstats.py:950
+#: pysollib/stats.py:46 pysollib/pysolgtk/tkstats.py:428
+#: pysollib/tile/tkstats.py:921 pysollib/tile/tkstats.py:951
+#: pysollib/tile/tkstats.py:970 pysollib/tile/tkstats.py:988
+#: pysollib/tk/tkstats.py:860 pysollib/tk/tkstats.py:879
+#: pysollib/tk/tkstats.py:897 pysollib/tk/tkstats.py:951
 msgid "% won"
 msgstr "% побед"
 
 #: pysollib/stats.py:108 pysollib/pysolgtk/statusbar.py:100
-#: pysollib/pysolgtk/tkstats.py:389 pysollib/pysolgtk/tkstats.py:459
-#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:677
-#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:670
+#: pysollib/pysolgtk/tkstats.py:390 pysollib/pysolgtk/tkstats.py:460
+#: pysollib/tile/statusbar.py:156 pysollib/tile/tkstats.py:678
+#: pysollib/tk/statusbar.py:153 pysollib/tk/tkstats.py:671
 msgid "Game number"
 msgstr "Номер игры"
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:390
-#: pysollib/pysolgtk/tkstats.py:460 pysollib/tile/tkstats.py:680
-#: pysollib/tk/tkstats.py:673
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:391
+#: pysollib/pysolgtk/tkstats.py:461 pysollib/tile/tkstats.py:681
+#: pysollib/tk/tkstats.py:674
 msgid "Started at"
 msgstr "Игра начата"
 
-#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:461
+#: pysollib/stats.py:108 pysollib/pysolgtk/tkstats.py:462
 msgid "Status"
 msgstr "Статус"
 
-#: pysollib/stats.py:132 pysollib/tile/tkstats.py:696
+#: pysollib/stats.py:132 pysollib/tile/tkstats.py:697
 #, python-format
 msgid "** UNKNOWN %d **"
 msgstr ""
@@ -1393,23 +1436,16 @@ msgstr "Не выиграл"
 msgid "Perfect"
 msgstr "Великолепная"
 
-#: pysollib/stats.py:201 pysollib/stats.py:233 pysollib/stats.py:240
+#: pysollib/stats.py:201 pysollib/stats.py:234 pysollib/stats.py:241
+#: pysollib/kivy/menubar.py:443
 msgid "Demo"
 msgstr "Демо"
 
 #: pysollib/stats.py:212 pysollib/pysolgtk/tkstats.py:70
 #: pysollib/tile/tkstats.py:371 pysollib/tk/tkstats.py:413
 #, python-format
-msgid "Total (%d out of %d games)"
-msgstr "Всего (%d из %d игр)"
-
-#: pysollib/stats.py:234
-msgid "Full log for "
-msgstr "Полный лог для "
-
-#: pysollib/stats.py:241
-msgid "Session log for "
-msgstr "Лог сессии для "
+msgid "Total (%(played)d out of %(total)d games)"
+msgstr "Всего (%(played)d из %(total)d игр)"
 
 #: pysollib/util.py:45
 msgid "Club"
@@ -1476,48 +1512,48 @@ msgid "Initial setting:"
 msgstr "Предварительные установки:"
 
 #: pysollib/wizardutil.py:105 pysollib/pysolgtk/selectgame.py:114
-#: pysollib/tile/selectgame.py:393 pysollib/tk/selectgame.py:395
+#: pysollib/tile/selectgame.py:391 pysollib/tk/selectgame.py:392
 msgid "Name:"
 msgstr "Имя:"
 
 #: pysollib/wizardutil.py:109 pysollib/kivy/selectgame.py:202
 #: pysollib/pysolgtk/selectgame.py:236 pysollib/pysolgtk/selectgame.py:473
-#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:563
-#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:564
+#: pysollib/tile/selectgame.py:179 pysollib/tile/selectgame.py:561
+#: pysollib/tk/selectgame.py:179 pysollib/tk/selectgame.py:562
 msgid "Luck only"
 msgstr "Только на везение"
 
 #: pysollib/wizardutil.py:110 pysollib/kivy/selectgame.py:204
 #: pysollib/pysolgtk/selectgame.py:237 pysollib/pysolgtk/selectgame.py:474
-#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:564
-#: pysollib/tk/selectgame.py:183 pysollib/tk/selectgame.py:565
+#: pysollib/tile/selectgame.py:181 pysollib/tile/selectgame.py:562
+#: pysollib/tk/selectgame.py:181 pysollib/tk/selectgame.py:563
 msgid "Mostly luck"
 msgstr "В основном на везение"
 
 #: pysollib/wizardutil.py:111 pysollib/wizardutil.py:115
 #: pysollib/kivy/selectgame.py:206 pysollib/pysolgtk/selectgame.py:238
 #: pysollib/pysolgtk/selectgame.py:475 pysollib/tile/selectgame.py:183
-#: pysollib/tile/selectgame.py:565 pysollib/tk/selectgame.py:185
-#: pysollib/tk/selectgame.py:566
+#: pysollib/tile/selectgame.py:563 pysollib/tk/selectgame.py:183
+#: pysollib/tk/selectgame.py:564
 msgid "Balanced"
 msgstr "Сбалансированные"
 
 #: pysollib/wizardutil.py:112 pysollib/kivy/selectgame.py:208
 #: pysollib/pysolgtk/selectgame.py:239 pysollib/pysolgtk/selectgame.py:476
-#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:566
-#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:567
+#: pysollib/tile/selectgame.py:186 pysollib/tile/selectgame.py:564
+#: pysollib/tk/selectgame.py:186 pysollib/tk/selectgame.py:565
 msgid "Mostly skill"
 msgstr "В основном на мастерство"
 
 #: pysollib/wizardutil.py:113 pysollib/kivy/selectgame.py:210
 #: pysollib/pysolgtk/selectgame.py:240 pysollib/pysolgtk/selectgame.py:477
-#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:567
-#: pysollib/tk/selectgame.py:190 pysollib/tk/selectgame.py:568
+#: pysollib/tile/selectgame.py:188 pysollib/tile/selectgame.py:565
+#: pysollib/tk/selectgame.py:188 pysollib/tk/selectgame.py:566
 msgid "Skill only"
 msgstr "Только на мастерство"
 
 #: pysollib/wizardutil.py:116 pysollib/pysolgtk/selectgame.py:118
-#: pysollib/tile/selectgame.py:397 pysollib/tk/selectgame.py:399
+#: pysollib/tile/selectgame.py:395 pysollib/tk/selectgame.py:396
 msgid "Skill level:"
 msgstr "Уровень мастерства:"
 
@@ -1572,8 +1608,8 @@ msgstr ""
 #: pysollib/wizardutil.py:147 pysollib/wizardutil.py:185
 #: pysollib/wizardutil.py:243 pysollib/wizardutil.py:301
 #: pysollib/pysolgtk/selectgame.py:117 pysollib/tile/selectcardset.py:454
-#: pysollib/tile/selectgame.py:396 pysollib/tk/selectcardset.py:445
-#: pysollib/tk/selectgame.py:398
+#: pysollib/tile/selectgame.py:394 pysollib/tk/selectcardset.py:445
+#: pysollib/tk/selectgame.py:395
 msgid "Type:"
 msgstr "Тип:"
 
@@ -1595,7 +1631,7 @@ msgstr "Три пересдачи"
 
 #: pysollib/wizardutil.py:155 pysollib/kivy/selectgame.py:252
 #: pysollib/pysolgtk/selectgame.py:273 pysollib/tile/selectgame.py:231
-#: pysollib/tk/selectgame.py:233
+#: pysollib/tk/selectgame.py:231
 msgid "Unlimited redeals"
 msgstr "Неограниченное количество пересдач"
 
@@ -1665,6 +1701,7 @@ msgid "Direction:"
 msgstr "Направление:"
 
 #: pysollib/wizardutil.py:204 pysollib/wizardutil.py:250
+#: pysollib/kivy/menubar.py:884
 msgid "None"
 msgstr "Нет"
 
@@ -1789,57 +1826,58 @@ msgstr "Резервные ячейки"
 msgid "Opening deal"
 msgstr "Начальная раздача"
 
-#: pysollib/game/__init__.py:139 pysollib/game/__init__.py:145
+#: pysollib/game/__init__.py:140 pysollib/game/__init__.py:146
 msgid "Player\n"
 msgstr "Игрок\n"
 
-#: pysollib/game/__init__.py:1266
-msgid "Discard current game ?"
+#: pysollib/game/__init__.py:1301
+#, fuzzy
+msgid "Discard current game?"
 msgstr "Завершить текущую игру?"
 
-#: pysollib/game/__init__.py:1887
+#: pysollib/game/__init__.py:1922
 #, fuzzy, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of playing time\n"
-"and # %d in the %s of moves."
+"# %(timerank)d in the top %(tops)d of playing time\n"
+"and # %(movesrank)d in the top %(tops)d of moves."
 msgstr ""
 "\n"
 "Вы достигли\n"
 "#%d в %s игрового времени\n"
 "и #%d в %s количества ходов."
 
-#: pysollib/game/__init__.py:1893
+#: pysollib/game/__init__.py:1930
 #, fuzzy, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of playing time."
+"# %(timerank)d in the top %(tops)d of playing time."
 msgstr ""
 "\n"
 "Вы достигли\n"
 "#%d в %s игрового времени."
 
-#: pysollib/game/__init__.py:1898
+#: pysollib/game/__init__.py:1936
 #, fuzzy, python-format
 msgid ""
 "\n"
 "You have reached\n"
-"# %d in the %s of moves."
+"# %(movesrank)d in the top %(tops)s of moves."
 msgstr ""
 "\n"
 "Вы достигли\n"
 "#%d в %s количества ходов."
 
-#: pysollib/game/__init__.py:1931 pysollib/game/__init__.py:1947
+#: pysollib/game/__init__.py:1971 pysollib/game/__init__.py:1987
 #, fuzzy, python-format
 msgid ""
-"Your playing time is %s\n"
-"for %d move."
+"Your playing time is %(time)s\n"
+"for %(n)d move."
 msgid_plural ""
-"Your playing time is %s\n"
-"for %d moves."
+"Your playing time is %(time)s\n"
+"for %(n)d moves."
 msgstr[0] ""
 "Ваше игровое время: %s\n"
 "Количество ходов: %s"
@@ -1850,53 +1888,34 @@ msgstr[2] ""
 "Ваше игровое время: %s\n"
 "Количество ходов: %s"
 
-#: pysollib/game/__init__.py:1936 pysollib/game/__init__.py:1952
-#: pysollib/pysolgtk/soundoptionsdialog.py:71
+#: pysollib/game/__init__.py:1975
+msgid ""
+"Congratulations, this\n"
+"was a truly perfect game!"
+msgstr ""
+"Поздравляем!\n"
+"Это была действительно\n"
+"великолепная игра!"
+
+#: pysollib/game/__init__.py:1977 pysollib/game/__init__.py:1993
+#: pysollib/kivy/tkwidget.py:170 pysollib/pysolgtk/soundoptionsdialog.py:71
 #: pysollib/tile/soundoptionsdialog.py:83 pysollib/tk/soundoptionsdialog.py:85
 msgid "Game won"
 msgstr "Игра выиграна"
 
-#: pysollib/game/__init__.py:1937
-#, python-format
-msgid ""
-"\n"
-"Congratulations, this\n"
-"was a truly perfect game !\n"
-"\n"
-"%s\n"
-"%s\n"
+#: pysollib/game/__init__.py:1991
+msgid "Congratulations, you did it!"
 msgstr ""
-"\n"
 "Поздравляем!\n"
-"Это была действительно\n"
-"великолепная игра!\n"
-"\n"
-"%s\n"
-"%s\n"
+"Вы сделали это!"
 
-#: pysollib/game/__init__.py:1954
-#, python-format
-msgid ""
-"\n"
-"Congratulations, you did it !\n"
-"\n"
-"%s\n"
-"%s\n"
-msgstr ""
-"\n"
-"Поздравляем!\n"
-"Вы сделали это!\n"
-"\n"
-"%s\n"
-"%s\n"
-
-#: pysollib/game/__init__.py:1963 pysollib/game/__init__.py:1970
-#: pysollib/pysolgtk/soundoptionsdialog.py:69
+#: pysollib/game/__init__.py:2001 pysollib/game/__init__.py:2008
+#: pysollib/kivy/tkwidget.py:173 pysollib/pysolgtk/soundoptionsdialog.py:69
 #: pysollib/tile/soundoptionsdialog.py:81 pysollib/tk/soundoptionsdialog.py:83
 msgid "Game finished"
 msgstr "Игра закончена"
 
-#: pysollib/game/__init__.py:1964 pysollib/game/__init__.py:2488
+#: pysollib/game/__init__.py:2002 pysollib/game/__init__.py:2527
 msgid ""
 "\n"
 "Game finished\n"
@@ -1904,7 +1923,7 @@ msgstr ""
 "\n"
 "Игра закончена\n"
 
-#: pysollib/game/__init__.py:1971
+#: pysollib/game/__init__.py:2009
 msgid ""
 "\n"
 "Game finished, but not without my help...\n"
@@ -1912,32 +1931,32 @@ msgstr ""
 "\n"
 "Игра закончена, но не без моей помощи...\n"
 
-#: pysollib/game/__init__.py:1972
+#: pysollib/game/__init__.py:2010
 msgid "&Restart"
 msgstr "&Начало"
 
-#: pysollib/game/__init__.py:2368
+#: pysollib/game/__init__.py:2406
 #, python-format
 msgid "Score %6d"
 msgstr "Счёт %6d"
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 msgid "&Great"
 msgstr "&Здорово"
 
-#: pysollib/game/__init__.py:2472
+#: pysollib/game/__init__.py:2510
 msgid "&Cool"
 msgstr "&Отлично"
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 msgid "&Yeah"
 msgstr "&Ага"
 
-#: pysollib/game/__init__.py:2473
+#: pysollib/game/__init__.py:2511
 msgid "&Wow"
 msgstr "&Ура"
 
-#: pysollib/game/__init__.py:2474
+#: pysollib/game/__init__.py:2512
 #, python-format
 msgid ""
 "\n"
@@ -1955,24 +1974,25 @@ msgstr[2] ""
 "\n"
 "Игра решена за %d ходов\n"
 
-#: pysollib/game/__init__.py:2478 pysollib/game/__init__.py:2492
-#: pysollib/game/__init__.py:2506
-msgid " Autopilot"
-msgstr " Автопилот"
+#: pysollib/game/__init__.py:2517 pysollib/game/__init__.py:2532
+#: pysollib/game/__init__.py:2547
+#, python-format
+msgid "%s Autopilot"
+msgstr "%s Автопилот"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Oh well"
 msgstr "&Ох"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&That's life"
 msgstr "&Такова жизнь"
 
-#: pysollib/game/__init__.py:2504
+#: pysollib/game/__init__.py:2544
 msgid "&Hmm"
 msgstr "&Хмм"
 
-#: pysollib/game/__init__.py:2507
+#: pysollib/game/__init__.py:2548
 msgid ""
 "\n"
 "This won't come out...\n"
@@ -1980,34 +2000,34 @@ msgstr ""
 "\n"
 "Не удалось...\n"
 
-#: pysollib/game/__init__.py:2966
+#: pysollib/game/__init__.py:3000
 msgid "Set bookmark"
 msgstr "Установить закладку"
 
-#: pysollib/game/__init__.py:2967
-#, python-format
-msgid "Replace existing bookmark %d ?"
+#: pysollib/game/__init__.py:3001
+#, fuzzy, python-format
+msgid "Replace existing bookmark %d?"
 msgstr "Заменить существующую закладку %d ?"
 
-#: pysollib/game/__init__.py:2988
+#: pysollib/game/__init__.py:3022
 msgid "Goto bookmark"
 msgstr "Перейти к закладке"
 
-#: pysollib/game/__init__.py:2989
-#, python-format
-msgid "Goto bookmark %d ?"
+#: pysollib/game/__init__.py:3023
+#, fuzzy, python-format
+msgid "Goto bookmark %d?"
 msgstr "Перейти к закладке %d ?"
 
-#: pysollib/game/__init__.py:3015
+#: pysollib/game/__init__.py:3049
 msgid "Open game"
 msgstr "Открыть игру"
 
-#: pysollib/game/__init__.py:3028 pysollib/game/__init__.py:3037
-#: pysollib/game/__init__.py:3043
+#: pysollib/game/__init__.py:3062 pysollib/game/__init__.py:3071
+#: pysollib/game/__init__.py:3077
 msgid "Load game error"
 msgstr "Ошибка при загрузке игры"
 
-#: pysollib/game/__init__.py:3030
+#: pysollib/game/__init__.py:3064
 msgid ""
 "Error while loading game.\n"
 "\n"
@@ -2019,11 +2039,11 @@ msgstr ""
 "Возможно повреждён файл,\n"
 "или ошибка в программе."
 
-#: pysollib/game/__init__.py:3038
+#: pysollib/game/__init__.py:3072
 msgid "Error while loading game"
 msgstr "Ошибка при загрузке игры"
 
-#: pysollib/game/__init__.py:3045
+#: pysollib/game/__init__.py:3079
 msgid ""
 "Internal error while loading game.\n"
 "\n"
@@ -2033,27 +2053,27 @@ msgstr ""
 "\n"
 "Пожалуйста сообщите об этой ошибке."
 
-#: pysollib/game/__init__.py:3071 pysollib/ui/tktile/menubar.py:1675
+#: pysollib/game/__init__.py:3105 pysollib/ui/tktile/menubar.py:1677
 msgid "Save game error"
 msgstr "Ошибка при сохранении игры"
 
-#: pysollib/game/__init__.py:3072
+#: pysollib/game/__init__.py:3106
 msgid "Error while saving game"
 msgstr "Ошибка при сохранении игры"
 
-#: pysollib/game/__init__.py:3091
+#: pysollib/game/__init__.py:3125
 #, python-format
 msgid "Invalid or damaged %s save file"
 msgstr ""
 
-#: pysollib/game/__init__.py:3111
+#: pysollib/game/__init__.py:3145
 #, python-format
 msgid ""
 "Cannot load games saved with\n"
-"%s version %s"
+"%(app)s version %(ver)s"
 msgstr ""
 
-#: pysollib/game/__init__.py:3130
+#: pysollib/game/__init__.py:3164
 #, python-format
 msgid ""
 "Cannot load this game from version %s\n"
@@ -2140,10 +2160,10 @@ msgstr "Резерв. Только для королей."
 
 #: pysollib/games/matriarchy.py:123
 #, python-format
-msgid "Round %d/%d"
-msgstr "Раунд %d/%d"
+msgid "Round %(round)d/%(max_rounds)d"
+msgstr "Раунд %(round)d/%(max_rounds)d"
 
-#: pysollib/games/matriarchy.py:125
+#: pysollib/games/matriarchy.py:126
 #, python-format
 msgid "Deal %d"
 msgstr "Сдача %d"
@@ -2226,6 +2246,517 @@ msgstr ""
 "Игровой стол. Складывать по убыванию не считаясь с мастью, можно перемещать "
 "любую серию открытых карт."
 
+#: pysollib/kivy/menubar.py:179
+msgid "File"
+msgstr "Файл"
+
+#: pysollib/kivy/menubar.py:183
+#, fuzzy
+msgid "Games"
+msgstr "Игра"
+
+#: pysollib/kivy/menubar.py:188 pysollib/kivy/menubar.py:1605
+#, fuzzy
+msgid "Tools"
+msgstr "Панель инструментов"
+
+#: pysollib/kivy/menubar.py:192 pysollib/kivy/menubar.py:1613
+#: pysollib/pysolgtk/selectgame.py:100 pysollib/pysolgtk/tkstats.py:177
+#: pysollib/tile/selectgame.py:385 pysollib/tile/tkstats.py:51
+#: pysollib/tile/toolbar.py:188 pysollib/tk/selectgame.py:384
+#: pysollib/tk/toolbar.py:188
+msgid "Statistics"
+msgstr "Статистика"
+
+#: pysollib/kivy/menubar.py:196
+#, fuzzy
+msgid "Assist"
+msgstr "&Подсказка"
+
+#: pysollib/kivy/menubar.py:201 pysollib/kivy/menubar.py:1629
+msgid "Options"
+msgstr "Настройка"
+
+#: pysollib/kivy/menubar.py:206 pysollib/kivy/menubar.py:320
+#: pysollib/kivy/menubar.py:1637
+msgid "Help"
+msgstr "Помощь"
+
+#: pysollib/kivy/menubar.py:227
+msgid "Recent games"
+msgstr "Выбрать недавнюю игру"
+
+#: pysollib/kivy/menubar.py:240
+msgid "Favorite games"
+msgstr "Избранные игры"
+
+#: pysollib/kivy/menubar.py:243
+msgid "<Add>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:245
+msgid "<Remove>"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:296 pysollib/kivy/toolbar.py:197
+#: pysollib/pysolgtk/soundoptionsdialog.py:63
+#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
+#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
+msgid "Undo"
+msgstr "Отмена"
+
+#: pysollib/kivy/menubar.py:298 pysollib/kivy/toolbar.py:198
+#: pysollib/pysolgtk/soundoptionsdialog.py:64
+#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
+#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
+msgid "Redo"
+msgstr "Повтор"
+
+#: pysollib/kivy/menubar.py:300
+#, fuzzy
+msgid "Redo all"
+msgstr "Вернуть все"
+
+#: pysollib/kivy/menubar.py:303 pysollib/kivy/menubar.py:517
+#: pysollib/pysolgtk/soundoptionsdialog.py:56
+#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
+msgid "Auto drop"
+msgstr "Автоматический сброс карты"
+
+#: pysollib/kivy/menubar.py:305 pysollib/kivy/toolbar.py:200
+#: pysollib/tile/toolbar.py:185 pysollib/tk/toolbar.py:185
+msgid "Shuffle tiles"
+msgstr "Перемешать фишки"
+
+#: pysollib/kivy/menubar.py:307
+msgid "Deal cards"
+msgstr "Сдать карты"
+
+#: pysollib/kivy/menubar.py:310 pysollib/kivy/toolbar.py:201
+#: pysollib/tile/toolbar.py:186 pysollib/tk/toolbar.py:186
+msgid "Pause"
+msgstr "Пауза"
+
+#: pysollib/kivy/menubar.py:315
+#, fuzzy
+msgid "Load game"
+msgstr "Ошибка при загрузке игры"
+
+#: pysollib/kivy/menubar.py:317 pysollib/tile/toolbar.py:180
+#: pysollib/tk/toolbar.py:180
+msgid "Save game"
+msgstr "Сохранить игру"
+
+#: pysollib/kivy/menubar.py:371
+#, fuzzy
+msgid "Current game..."
+msgstr "Текущая игра..."
+
+#: pysollib/kivy/menubar.py:434
+#, fuzzy
+msgid "Hint"
+msgstr "Подсказка:"
+
+#: pysollib/kivy/menubar.py:437
+#, fuzzy
+msgid "Highlight piles"
+msgstr "Подсветка групп:"
+
+#: pysollib/kivy/menubar.py:509
+#, fuzzy
+msgid "Automatic play"
+msgstr "Настройки &автоматической игры"
+
+#: pysollib/kivy/menubar.py:512
+#, fuzzy
+msgid "Auto face up"
+msgstr "Автоматически &переворачивать"
+
+#: pysollib/kivy/menubar.py:522
+#, fuzzy
+msgid "Auto deal"
+msgstr "Автоматически &сдавать карты"
+
+#: pysollib/kivy/menubar.py:529
+#, fuzzy
+msgid "Quick play"
+msgstr "&Быстрая игра"
+
+#: pysollib/kivy/menubar.py:537
+#, fuzzy
+msgid "Assist level"
+msgstr "&Уровень подсказки"
+
+#: pysollib/kivy/menubar.py:540
+#, fuzzy
+msgid "Enable undo"
+msgstr "Разрешить &возврат хода"
+
+#: pysollib/kivy/menubar.py:545
+#, fuzzy
+msgid "Enable bookmarks"
+msgstr "Разрешить &закладки"
+
+#: pysollib/kivy/menubar.py:550
+#, fuzzy
+msgid "Enable hint"
+msgstr "Разрешить &подсказки"
+
+#: pysollib/kivy/menubar.py:555
+#, fuzzy
+msgid "Enable shuffle"
+msgstr "Разрешить перемешивание &фишек"
+
+#: pysollib/kivy/menubar.py:560
+#, fuzzy
+msgid "Enable highlight piles"
+msgstr "Разрешить показывать к&учи"
+
+#: pysollib/kivy/menubar.py:565
+#, fuzzy
+msgid "Enable highlight cards"
+msgstr "Разрешить показывать &карты"
+
+#: pysollib/kivy/menubar.py:570
+#, fuzzy
+msgid "Enable highlight same rank"
+msgstr "Разрешить показывать карты &одного достоинства"
+
+#: pysollib/kivy/menubar.py:575
+#, fuzzy
+msgid "Highlight no matching"
+msgstr "Подсветка отсутствия &совпадения"
+
+#: pysollib/kivy/menubar.py:582
+#, fuzzy
+msgid "Show removed tiles (in Mahjongg games)"
+msgstr "Показывать удалённые (в Маджонг)"
+
+#: pysollib/kivy/menubar.py:587
+#, fuzzy
+msgid "Show hint arrow (in Shisen-Sho games)"
+msgstr "Показывать стрелку (в Шисен-Сё)"
+
+#: pysollib/kivy/menubar.py:597
+#, fuzzy
+msgid "Sound"
+msgstr "&Звук..."
+
+#: pysollib/kivy/menubar.py:600
+#, fuzzy
+msgid "Enable"
+msgstr "Разрешить &возврат хода"
+
+#: pysollib/kivy/menubar.py:605
+msgid "Volume"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:608
+msgid "100%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:612
+msgid "75%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:616
+msgid "50%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:620
+msgid "25%"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:625
+#, fuzzy
+msgid "Samples"
+msgstr "Простые игры"
+
+#: pysollib/kivy/menubar.py:630
+msgid "are you sure"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:636
+#, fuzzy
+msgid "auto drop"
+msgstr "Автоматический сброс карты"
+
+#: pysollib/kivy/menubar.py:642
+#, fuzzy
+msgid "auto flip"
+msgstr "Автоматическое переворачивание"
+
+#: pysollib/kivy/menubar.py:648
+#, fuzzy
+msgid "auto pilot lost"
+msgstr "Автопилот выиграл"
+
+#: pysollib/kivy/menubar.py:654
+#, fuzzy
+msgid "auto pilot won"
+msgstr "Автопилот проиграл"
+
+#: pysollib/kivy/menubar.py:660
+#, fuzzy
+msgid "deal"
+msgstr "Сдать"
+
+#: pysollib/kivy/menubar.py:666
+#, fuzzy
+msgid "deal waste"
+msgstr "Выкладывание на сброс"
+
+#: pysollib/kivy/menubar.py:672
+#, fuzzy
+msgid "drop pair"
+msgstr "Сброс двух карт"
+
+#: pysollib/kivy/menubar.py:678
+#, fuzzy
+msgid "drop"
+msgstr "Сбросить"
+
+#: pysollib/kivy/menubar.py:684
+#, fuzzy
+msgid "flip"
+msgstr "Автоматическое переворачивание"
+
+#: pysollib/kivy/menubar.py:690
+#, fuzzy
+msgid "move"
+msgstr "Отмена перемещения"
+
+#: pysollib/kivy/menubar.py:696
+#, fuzzy
+msgid "no move"
+msgstr "Отмена перемещения"
+
+#: pysollib/kivy/menubar.py:702
+msgid "redo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:708
+#, fuzzy
+msgid "start drag"
+msgstr "Начало перемещения"
+
+#: pysollib/kivy/menubar.py:714
+#, fuzzy
+msgid "turn waste"
+msgstr "Перелистывание сброса"
+
+#: pysollib/kivy/menubar.py:720
+msgid "undo"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:726
+#, fuzzy
+msgid "game finished"
+msgstr "Игра закончена"
+
+#: pysollib/kivy/menubar.py:732
+#, fuzzy
+msgid "game lost"
+msgstr "Игра проиграна"
+
+#: pysollib/kivy/menubar.py:738
+#, fuzzy
+msgid "game perfect"
+msgstr "Великолепная"
+
+#: pysollib/kivy/menubar.py:744
+#, fuzzy
+msgid "game won"
+msgstr "Игра выиграна"
+
+#: pysollib/kivy/menubar.py:752
+#, fuzzy
+msgid "Cardsets"
+msgstr "Все колоды"
+
+#: pysollib/kivy/menubar.py:792
+#, fuzzy
+msgid "Table"
+msgstr "Игровой стол"
+
+#: pysollib/kivy/menubar.py:795
+msgid "Solid colors"
+msgstr "Монотонный цвет"
+
+#: pysollib/kivy/menubar.py:800 pysollib/pysolgtk/selecttile.py:105
+#: pysollib/tile/selecttile.py:74 pysollib/tk/selecttile.py:73
+msgid "Blue"
+msgstr "Голубой"
+
+#: pysollib/kivy/menubar.py:805 pysollib/pysolgtk/selecttile.py:106
+#: pysollib/tile/selecttile.py:75 pysollib/tk/selecttile.py:74
+#: pysollib/games/ultra/dashavatara.py:361 pysollib/games/ultra/mughal.py:264
+msgid "Green"
+msgstr "Зелёный"
+
+#: pysollib/kivy/menubar.py:810 pysollib/pysolgtk/selecttile.py:107
+#: pysollib/tile/selecttile.py:76 pysollib/tk/selecttile.py:75
+msgid "Navy"
+msgstr "Синий"
+
+#: pysollib/kivy/menubar.py:815 pysollib/pysolgtk/selecttile.py:108
+#: pysollib/tile/selecttile.py:77 pysollib/tk/selecttile.py:76
+#: pysollib/games/ultra/dashavatara.py:362
+msgid "Olive"
+msgstr "Оливковый"
+
+#: pysollib/kivy/menubar.py:820 pysollib/pysolgtk/selecttile.py:109
+#: pysollib/tile/selecttile.py:78 pysollib/tk/selecttile.py:77
+#: pysollib/games/ultra/dashavatara.py:362 pysollib/games/ultra/mughal.py:264
+msgid "Orange"
+msgstr "Оранжевый"
+
+#: pysollib/kivy/menubar.py:825 pysollib/pysolgtk/selecttile.py:110
+#: pysollib/tile/selecttile.py:79 pysollib/tk/selecttile.py:78
+msgid "Teal"
+msgstr "Чайный"
+
+#: pysollib/kivy/menubar.py:830
+msgid "Tiles and Images"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:850
+#, fuzzy
+msgid "Card view"
+msgstr "&Вид карты"
+
+#: pysollib/kivy/menubar.py:853
+#, fuzzy
+msgid "Card shadow"
+msgstr "Тень карты"
+
+#: pysollib/kivy/menubar.py:858
+#, fuzzy
+msgid "Shade legal moves"
+msgstr "Подсвечивать &разрешённые ходы"
+
+#: pysollib/kivy/menubar.py:863
+#, fuzzy
+msgid "Negative cards bottom"
+msgstr "&Негативные контуры карты"
+
+#: pysollib/kivy/menubar.py:868 pysollib/ui/tktile/menubar.py:559
+msgid "Shrink face-down cards"
+msgstr "Сжимать закрытые карты"
+
+#: pysollib/kivy/menubar.py:873
+#, fuzzy
+msgid "Shade filled stacks"
+msgstr "Затемнять заполненные ячейки"
+
+#: pysollib/kivy/menubar.py:881
+#, fuzzy
+msgid "Animations"
+msgstr "Анимаци&я"
+
+#: pysollib/kivy/menubar.py:889
+#, fuzzy
+msgid "Very fast"
+msgstr "&Очень быстрая"
+
+#: pysollib/kivy/menubar.py:894
+#, fuzzy
+msgid "Fast"
+msgstr "&Быстрая"
+
+#: pysollib/kivy/menubar.py:899
+#, fuzzy
+msgid "Medium"
+msgstr "С&редняя"
+
+#: pysollib/kivy/menubar.py:904
+#, fuzzy
+msgid "Slow"
+msgstr "&Медленная"
+
+#: pysollib/kivy/menubar.py:909
+#, fuzzy
+msgid "Very slow"
+msgstr "&Очень медленная"
+
+#: pysollib/kivy/menubar.py:916
+#, fuzzy
+msgid "Redeal animation"
+msgstr "Анимация пере&сдачи"
+
+#: pysollib/kivy/menubar.py:921
+#, fuzzy
+msgid "Winning animation"
+msgstr "Анимация &победы"
+
+#: pysollib/kivy/menubar.py:929
+msgid "Touch mode"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:932
+msgid "Drag-and-Drop"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:937
+msgid "Point-and-Click"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:971 pysollib/tile/toolbar.py:202
+#: pysollib/tk/toolbar.py:211
+msgid "Toolbar"
+msgstr "Панель инструментов"
+
+#: pysollib/kivy/menubar.py:974 pysollib/ui/tktile/menubar.py:41
+msgid "Hide"
+msgstr "Спрятать"
+
+#: pysollib/kivy/menubar.py:989 pysollib/ui/tktile/menubar.py:50
+msgid "Left"
+msgstr "Слева"
+
+#: pysollib/kivy/menubar.py:993 pysollib/ui/tktile/menubar.py:53
+msgid "Right"
+msgstr "Справа"
+
+#: pysollib/kivy/menubar.py:1030
+#, fuzzy
+msgid "Startup splash screen"
+msgstr "О&кно запуска"
+
+#: pysollib/kivy/menubar.py:1035
+msgid "Winning splash"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1058
+msgid "Contents"
+msgstr "Содержание"
+
+#: pysollib/kivy/menubar.py:1062
+msgid "How to play"
+msgstr "Как играть"
+
+#: pysollib/kivy/menubar.py:1066 pysollib/kivy/toolbar.py:204
+#: pysollib/tile/toolbar.py:189 pysollib/tk/toolbar.py:189
+msgid "Rules for this game"
+msgstr "Правила текущей игры"
+
+#: pysollib/kivy/menubar.py:1070
+msgid "License terms"
+msgstr "Лицензия"
+
+#: pysollib/kivy/menubar.py:1074
+#, python-format
+msgid "About %s..."
+msgstr "О программе %s..."
+
+#: pysollib/kivy/menubar.py:1348
+msgid "Menu"
+msgstr ""
+
+#: pysollib/kivy/menubar.py:1576 pysollib/ui/tktile/menubar.py:971
+msgid "<none>"
+msgstr ""
+
 #: pysollib/kivy/menubar.py:1589
 msgid "Main Menu"
 msgstr ""
@@ -2234,288 +2765,331 @@ msgstr ""
 msgid "File Menu"
 msgstr ""
 
-#: pysollib/kivy/menubar.py:1605
-#, fuzzy
-msgid "Tools"
-msgstr "Панель инструментов"
-
 #: pysollib/kivy/menubar.py:1621
 #, fuzzy
 msgid "Assists"
 msgstr "&Подсказка"
 
-#: pysollib/kivy/menubar.py:1629
-#, fuzzy
-msgid "Options"
-msgstr "&Настройка"
+#. TRANSLATORS: Usually, 'PySol files'
+#: pysollib/kivy/menubar.py:1795 pysollib/ui/tktile/menubar.py:1136
+#, fuzzy, python-format
+msgid "%s files"
+msgstr "Всё время"
 
-#: pysollib/kivy/menubar.py:1637
+#: pysollib/kivy/menubar.py:1796 pysollib/ui/tktile/menubar.py:1137
 #, fuzzy
-msgid "Help"
-msgstr " Помощь"
+msgid "All files"
+msgstr "Всё время"
 
-#: pysollib/kivy/menubar.py:2065 pysollib/kivy/menubar.py:2067
-#: pysollib/kivy/selectcardset.py:61 pysollib/pysolgtk/selectcardset.py:229
+#: pysollib/kivy/menubar.py:2066 pysollib/kivy/menubar.py:2068
+#: pysollib/kivy/selectcardset.py:57 pysollib/pysolgtk/selectcardset.py:229
 #: pysollib/tk/menubar.py:89 pysollib/tk/menubar.py:90
 #: pysollib/tk/selectcardset.py:313
 msgid "&Load"
 msgstr "&Загрузить"
 
-#: pysollib/kivy/menubar.py:2068 pysollib/kivy/selectcardset.py:61
+#: pysollib/kivy/menubar.py:2069 pysollib/kivy/selectcardset.py:57
 #: pysollib/pysolgtk/selectcardset.py:229 pysollib/tile/selectcardset.py:318
 #: pysollib/tk/menubar.py:90
 msgid "&Info..."
 msgstr "&Информация..."
 
-#: pysollib/kivy/menubar.py:2072 pysollib/tile/menubar.py:90
-#: pysollib/tk/menubar.py:94
-msgid "Select "
-msgstr "Выбрать "
+#: pysollib/kivy/menubar.py:2072 pysollib/pysolgtk/menubar.py:696
+#, fuzzy
+msgid "Select cardset"
+msgstr "Выбрать имя"
 
-#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1664
+#: pysollib/kivy/menubar.py:2285 pysollib/ui/tktile/menubar.py:1666
 msgid "Solitaire Wizard"
 msgstr "Конструктор пасьянсов"
 
 #: pysollib/kivy/selectgame.py:83 pysollib/tile/selectgame.py:84
-#: pysollib/tk/selectgame.py:85
+#: pysollib/tk/selectgame.py:84
 msgid "(no games)"
 msgstr "(нет игр)"
 
 #: pysollib/kivy/selectgame.py:104 pysollib/pysolgtk/selectgame.py:227
-#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:109
+#: pysollib/tile/selectgame.py:108 pysollib/tk/selectgame.py:108
 msgid "Mahjongg Games"
 msgstr "Игры маджонг"
 
 #: pysollib/kivy/selectgame.py:108 pysollib/pysolgtk/selectgame.py:233
-#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:113
+#: pysollib/tile/selectgame.py:112 pysollib/tk/selectgame.py:112
 msgid "French games"
 msgstr "Классические игры"
 
 #: pysollib/kivy/selectgame.py:111 pysollib/pysolgtk/selectgame.py:229
-#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:116
+#: pysollib/tile/selectgame.py:115 pysollib/tk/selectgame.py:115
 msgid "Oriental Games"
 msgstr "Восточные игры"
 
 #: pysollib/kivy/selectgame.py:114 pysollib/pysolgtk/selectgame.py:231
-#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:119
+#: pysollib/tile/selectgame.py:118 pysollib/tk/selectgame.py:118
 msgid "Special Games"
 msgstr "Особые игры"
 
 #: pysollib/kivy/selectgame.py:117 pysollib/pysolgtk/selectgame.py:315
-#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:122
+#: pysollib/tile/selectgame.py:121 pysollib/tk/selectgame.py:121
 msgid "Original Games"
 msgstr "Оригинальные игры"
 
 #: pysollib/kivy/selectgame.py:146 pysollib/pysolgtk/selectgame.py:216
-#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:170
+#: pysollib/tile/selectgame.py:168 pysollib/tk/selectgame.py:168
 msgid "All Games"
 msgstr "Все игры"
 
 #: pysollib/kivy/selectgame.py:157 pysollib/pysolgtk/selectgame.py:286
-#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:138
+#: pysollib/tile/selectgame.py:137 pysollib/tk/selectgame.py:137
 msgid "by Compatibility"
 msgstr "По совместимости с другими программами"
 
 #: pysollib/kivy/selectgame.py:168 pysollib/pysolgtk/selectgame.py:293
-#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:149
-msgid "New games in v. "
-msgstr "Новые игры в версии "
+#: pysollib/tile/selectgame.py:147 pysollib/tk/selectgame.py:147
+#, python-format
+msgid "New games in v. %(version)s"
+msgstr "Новые игры в версии %(version)s"
 
 #: pysollib/kivy/selectgame.py:171 pysollib/pysolgtk/selectgame.py:296
-#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:152
+#: pysollib/tile/selectgame.py:150 pysollib/tk/selectgame.py:150
 msgid "by PySol version"
 msgstr "По версии PySol"
 
 #: pysollib/kivy/selectgame.py:183 pysollib/tile/selectgame.py:161
-#: pysollib/tk/selectgame.py:163
+#: pysollib/tk/selectgame.py:161
 msgid "by Inventors"
 msgstr "По изобретателям игр"
 
 #: pysollib/kivy/selectgame.py:191 pysollib/pysolgtk/selectgame.py:218
-#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:172
+#: pysollib/tile/selectgame.py:170 pysollib/tk/selectgame.py:170
 msgid "Popular Games"
 msgstr "Популярные игры"
 
 #: pysollib/kivy/selectgame.py:198 pysollib/pysolgtk/selectgame.py:217
-#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:171
+#: pysollib/tile/selectgame.py:169 pysollib/tk/selectgame.py:169
 msgid "Alternate Names"
 msgstr "Другие имена"
 
 #: pysollib/kivy/selectgame.py:201 pysollib/pysolgtk/selectgame.py:243
-#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:180
+#: pysollib/tile/selectgame.py:178 pysollib/tk/selectgame.py:178
 msgid "by Skill Level"
 msgstr "По уровню мастерства"
 
 #: pysollib/kivy/selectgame.py:213 pysollib/pysolgtk/selectgame.py:247
-#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:193
+#: pysollib/tile/selectgame.py:191 pysollib/tk/selectgame.py:191
 msgid "by Game Feature"
 msgstr "По особенностям игры"
 
 #: pysollib/kivy/selectgame.py:214 pysollib/pysolgtk/selectgame.py:260
-#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:194
+#: pysollib/tile/selectgame.py:192 pysollib/tk/selectgame.py:192
 msgid "by Number of Cards"
 msgstr "По количеству карт"
 
 #: pysollib/kivy/selectgame.py:215 pysollib/pysolgtk/selectgame.py:249
-#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:195
+#: pysollib/tile/selectgame.py:193 pysollib/tk/selectgame.py:193
 msgid "32 cards"
 msgstr "32 карты"
 
 #: pysollib/kivy/selectgame.py:217 pysollib/pysolgtk/selectgame.py:250
-#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:197
+#: pysollib/tile/selectgame.py:195 pysollib/tk/selectgame.py:195
 msgid "48 cards"
 msgstr "48 карт"
 
 #: pysollib/kivy/selectgame.py:219 pysollib/pysolgtk/selectgame.py:251
-#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:199
+#: pysollib/tile/selectgame.py:197 pysollib/tk/selectgame.py:197
 msgid "52 cards"
 msgstr "52 карты"
 
 #: pysollib/kivy/selectgame.py:221 pysollib/pysolgtk/selectgame.py:252
-#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:201
+#: pysollib/tile/selectgame.py:199 pysollib/tk/selectgame.py:199
 msgid "64 cards"
 msgstr "64 карты"
 
 #: pysollib/kivy/selectgame.py:223 pysollib/pysolgtk/selectgame.py:253
-#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:203
+#: pysollib/tile/selectgame.py:201 pysollib/tk/selectgame.py:201
 msgid "78 cards"
 msgstr "78 карт"
 
 #: pysollib/kivy/selectgame.py:225 pysollib/pysolgtk/selectgame.py:254
-#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:205
+#: pysollib/tile/selectgame.py:203 pysollib/tk/selectgame.py:203
 msgid "104 cards"
 msgstr "104 карты"
 
 #: pysollib/kivy/selectgame.py:227 pysollib/pysolgtk/selectgame.py:255
-#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:207
+#: pysollib/tile/selectgame.py:205 pysollib/tk/selectgame.py:205
 msgid "144 cards"
 msgstr "144 карты"
 
 #: pysollib/kivy/selectgame.py:229 pysollib/pysolgtk/selectgame.py:256
-#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:210
+#: pysollib/tile/selectgame.py:208 pysollib/tk/selectgame.py:208
 msgid "Other number"
 msgstr "Другое количество"
 
 #: pysollib/kivy/selectgame.py:233 pysollib/pysolgtk/selectgame.py:267
-#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:214
+#: pysollib/tile/selectgame.py:212 pysollib/tk/selectgame.py:212
 msgid "by Number of Decks"
 msgstr "По количеству колод"
 
 #: pysollib/kivy/selectgame.py:234 pysollib/pysolgtk/selectgame.py:262
-#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:215
+#: pysollib/tile/selectgame.py:213 pysollib/tk/selectgame.py:213
 msgid "1 deck games"
 msgstr "Игры с 1 колодой"
 
 #: pysollib/kivy/selectgame.py:236 pysollib/pysolgtk/selectgame.py:263
-#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:217
+#: pysollib/tile/selectgame.py:215 pysollib/tk/selectgame.py:215
 msgid "2 deck games"
 msgstr "Игры с 2 колодами"
 
 #: pysollib/kivy/selectgame.py:238 pysollib/pysolgtk/selectgame.py:264
-#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:219
+#: pysollib/tile/selectgame.py:217 pysollib/tk/selectgame.py:217
 msgid "3 deck games"
 msgstr "Игры с 3 колодами"
 
 #: pysollib/kivy/selectgame.py:240 pysollib/pysolgtk/selectgame.py:265
-#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:221
+#: pysollib/tile/selectgame.py:219 pysollib/tk/selectgame.py:219
 msgid "4 deck games"
 msgstr "Игры с 4 колодами"
 
 #: pysollib/kivy/selectgame.py:243 pysollib/pysolgtk/selectgame.py:278
-#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:224
+#: pysollib/tile/selectgame.py:222 pysollib/tk/selectgame.py:222
 msgid "by Number of Redeals"
 msgstr "По количеству пересдач"
 
 #: pysollib/kivy/selectgame.py:244 pysollib/pysolgtk/selectgame.py:269
-#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:225
+#: pysollib/tile/selectgame.py:223 pysollib/tk/selectgame.py:223
 msgid "No redeal"
 msgstr "Без пересдачи"
 
 #: pysollib/kivy/selectgame.py:246 pysollib/pysolgtk/selectgame.py:270
-#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:227
+#: pysollib/tile/selectgame.py:225 pysollib/tk/selectgame.py:225
 msgid "1 redeal"
 msgstr "1 пересдача"
 
 #: pysollib/kivy/selectgame.py:248 pysollib/pysolgtk/selectgame.py:271
-#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:229
+#: pysollib/tile/selectgame.py:227 pysollib/tk/selectgame.py:227
 msgid "2 redeals"
 msgstr "2 пересдачи"
 
 #: pysollib/kivy/selectgame.py:250 pysollib/pysolgtk/selectgame.py:272
-#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:231
+#: pysollib/tile/selectgame.py:229 pysollib/tk/selectgame.py:229
 msgid "3 redeals"
 msgstr "3 пересдачи"
 
 #: pysollib/kivy/selectgame.py:256 pysollib/pysolgtk/selectgame.py:275
-#: pysollib/tile/selectgame.py:236 pysollib/tk/selectgame.py:238
+#: pysollib/tile/selectgame.py:234 pysollib/tk/selectgame.py:234
 msgid "Other number of redeals"
 msgstr "Другое количество пересдач"
 
 #: pysollib/kivy/selectgame.py:264 pysollib/pysolgtk/selectgame.py:311
-#: pysollib/tile/selectgame.py:243 pysollib/tk/selectgame.py:245
+#: pysollib/tile/selectgame.py:241 pysollib/tk/selectgame.py:241
 msgid "Other Categories"
 msgstr "Другие категории"
 
 #: pysollib/kivy/selectgame.py:265 pysollib/pysolgtk/selectgame.py:300
-#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:246
+#: pysollib/tile/selectgame.py:242 pysollib/tk/selectgame.py:242
 msgid "Games for Children (very easy)"
 msgstr "Игры для детей (очень лёгкие)"
 
 #: pysollib/kivy/selectgame.py:267 pysollib/pysolgtk/selectgame.py:302
-#: pysollib/tile/selectgame.py:246 pysollib/tk/selectgame.py:248
+#: pysollib/tile/selectgame.py:244 pysollib/tk/selectgame.py:244
 msgid "Games with Scoring"
 msgstr "Игры со счётом"
 
 #: pysollib/kivy/selectgame.py:269 pysollib/pysolgtk/selectgame.py:304
-#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:251
+#: pysollib/tile/selectgame.py:247 pysollib/tk/selectgame.py:247
 msgid "Games with Separate Decks"
 msgstr "Игры с раздельными колодами"
 
 #: pysollib/kivy/selectgame.py:271 pysollib/pysolgtk/selectgame.py:306
-#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:253
+#: pysollib/tile/selectgame.py:249 pysollib/tk/selectgame.py:249
 msgid "Open Games (all cards visible)"
 msgstr "Открытые игры (все карты видны)"
 
 #: pysollib/kivy/selectgame.py:273 pysollib/pysolgtk/selectgame.py:308
-#: pysollib/tile/selectgame.py:253 pysollib/tk/selectgame.py:255
+#: pysollib/tile/selectgame.py:251 pysollib/tk/selectgame.py:251
 msgid "Relaxed Variants"
 msgstr "Облегчённые варианты"
+
+#: pysollib/kivy/tkhtml.py:409
+#, fuzzy
+msgid "Browser"
+msgstr "Коричневый"
+
+#: pysollib/kivy/tkhtml.py:434 pysollib/pysolgtk/tkhtml.py:218
+#: pysollib/tile/tkhtml.py:77 pysollib/tk/tkhtml.py:72
+msgid "Index"
+msgstr "Индекс"
+
+#: pysollib/kivy/tkhtml.py:435 pysollib/pysolgtk/tkhtml.py:219
+#: pysollib/tile/tkhtml.py:81 pysollib/tk/tkhtml.py:76
+msgid "Back"
+msgstr "Назад"
+
+#: pysollib/kivy/tkhtml.py:437 pysollib/pysolgtk/tkhtml.py:220
+#: pysollib/tile/tkhtml.py:85 pysollib/tk/tkhtml.py:80
+msgid "Forward"
+msgstr "Вперёд"
+
+#: pysollib/kivy/tkhtml.py:438 pysollib/pysolgtk/tkhtml.py:221
+#: pysollib/tile/tkhtml.py:89 pysollib/tk/tkhtml.py:84
+msgid "Close"
+msgstr "Закрыть"
 
 #: pysollib/kivy/tkstats.py:148 pysollib/tile/tkstats.py:163
 #: pysollib/tk/tkstats.py:53
 msgid "Demo games"
 msgstr "Демо игры"
 
-#: pysollib/kivy/tkstats.py:220 pysollib/pysolgtk/selectgame.py:123
-#: pysollib/tile/selectgame.py:402 pysollib/tile/tkstats.py:182
-#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:404
+#: pysollib/kivy/tkstats.py:175
+#, python-format
+msgid ""
+"Total:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+"\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:187
+#, python-format
+msgid ""
+"Current Session:\n"
+"   won: %(won)s ... %(percentwon)s%%\n"
+"   lost: %(lost)s ... %(percentlost)s%%\n"
+msgstr ""
+
+#: pysollib/kivy/tkstats.py:225 pysollib/pysolgtk/selectgame.py:123
+#: pysollib/tile/selectgame.py:400 pysollib/tile/tkstats.py:182
+#: pysollib/tile/tkstats.py:234 pysollib/tk/selectgame.py:401
 #: pysollib/tk/tkstats.py:87 pysollib/tk/tkstats.py:141 data/pysolfc.glade:241
 #: data/pysolfc.glade:519
 msgid "Won:"
 msgstr "Выиграл:"
 
-#: pysollib/kivy/tkstats.py:222 pysollib/pysolgtk/selectgame.py:124
-#: pysollib/tile/selectgame.py:403 pysollib/tile/tkstats.py:183
-#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:405
+#: pysollib/kivy/tkstats.py:227 pysollib/pysolgtk/selectgame.py:124
+#: pysollib/tile/selectgame.py:401 pysollib/tile/tkstats.py:183
+#: pysollib/tile/tkstats.py:236 pysollib/tk/selectgame.py:402
 #: pysollib/tk/tkstats.py:88 pysollib/tk/tkstats.py:143 data/pysolfc.glade:307
 #: data/pysolfc.glade:544
 msgid "Lost:"
 msgstr "Проиграл:"
 
-#: pysollib/kivy/tkstats.py:224 pysollib/tile/tkstats.py:184
+#: pysollib/kivy/tkstats.py:229 pysollib/tile/tkstats.py:184
 #: pysollib/tile/tkstats.py:238 pysollib/tk/tkstats.py:89
 #: pysollib/tk/tkstats.py:145 data/pysolfc.glade:266 data/pysolfc.glade:569
 msgid "Total:"
 msgstr "Всего:"
 
-#: pysollib/kivy/tkstats.py:250 pysollib/tk/tkstats.py:279
+#: pysollib/kivy/tkstats.py:255 pysollib/tk/tkstats.py:279
 msgid "&All games..."
 msgstr "&Все игры..."
 
-#: pysollib/kivy/tkstats.py:252 pysollib/tile/tkstats.py:102
+#: pysollib/kivy/tkstats.py:257 pysollib/tile/tkstats.py:102
 #: pysollib/tk/tkstats.py:281
 msgid "&Reset..."
 msgstr "О&чистить..."
+
+#: pysollib/kivy/tkwidget.py:183
+msgid "Error"
+msgstr ""
 
 #: pysollib/kivy/toolbar.py:191 pysollib/tile/toolbar.py:176
 #: pysollib/tk/toolbar.py:176
@@ -2536,22 +3110,10 @@ msgstr ""
 "Начать текущую игру\n"
 "с начала"
 
-#: pysollib/kivy/toolbar.py:197 pysollib/pysolgtk/soundoptionsdialog.py:63
-#: pysollib/tile/soundoptionsdialog.py:75 pysollib/tile/toolbar.py:182
-#: pysollib/tk/soundoptionsdialog.py:77 pysollib/tk/toolbar.py:182
-msgid "Undo"
-msgstr "Отмена"
-
 #: pysollib/kivy/toolbar.py:197 pysollib/tile/toolbar.py:182
 #: pysollib/tk/toolbar.py:182
 msgid "Undo last move"
 msgstr "Отменить последний ход"
-
-#: pysollib/kivy/toolbar.py:198 pysollib/pysolgtk/soundoptionsdialog.py:64
-#: pysollib/tile/soundoptionsdialog.py:76 pysollib/tile/toolbar.py:183
-#: pysollib/tk/soundoptionsdialog.py:78 pysollib/tk/toolbar.py:183
-msgid "Redo"
-msgstr "Повтор"
 
 #: pysollib/kivy/toolbar.py:198 pysollib/tile/toolbar.py:183
 #: pysollib/tk/toolbar.py:183
@@ -2573,16 +3135,6 @@ msgstr "Автоматически сбросить карты"
 msgid "Shuffle"
 msgstr "Перемешать"
 
-#: pysollib/kivy/toolbar.py:200 pysollib/tile/toolbar.py:185
-#: pysollib/tk/toolbar.py:185
-msgid "Shuffle tiles"
-msgstr "Перемешать фишки"
-
-#: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
-#: pysollib/tk/toolbar.py:186
-msgid "Pause"
-msgstr "Пауза"
-
 #: pysollib/kivy/toolbar.py:201 pysollib/tile/toolbar.py:186
 #: pysollib/tk/toolbar.py:186
 msgid "Pause game"
@@ -2592,11 +3144,6 @@ msgstr "Приостановить игру"
 #: pysollib/tk/toolbar.py:189
 msgid "Rules"
 msgstr "Правила"
-
-#: pysollib/kivy/toolbar.py:204 pysollib/tile/toolbar.py:189
-#: pysollib/tk/toolbar.py:189
-msgid "Rules for this game"
-msgstr "Правила текущей игры"
 
 #: pysollib/kivy/toolbar.py:206 pysollib/tile/toolbar.py:191
 #: pysollib/tk/toolbar.py:191
@@ -2622,19 +3169,14 @@ msgstr "Открыть игру"
 msgid "Save Game"
 msgstr "Сохранить игру"
 
-#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1298
+#: pysollib/pysolgtk/menubar.py:671 pysollib/ui/tktile/menubar.py:1300
 #: data/pysolfc.glade:4127
 msgid "Sound settings"
 msgstr "Настройка звука"
 
-#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1521
+#: pysollib/pysolgtk/menubar.py:680 pysollib/ui/tktile/menubar.py:1523
 msgid "Select table background"
 msgstr "Выбрать фоновое изображение"
-
-#: pysollib/pysolgtk/menubar.py:696
-#, fuzzy
-msgid "Select cardset"
-msgstr "Выбрать имя"
 
 #: pysollib/pysolgtk/playeroptionsdialog.py:62
 #: pysollib/tile/playeroptionsdialog.py:61
@@ -2712,114 +3254,82 @@ msgstr "По национальности"
 msgid "by Date"
 msgstr "По дате"
 
-#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:384
-#: pysollib/tk/selectgame.py:386
+#: pysollib/pysolgtk/selectgame.py:88 pysollib/tile/selectgame.py:382
+#: pysollib/tk/selectgame.py:383
 msgid "About game"
 msgstr "Об игре "
 
-#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:394
-#: pysollib/tk/selectgame.py:396
+#: pysollib/pysolgtk/selectgame.py:115 pysollib/tile/selectgame.py:392
+#: pysollib/tk/selectgame.py:393
 msgid "Alternate names:"
 msgstr "Другие имена:"
 
-#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:395
-#: pysollib/tk/selectgame.py:397
+#: pysollib/pysolgtk/selectgame.py:116 pysollib/tile/selectgame.py:393
+#: pysollib/tk/selectgame.py:394
 msgid "Category:"
 msgstr "Категория:"
 
-#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:398
-#: pysollib/tk/selectgame.py:400
+#: pysollib/pysolgtk/selectgame.py:119 pysollib/tile/selectgame.py:396
+#: pysollib/tk/selectgame.py:397
 msgid "Decks:"
 msgstr "Колод:"
 
-#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:399
-#: pysollib/tk/selectgame.py:401
+#: pysollib/pysolgtk/selectgame.py:120 pysollib/tile/selectgame.py:397
+#: pysollib/tk/selectgame.py:398
 msgid "Redeals:"
 msgstr "Пересдач:"
 
-#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:401
-#: pysollib/tk/selectgame.py:403
+#: pysollib/pysolgtk/selectgame.py:122 pysollib/tile/selectgame.py:399
+#: pysollib/tk/selectgame.py:400
 msgid "Played:"
 msgstr "Играл:"
 
-#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:404
-#: pysollib/tile/tkstats.py:777 pysollib/tk/selectgame.py:406
-#: pysollib/tk/tkstats.py:740 data/pysolfc.glade:717
+#: pysollib/pysolgtk/selectgame.py:125 pysollib/tile/selectgame.py:402
+#: pysollib/tile/tkstats.py:778 pysollib/tk/selectgame.py:403
+#: pysollib/tk/tkstats.py:741 data/pysolfc.glade:717
 msgid "Playing time:"
 msgstr "Игровое время:"
 
-#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:405
-#: pysollib/tile/tkstats.py:784 pysollib/tk/selectgame.py:407
-#: pysollib/tk/tkstats.py:747 data/pysolfc.glade:813
+#: pysollib/pysolgtk/selectgame.py:126 pysollib/tile/selectgame.py:403
+#: pysollib/tile/tkstats.py:785 pysollib/tk/selectgame.py:404
+#: pysollib/tk/tkstats.py:748 data/pysolfc.glade:813
 msgid "Moves:"
 msgstr "Ходов:"
 
-#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:406
-#: pysollib/tk/selectgame.py:408
+#: pysollib/pysolgtk/selectgame.py:127 pysollib/tile/selectgame.py:404
+#: pysollib/tk/selectgame.py:405
 msgid "% won:"
 msgstr "% побед:"
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:438
-#: pysollib/tk/selectgame.py:439 pysollib/ui/tktile/menubar.py:352
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:436
+#: pysollib/tk/selectgame.py:437 pysollib/ui/tktile/menubar.py:352
 msgid "&Select"
 msgstr "&Выбрать"
 
-#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:437
-#: pysollib/tk/selectgame.py:439
+#: pysollib/pysolgtk/selectgame.py:324 pysollib/tile/selectgame.py:435
+#: pysollib/tk/selectgame.py:436
 msgid "&Rules"
 msgstr "&Правила"
 
-#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:518
-#: pysollib/tk/selectgame.py:519
-msgid "Playable Preview - "
-msgstr "Играемый предпросмотр - "
+#: pysollib/pysolgtk/selectgame.py:426 pysollib/tile/selectgame.py:516
+#: pysollib/tk/selectgame.py:517
+#, python-format
+msgid "Playable Preview - %(game)s"
+msgstr "Играемый предпросмотр - %(game)s"
 
-#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:571
-#: pysollib/tk/selectgame.py:572
+#: pysollib/pysolgtk/selectgame.py:481 pysollib/tile/selectgame.py:569
+#: pysollib/tk/selectgame.py:570
 msgid "variable"
 msgstr "переменное кол-во"
 
-#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:573
-#: pysollib/tk/selectgame.py:574
+#: pysollib/pysolgtk/selectgame.py:483 pysollib/tile/selectgame.py:571
+#: pysollib/tk/selectgame.py:572
 msgid "unlimited"
 msgstr "неограниченное кол-во"
 
 #: pysollib/pysolgtk/selecttile.py:104
-#, fuzzy
 msgid "Solid color"
 msgstr "Монотонный цвет"
-
-#: pysollib/pysolgtk/selecttile.py:105 pysollib/tile/selecttile.py:74
-#: pysollib/tk/selecttile.py:73
-msgid "Blue"
-msgstr "Голубой"
-
-#: pysollib/pysolgtk/selecttile.py:106 pysollib/tile/selecttile.py:75
-#: pysollib/tk/selecttile.py:74 pysollib/games/ultra/dashavatara.py:361
-#: pysollib/games/ultra/mughal.py:264
-msgid "Green"
-msgstr "Зелёный"
-
-#: pysollib/pysolgtk/selecttile.py:107 pysollib/tile/selecttile.py:76
-#: pysollib/tk/selecttile.py:75
-msgid "Navy"
-msgstr "Синий"
-
-#: pysollib/pysolgtk/selecttile.py:108 pysollib/tile/selecttile.py:77
-#: pysollib/tk/selecttile.py:76 pysollib/games/ultra/dashavatara.py:362
-msgid "Olive"
-msgstr "Оливковый"
-
-#: pysollib/pysolgtk/selecttile.py:109 pysollib/tile/selecttile.py:78
-#: pysollib/tk/selecttile.py:77 pysollib/games/ultra/dashavatara.py:362
-#: pysollib/games/ultra/mughal.py:264
-msgid "Orange"
-msgstr "Оранжевый"
-
-#: pysollib/pysolgtk/selecttile.py:110 pysollib/tile/selecttile.py:79
-#: pysollib/tk/selecttile.py:78
-msgid "Teal"
-msgstr "Чайный"
 
 #: pysollib/pysolgtk/selecttile.py:121 pysollib/tile/selecttile.py:82
 #: pysollib/tk/selecttile.py:81
@@ -2876,11 +3386,6 @@ msgstr "Сброс карты"
 msgid "Drop pair"
 msgstr "Сброс двух карт"
 
-#: pysollib/pysolgtk/soundoptionsdialog.py:56
-#: pysollib/tile/soundoptionsdialog.py:68 pysollib/tk/soundoptionsdialog.py:70
-msgid "Auto drop"
-msgstr "Автоматический сброс карты"
-
 #: pysollib/pysolgtk/soundoptionsdialog.py:58
 #: pysollib/tile/soundoptionsdialog.py:70 pysollib/tk/soundoptionsdialog.py:72
 msgid "Flip"
@@ -2931,80 +3436,60 @@ msgstr "Ходов/Всего ходов"
 msgid "Games played: won/lost"
 msgstr "Игр: выиграно/проиграно"
 
-#: pysollib/pysolgtk/tkhtml.py:218 pysollib/tile/tkhtml.py:77
-#: pysollib/tk/tkhtml.py:72
-msgid "Index"
-msgstr "Индекс"
-
-#: pysollib/pysolgtk/tkhtml.py:219 pysollib/tile/tkhtml.py:81
-#: pysollib/tk/tkhtml.py:76
-msgid "Back"
-msgstr "Назад"
-
-#: pysollib/pysolgtk/tkhtml.py:220 pysollib/tile/tkhtml.py:85
-#: pysollib/tk/tkhtml.py:80
-msgid "Forward"
-msgstr "Вперёд"
-
-#: pysollib/pysolgtk/tkhtml.py:221 pysollib/tile/tkhtml.py:89
-#: pysollib/tk/tkhtml.py:84
-msgid "Close"
-msgstr "Закрыть"
-
 #: pysollib/pysolgtk/tkhtml.py:437 pysollib/ui/tktile/tkhtml.py:314
 #, python-format
 msgid ""
-"HTML limitation:\n"
-"The %s protocol is not supported yet.\n"
+"%(app)s HTML limitation:\n"
+"The %(protocol)s protocol is not supported yet.\n"
 "\n"
 "Please use your standard web browser\n"
 "to open the following URL:\n"
-"%s\n"
+"%(url)s\n"
 msgstr ""
-"Ограничения HTML:\n"
-"Протокол %s не поддерживается.\n"
+"Ограничения %(app)s HTML:\n"
+"Протокол %(protocol)s не поддерживается.\n"
 "\n"
 "Пожалуйста воспользуйтесь Вашим стандартным браузером\n"
 "чтобы открыть URL:\n"
-"%s\n"
+"%(url)s\n"
 
 #: pysollib/pysolgtk/tkhtml.py:464 pysollib/pysolgtk/tkhtml.py:469
 #: pysollib/ui/tktile/tkhtml.py:342 pysollib/ui/tktile/tkhtml.py:348
 msgid "Unable to service request:\n"
 msgstr "Невозможно выполнить запрос:\n"
 
-#: pysollib/pysolgtk/tkstats.py:328 pysollib/tile/tkstats.py:290
+#: pysollib/pysolgtk/tkstats.py:329 pysollib/tile/tkstats.py:290
 #: pysollib/tk/tkstats.py:266
 msgid "No games"
 msgstr "Нет игр"
 
-#: pysollib/pysolgtk/tkstats.py:388 pysollib/tile/tkstats.py:670
-#: pysollib/tk/tkstats.py:667
+#: pysollib/pysolgtk/tkstats.py:389 pysollib/tile/tkstats.py:671
+#: pysollib/tk/tkstats.py:668
 msgid "N"
 msgstr "N"
 
-#: pysollib/pysolgtk/tkstats.py:391 pysollib/tile/tkstats.py:683
-#: pysollib/tk/tkstats.py:676
+#: pysollib/pysolgtk/tkstats.py:392 pysollib/tile/tkstats.py:684
+#: pysollib/tk/tkstats.py:677
 msgid "Result"
 msgstr "Результат"
 
-#: pysollib/pysolgtk/tkstats.py:526 pysollib/tile/tkstats.py:613
-#: pysollib/tk/tkstats.py:608
+#: pysollib/pysolgtk/tkstats.py:527 pysollib/tile/tkstats.py:614
+#: pysollib/tk/tkstats.py:609
 msgid "Highlight piles: "
 msgstr "Подсветка групп: "
 
-#: pysollib/pysolgtk/tkstats.py:527 pysollib/tile/tkstats.py:614
-#: pysollib/tk/tkstats.py:609
+#: pysollib/pysolgtk/tkstats.py:528 pysollib/tile/tkstats.py:615
+#: pysollib/tk/tkstats.py:610
 msgid "Highlight cards: "
 msgstr "Подсветка карт: "
 
-#: pysollib/pysolgtk/tkstats.py:528 pysollib/tile/tkstats.py:615
-#: pysollib/tk/tkstats.py:610
+#: pysollib/pysolgtk/tkstats.py:529 pysollib/tile/tkstats.py:616
+#: pysollib/tk/tkstats.py:611
 msgid "Highlight same rank: "
 msgstr "Подсветка карт одного достоинства: "
 
-#: pysollib/pysolgtk/tkstats.py:532 pysollib/tile/tkstats.py:619
-#: pysollib/tk/tkstats.py:614
+#: pysollib/pysolgtk/tkstats.py:533 pysollib/tile/tkstats.py:620
+#: pysollib/tk/tkstats.py:615
 msgid ""
 "\n"
 "Redeals: "
@@ -3012,8 +3497,8 @@ msgstr ""
 "\n"
 "Раздач: "
 
-#: pysollib/pysolgtk/tkstats.py:533 pysollib/tile/tkstats.py:620
-#: pysollib/tk/tkstats.py:615
+#: pysollib/pysolgtk/tkstats.py:534 pysollib/tile/tkstats.py:621
+#: pysollib/tk/tkstats.py:616
 msgid ""
 "\n"
 "Cards in Talon: "
@@ -3021,8 +3506,8 @@ msgstr ""
 "\n"
 "Карт в колоде: "
 
-#: pysollib/pysolgtk/tkstats.py:535 pysollib/tile/tkstats.py:622
-#: pysollib/tk/tkstats.py:617
+#: pysollib/pysolgtk/tkstats.py:536 pysollib/tile/tkstats.py:623
+#: pysollib/tk/tkstats.py:618
 msgid ""
 "\n"
 "Cards in Waste: "
@@ -3030,8 +3515,8 @@ msgstr ""
 "\n"
 "Карт в сбросе: "
 
-#: pysollib/pysolgtk/tkstats.py:537 pysollib/tile/tkstats.py:624
-#: pysollib/tk/tkstats.py:619
+#: pysollib/pysolgtk/tkstats.py:538 pysollib/tile/tkstats.py:625
+#: pysollib/tk/tkstats.py:620
 msgid ""
 "\n"
 "Cards in Foundations: "
@@ -3039,58 +3524,58 @@ msgstr ""
 "\n"
 "Карт на базовых ячейках: "
 
-#: pysollib/pysolgtk/tkstats.py:542 pysollib/tile/tkstats.py:629
-#: pysollib/tk/tkstats.py:625
+#: pysollib/pysolgtk/tkstats.py:543 pysollib/tile/tkstats.py:630
+#: pysollib/tk/tkstats.py:626
 msgid "Game status"
 msgstr "Статус игры"
 
-#: pysollib/pysolgtk/tkstats.py:545 pysollib/tile/tkstats.py:632
-#: pysollib/tk/tkstats.py:628
+#: pysollib/pysolgtk/tkstats.py:546 pysollib/tile/tkstats.py:633
+#: pysollib/tk/tkstats.py:629
 msgid "Playing time: "
 msgstr "Игровое время: "
 
-#: pysollib/pysolgtk/tkstats.py:546 pysollib/tile/tkstats.py:633
-#: pysollib/tk/tkstats.py:629
+#: pysollib/pysolgtk/tkstats.py:547 pysollib/tile/tkstats.py:634
+#: pysollib/tk/tkstats.py:630
 msgid "Started at: "
 msgstr "Игра начата: "
 
-#: pysollib/pysolgtk/tkstats.py:547 pysollib/tile/tkstats.py:634
-#: pysollib/tk/tkstats.py:630
+#: pysollib/pysolgtk/tkstats.py:548 pysollib/tile/tkstats.py:635
+#: pysollib/tk/tkstats.py:631
 msgid "Moves: "
 msgstr "Ходов: "
 
-#: pysollib/pysolgtk/tkstats.py:548 pysollib/tile/tkstats.py:635
-#: pysollib/tk/tkstats.py:631
+#: pysollib/pysolgtk/tkstats.py:549 pysollib/tile/tkstats.py:636
+#: pysollib/tk/tkstats.py:632
 msgid "Undo moves: "
 msgstr "Отменено ходов: "
 
-#: pysollib/pysolgtk/tkstats.py:549 pysollib/tile/tkstats.py:636
-#: pysollib/tk/tkstats.py:632
+#: pysollib/pysolgtk/tkstats.py:550 pysollib/tile/tkstats.py:637
+#: pysollib/tk/tkstats.py:633
 msgid "Bookmark moves: "
 msgstr "Ходов по закладкам: "
 
-#: pysollib/pysolgtk/tkstats.py:550 pysollib/tile/tkstats.py:637
-#: pysollib/tk/tkstats.py:633
+#: pysollib/pysolgtk/tkstats.py:551 pysollib/tile/tkstats.py:638
+#: pysollib/tk/tkstats.py:634
 msgid "Demo moves: "
 msgstr "Демо ходов: "
 
-#: pysollib/pysolgtk/tkstats.py:551 pysollib/tile/tkstats.py:638
-#: pysollib/tk/tkstats.py:634
+#: pysollib/pysolgtk/tkstats.py:552 pysollib/tile/tkstats.py:639
+#: pysollib/tk/tkstats.py:635
 msgid "Total player moves: "
 msgstr "Всего ходов игрока:"
 
-#: pysollib/pysolgtk/tkstats.py:552 pysollib/tile/tkstats.py:639
-#: pysollib/tk/tkstats.py:635
+#: pysollib/pysolgtk/tkstats.py:553 pysollib/tile/tkstats.py:640
+#: pysollib/tk/tkstats.py:636
 msgid "Total moves in this game: "
 msgstr "Всего ходов в этой игре: "
 
-#: pysollib/pysolgtk/tkstats.py:553 pysollib/tile/tkstats.py:640
-#: pysollib/tk/tkstats.py:636
+#: pysollib/pysolgtk/tkstats.py:554 pysollib/tile/tkstats.py:641
+#: pysollib/tk/tkstats.py:637
 msgid "Hints: "
 msgstr "Подсказок: "
 
-#: pysollib/pysolgtk/tkstats.py:557 pysollib/tile/tkstats.py:643
-#: pysollib/tk/tkstats.py:640 pysollib/ui/tktile/menubar.py:420
+#: pysollib/pysolgtk/tkstats.py:558 pysollib/tile/tkstats.py:644
+#: pysollib/tk/tkstats.py:641 pysollib/ui/tktile/menubar.py:420
 msgid "&Statistics..."
 msgstr "&Статистика..."
 
@@ -3160,17 +3645,22 @@ msgstr "Изменить..."
 msgid "Select font"
 msgstr "Выбрать шрифт"
 
+#: pysollib/tile/menubar.py:90 pysollib/tk/menubar.py:94
+msgid "Select "
+msgstr "Выбрать "
+
 #: pysollib/tile/menubar.py:106
 msgid "Change theme"
 msgstr "Изменение темы"
 
 #: pysollib/tile/menubar.py:107
+#, python-format
 msgid ""
-"This settings will take effect\n"
-"the next time you restart "
+"These settings will take effect\n"
+"the next time you restart %(app)s"
 msgstr ""
 "Эта установка вступит в силу\n"
-"при следующем запуске "
+"при следующем запуске %(app)s"
 
 #: pysollib/tile/menubar.py:114
 msgid "Set t&heme"
@@ -3266,7 +3756,7 @@ msgstr ""
 msgid "&Save"
 msgstr "&Сохранить"
 
-#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:177
+#: pysollib/tile/selectgame.py:176 pysollib/tk/selectgame.py:176
 msgid "Custom Games"
 msgstr "Самодельные игры"
 
@@ -3376,14 +3866,14 @@ msgstr "Подсветка карты:"
 msgid "Highlight same rank:"
 msgstr "Подсветка одинаковых карт:"
 
-#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:740
-#: pysollib/tile/tkstats.py:887 pysollib/tk/tkstats.py:909
+#: pysollib/tile/tkstats.py:70 pysollib/tile/tkstats.py:741
+#: pysollib/tile/tkstats.py:888 pysollib/tk/tkstats.py:910
 #: data/pysolfc.glade:660
 msgid "Current game"
 msgstr "Текущая игра"
 
-#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:748
-#: pysollib/tile/tkstats.py:883 pysollib/tk/tkstats.py:903
+#: pysollib/tile/tkstats.py:74 pysollib/tile/tkstats.py:749
+#: pysollib/tile/tkstats.py:884 pysollib/tk/tkstats.py:904
 #: data/pysolfc.glade:1342
 msgid "All games"
 msgstr "Все игры"
@@ -3406,75 +3896,83 @@ msgstr "Всего"
 msgid "Current session"
 msgstr "Текущая сессия"
 
-#: pysollib/tile/tkstats.py:510
+#: pysollib/tile/tkstats.py:511
 msgid "Log"
 msgstr "Лог"
 
-#: pysollib/tile/tkstats.py:541 pysollib/tk/tkstats.py:506
-#: pysollib/tk/tkstats.py:575 pysollib/tk/tkstats.py:592
+#: pysollib/tile/tkstats.py:523 data/pysolfc.glade:1404
+msgid "Full log"
+msgstr "Полный лог"
+
+#: pysollib/tile/tkstats.py:527 data/pysolfc.glade:1466
+msgid "Session log"
+msgstr "Лог сессии"
+
+#: pysollib/tile/tkstats.py:542 pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:576 pysollib/tk/tkstats.py:593
 msgid "&Save to file"
 msgstr "&Сохранить в файл"
 
-#: pysollib/tile/tkstats.py:745 pysollib/tk/tkstats.py:785
+#: pysollib/tile/tkstats.py:746 pysollib/tk/tkstats.py:786
 msgid "No TOP for this game"
 msgstr "TOP для текущей игры отсутствует"
 
-#: pysollib/tile/tkstats.py:753
+#: pysollib/tile/tkstats.py:754
 msgid "No TOP for all games"
 msgstr "TOP для всех игр отсутствует"
 
-#: pysollib/tile/tkstats.py:765 pysollib/tk/tkstats.py:732
+#: pysollib/tile/tkstats.py:766 pysollib/tk/tkstats.py:733
 #: data/pysolfc.glade:1005
 msgid "Minimum"
 msgstr "Минимум"
 
-#: pysollib/tile/tkstats.py:767 pysollib/tk/tkstats.py:733
+#: pysollib/tile/tkstats.py:768 pysollib/tk/tkstats.py:734
 #: data/pysolfc.glade:1028
 msgid "Maximum"
 msgstr "Максимум"
 
-#: pysollib/tile/tkstats.py:769 pysollib/tk/tkstats.py:734
+#: pysollib/tile/tkstats.py:770 pysollib/tk/tkstats.py:735
 #: data/pysolfc.glade:1051
 msgid "Average"
 msgstr "Среднее"
 
-#: pysollib/tile/tkstats.py:791 pysollib/tk/tkstats.py:754
+#: pysollib/tile/tkstats.py:792 pysollib/tk/tkstats.py:755
 #: data/pysolfc.glade:909
 msgid "Total moves:"
 msgstr "Всего ходов:"
 
-#: pysollib/tile/tkstats.py:891 pysollib/tk/tkstats.py:915
+#: pysollib/tile/tkstats.py:892 pysollib/tk/tkstats.py:916
 msgid "Statistics for"
 msgstr "Статистика за"
 
-#: pysollib/tile/tkstats.py:896 pysollib/tk/tkstats.py:920
+#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
 msgid "Last 7 days"
 msgstr "Последние 7 дней"
 
-#: pysollib/tile/tkstats.py:897 pysollib/tk/tkstats.py:921
+#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
 msgid "Last month"
 msgstr "Последний месяц"
 
-#: pysollib/tile/tkstats.py:898 pysollib/tk/tkstats.py:922
+#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
 msgid "Last year"
 msgstr "Последний год"
 
-#: pysollib/tile/tkstats.py:899 pysollib/tk/tkstats.py:923
+#: pysollib/tile/tkstats.py:900 pysollib/tk/tkstats.py:924
 msgid "All time"
 msgstr "Всё время"
 
-#: pysollib/tile/tkstats.py:904 pysollib/tk/tkstats.py:930
+#: pysollib/tile/tkstats.py:905 pysollib/tk/tkstats.py:931
 msgid "Show graphs"
 msgstr "Показывать графики"
 
-#: pysollib/tile/tkstats.py:948 pysollib/tile/tkstats.py:964
-#: pysollib/tile/tkstats.py:1002 pysollib/tk/tkstats.py:857
-#: pysollib/tk/tkstats.py:873 pysollib/tk/tkstats.py:977
+#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:965
+#: pysollib/tile/tkstats.py:1003 pysollib/tk/tkstats.py:858
+#: pysollib/tk/tkstats.py:874 pysollib/tk/tkstats.py:978
 msgid "Games/day"
 msgstr "Игр за день"
 
-#: pysollib/tile/tkstats.py:949 pysollib/tile/tkstats.py:1004
-#: pysollib/tk/tkstats.py:858 pysollib/tk/tkstats.py:979
+#: pysollib/tile/tkstats.py:950 pysollib/tile/tkstats.py:1005
+#: pysollib/tk/tkstats.py:859 pysollib/tk/tkstats.py:980
 msgid "Games/week"
 msgstr "Игр за неделю"
 
@@ -3494,17 +3992,9 @@ msgstr ""
 msgid "Save"
 msgstr "Сохранить"
 
-#: pysollib/tile/toolbar.py:180 pysollib/tk/toolbar.py:180
-msgid "Save game"
-msgstr "Сохранить игру"
-
 #: pysollib/tile/toolbar.py:188 pysollib/tk/toolbar.py:188
 msgid "View statistics"
 msgstr "Посмотреть статистику"
-
-#: pysollib/tile/toolbar.py:202 pysollib/tk/toolbar.py:211
-msgid "Toolbar"
-msgstr "Панель инструментов"
 
 #: pysollib/tile/toolbar.py:209 pysollib/tk/toolbar.py:206
 msgid "Player"
@@ -3526,15 +4016,15 @@ msgstr "Выбрать имя"
 msgid "Enable samles"
 msgstr "Включить звуки"
 
-#: pysollib/tk/tkstats.py:507
+#: pysollib/tk/tkstats.py:508
 msgid "&Reset all..."
 msgstr "О&чистить все..."
 
-#: pysollib/tk/tkstats.py:574
+#: pysollib/tk/tkstats.py:575
 msgid "Session &log..."
 msgstr "&Лог сессии..."
 
-#: pysollib/tk/tkstats.py:591
+#: pysollib/tk/tkstats.py:592
 msgid "&Full log..."
 msgstr "&Полный лог..."
 
@@ -3985,10 +4475,6 @@ msgstr "Найти карту"
 msgid "Compound"
 msgstr "Компоновка"
 
-#: pysollib/ui/tktile/menubar.py:41
-msgid "Hide"
-msgstr "Спрятать"
-
 #: pysollib/ui/tktile/menubar.py:44
 msgid "Top"
 msgstr "Сверху"
@@ -3997,21 +4483,14 @@ msgstr "Сверху"
 msgid "Bottom"
 msgstr "Внизу"
 
-#: pysollib/ui/tktile/menubar.py:50
-msgid "Left"
-msgstr "Слева"
-
-#: pysollib/ui/tktile/menubar.py:53
-msgid "Right"
-msgstr "Справа"
-
 #: pysollib/ui/tktile/menubar.py:64
 msgid "Visible buttons"
 msgstr "Показывать кнопки"
 
-#: pysollib/ui/tktile/menubar.py:296 pysollib/ui/tktile/menubar.py:666
-msgid "&About "
-msgstr "&О программе "
+#: pysollib/ui/tktile/menubar.py:296
+#, python-format
+msgid "&About %s"
+msgstr "&О программе %s"
 
 #: pysollib/ui/tktile/menubar.py:298
 msgid "&File"
@@ -4155,7 +4634,6 @@ msgid "D&emo statistics"
 msgstr "Статистика демо"
 
 #: pysollib/ui/tktile/menubar.py:430
-#, fuzzy
 msgid "&Assist"
 msgstr "&Подсказка"
 
@@ -4189,7 +4667,6 @@ msgid "&Piles description"
 msgstr "Описания &ячеек"
 
 #: pysollib/ui/tktile/menubar.py:459
-#, fuzzy
 msgid "&Options"
 msgstr "&Настройка"
 
@@ -4308,10 +4785,6 @@ msgstr "Подсвечивать &разрешённые ходы"
 #: pysollib/ui/tktile/menubar.py:555
 msgid "&Negative cards bottom"
 msgstr "&Негативные контуры карты"
-
-#: pysollib/ui/tktile/menubar.py:559
-msgid "Shrink face-down cards"
-msgstr "Сжимать закрытые карты"
 
 #: pysollib/ui/tktile/menubar.py:563
 msgid "Shade &filled stacks"
@@ -4437,6 +4910,11 @@ msgstr "&Правила текущей игры"
 msgid "&License terms"
 msgstr "&Лицензия"
 
+#: pysollib/ui/tktile/menubar.py:666
+#, python-format
+msgid "&About %s..."
+msgstr "&О программе %s..."
+
 #: pysollib/ui/tktile/menubar.py:796
 msgid "All &games..."
 msgstr "&Все игры..."
@@ -4473,29 +4951,29 @@ msgstr "&Самодельные игры"
 msgid "&All games by name"
 msgstr "&Все игры по имени"
 
-#: pysollib/ui/tktile/menubar.py:1177
+#: pysollib/ui/tktile/menubar.py:1179
 #, fuzzy
 msgid "Export game error"
 msgstr "Ошибка при загрузке игры"
 
-#: pysollib/ui/tktile/menubar.py:1178
+#: pysollib/ui/tktile/menubar.py:1180
 msgid ""
 "\n"
 "Unsupported game for export.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1214 pysollib/ui/tktile/menubar.py:1248
+#: pysollib/ui/tktile/menubar.py:1216 pysollib/ui/tktile/menubar.py:1250
 #, fuzzy
 msgid "Import game error"
 msgstr "Ошибка при загрузке игры"
 
-#: pysollib/ui/tktile/menubar.py:1215
+#: pysollib/ui/tktile/menubar.py:1217
 msgid ""
 "\n"
 "Unsupported game for import.\n"
 msgstr ""
 
-#: pysollib/ui/tktile/menubar.py:1676
+#: pysollib/ui/tktile/menubar.py:1678
 #, python-format
 msgid ""
 "\n"
@@ -4507,6 +4985,11 @@ msgstr ""
 "Ошибка при сохранении игры\n"
 "\n"
 "%s\n"
+
+#: pysollib/ui/tktile/solverdialog.py:28
+#, python-format
+msgid "%(app)s - FreeCell Solver"
+msgstr ""
 
 #: pysollib/ui/tktile/solverdialog.py:44 data/pysolfc.glade:74
 #: data/pysolfc.glade:1250
@@ -4597,6 +5080,34 @@ msgstr "Всего ходов"
 msgid "Set font"
 msgstr "Настроить шрифт"
 
+#~ msgid "Statistics for "
+#~ msgstr "Статистика игры "
+
+#~ msgid "Full log for "
+#~ msgstr "Полный лог для "
+
+#~ msgid "Session log for "
+#~ msgstr "Лог сессии для "
+
+#~ msgid "Error while loading "
+#~ msgstr "Ошибка при загрузке"
+
+#~ msgid " HTML Problem"
+#~ msgstr " проблема с HTML"
+
+#~ msgid " Demo "
+#~ msgstr " Демо "
+
+#~ msgid "Your statistics"
+#~ msgstr "Ваша статистика"
+
+#~ msgid ""
+#~ " were appended to\n"
+#~ "\n"
+#~ msgstr ""
+#~ " добавлена в файл\n"
+#~ "\n"
+
 #~ msgid "Solving method:"
 #~ msgstr "Метод решения:"
 
@@ -4605,9 +5116,6 @@ msgstr "Настроить шрифт"
 
 #~ msgid "&Statistics"
 #~ msgstr "Ст&атистика"
-
-#~ msgid "Current game..."
-#~ msgstr "Текущая игра..."
 
 #~ msgid "All games..."
 #~ msgstr "Все игры..."

--- a/pysollib/app.py
+++ b/pysollib/app.py
@@ -60,7 +60,7 @@ from pysollib.resource import Tile, TileManager
 from pysollib.settings import DEBUG
 from pysollib.settings import PACKAGE, VERSION_TUPLE, WIN_SYSTEM
 from pysollib.settings import TOOLKIT
-from pysollib.util import CARDSET, IMAGE_EXTENSIONS
+from pysollib.util import IMAGE_EXTENSIONS
 from pysollib.winsystems import TkSettings
 if TOOLKIT == 'tk':
     from pysollib.ui.tktile.solverdialog import destroy_solver_dialog
@@ -329,7 +329,8 @@ class Application:
             elif self.commandline.game is not None:
                 gameid = self.gdb.getGameByName(self.commandline.game)
                 if gameid is None:
-                    print_err(_("can't find game: ") + self.commandline.game)
+                    print_err(_("can't find game: %(game)s") % {
+                        'game': self.commandline.game})
                     sys.exit(-1)
                 else:
                     self.nextgame.id = gameid
@@ -668,7 +669,7 @@ class Application:
         if progress is None:
             self.wm_save_state()
             self.wm_withdraw()
-            title = _("Loading %s %s...") % (CARDSET, cs.name)
+            title = _("Loading cardset %s...") % cs.name
             color = self.opt.colors['table']
             if self.tabletile_index > 0:
                 color = "#008200"
@@ -678,7 +679,7 @@ class Application:
         images = Images(self.dataloader, cs)
         try:
             if not images.load(app=self, progress=progress):
-                raise Exception("Invalid or damaged "+CARDSET)
+                raise Exception("Invalid or damaged cardset")
             simages = SubsampledImages(images)
             if self.opt.save_cardsets:
                 c = self.cardsets_cache.get(cs.type)
@@ -710,8 +711,8 @@ class Application:
             # images.destruct()
             destruct(images)
             MfxExceptionDialog(
-                self.top, ex, title=CARDSET+_(" load error"),
-                text=_("Error while loading ")+CARDSET)
+                self.top, ex, title=_("Cardset load error"),
+                text=_("Error while loading cardset"))
         self.intro.progress = progress
         if r and self.menubar is not None:
             self.menubar.updateBackgroundImagesMenu()
@@ -806,14 +807,14 @@ class Application:
         #
         t = self.checkCompatibleCardsetType(gi, self.cardset)
         MfxMessageDialog(
-            self.top, title=_("Incompatible ")+CARDSET,
+            self.top, title=_("Incompatible cardset"),
             bitmap="warning",
-            text=_('''The currently selected %s %s
+            text=_('''The currently selected cardset %(cardset)s
 is not compatible with the game
-%s
+%(game)s
 
-Please select a %s type %s.
-''') % (CARDSET, self.cardset.name, gi.name, t[0], CARDSET),
+Please select a %(correct_type)s type cardset.
+''') % {'cardset': self.cardset.name, 'game': gi.name, 'correct_type': t[0]},
             strings=(_("&OK"),), default=0)
         cs = self.__selectCardsetDialog(t)
         if cs is None:
@@ -852,7 +853,7 @@ Please select a %s type %s.
 
     def __selectCardsetDialog(self, t):
         cs = self.selectCardset(
-            _("Please select a %s type %s") % (t[0], CARDSET),
+            _("Please select a %s type cardset") % t[0],
             self.cardset.index)
         return cs
 
@@ -1060,7 +1061,8 @@ Please select a %s type %s.
                 except Exception as ex:
                     if DEBUG:
                         traceback.print_exc()
-                    print_err(_("error loading plugin %s: %s") % (n, ex))
+                    print_err(_("error loading plugin %(file)s: %(err)s") %
+                              {'file': n, 'err': ex})
 
     #
     # init cardsets

--- a/pysollib/game/__init__.py
+++ b/pysollib/game/__init__.py
@@ -63,7 +63,7 @@ from pysollib.pysoltk import MfxExceptionDialog, MfxMessageDialog
 from pysollib.pysoltk import after, after_cancel, after_idle
 from pysollib.pysoltk import bind, wm_map
 from pysollib.settings import DEBUG
-from pysollib.settings import PACKAGE, TITLE, TOOLKIT, TOP_TITLE
+from pysollib.settings import PACKAGE, TITLE, TOOLKIT, TOP_SIZE
 from pysollib.settings import VERSION, VERSION_TUPLE
 from pysollib.struct_new import NewStruct
 
@@ -1310,7 +1310,7 @@ class Game(object):
             if not title:
                 title = TITLE
             if not text:
-                text = _("Discard current game ?")
+                text = _("Discard current game?")
             self.playSample("areyousure")
             d = MfxMessageDialog(self.top, title=title, text=text,
                                  bitmap="question",
@@ -1931,19 +1931,24 @@ class Game(object):
                 if ret:
                     if ret[0] and ret[1]:
                         top_msg = _(
-                            '''\nYou have reached\n''' +
-                            '# %d in the %s of playing time' +
-                            '\nand # %d in the %s of moves.') % \
-                            (ret[0], TOP_TITLE, ret[1], TOP_TITLE)
+                            '\nYou have reached\n# %(timerank)d in the top ' +
+                            '%(tops)d of playing time\nand # %(movesrank)d ' +
+                            'in the top %(tops)d of moves.') % {
+                                'timerank': ret[0],
+                                'movesrank': ret[1],
+                                'tops': TOP_SIZE}
                     elif ret[0]:        # playing time
                         top_msg = _(
-                            '''\nYou have reached\n''' +
-                            '''# %d in the %s of playing time.''') \
-                            % (ret[0], TOP_TITLE)
+                            '\nYou have reached\n# %(timerank)d in the top ' +
+                            '%(tops)d of playing time.') % {
+                                'timerank': ret[0],
+                                'tops': TOP_SIZE}
                     elif ret[1]:        # moves
                         top_msg = _(
-                            '''\nYou have reached\n''' +
-                            '# %d in the %s of moves.') % (ret[1], TOP_TITLE)
+                            '\nYou have reached\n# %(movesrank)d in the top ' +
+                            '%(tops)s of moves.') % {
+                                'movesrank': ret[1],
+                                'tops': TOP_SIZE}
                 return top_msg
         elif not demo:
             # only update the session log
@@ -1975,14 +1980,14 @@ class Game(object):
             self.finished = True
             self.playSample("gameperfect", priority=1000)
             self.winAnimation(perfect=1)
-            text = ungettext('''Your playing time is %s\nfor %d move.''',
-                             '''Your playing time is %s\nfor %d moves.''',
+            text = ungettext('Your playing time is %(time)s\nfor %(n)d move.',
+                             'Your playing time is %(time)s\nfor %(n)d moves.',
                              self.moves.index)
-            text = text % (time, self.moves.index)
+            text = text % {'time': time, 'n': self.moves.index}
+            congrats = _('Congratulations, this\nwas a truly perfect game!')
             d = MfxMessageDialog(
                 self.top, title=_("Game won"),
-                text=_('\nCongratulations, this\nwas a truly perfect game !' +
-                       '\n\n%s\n%s\n') % (text, top_msg),
+                text='\n' + congrats + '\n\n' + text + '\n' + top_msg + '\n',
                 strings=(_("&New game"), None, _("&Cancel")),
                 image=self.app.gimages.logos[5])
         elif status == 1:
@@ -1991,16 +1996,14 @@ class Game(object):
             self.finished = True
             self.playSample("gamewon", priority=1000)
             self.winAnimation()
-            text = ungettext('''Your playing time is %s\nfor %d move.''',
-                             '''Your playing time is %s\nfor %d moves.''',
+            text = ungettext('Your playing time is %(time)s\nfor %(n)d move.',
+                             'Your playing time is %(time)s\nfor %(n)d moves.',
                              self.moves.index)
-            text = text % (time, self.moves.index)
+            text = text % {'time': time, 'n': self.moves.index}
+            congrats = _('Congratulations, you did it!')
             d = MfxMessageDialog(
                 self.top, title=_("Game won"),
-                text=(
-                    _('\nCongratulations, you did it !\n\n%s\n%s\n') %
-                    (text, top_msg)
-                ),
+                text='\n' + congrats + '\n\n' + text + '\n' + top_msg + '\n',
                 strings=(_("&New game"), None, _("&Cancel")),
                 image=self.app.gimages.logos[4])
         elif self.gstats.updated < 0:
@@ -2522,7 +2525,8 @@ class Game(object):
                                  '\nGame solved in %d moves.\n',
                                  self.moves.index)
                 text = text % self.moves.index
-                d = MfxMessageDialog(self.top, title=TITLE+_(" Autopilot"),
+                d = MfxMessageDialog(self.top,
+                                     title=_("%s Autopilot") % TITLE,
                                      text=text,
                                      image=self.app.gimages.logos[4],
                                      strings=(s,),
@@ -2536,7 +2540,8 @@ class Game(object):
                 if DEBUG:
                     text += "\nplayer_moves: %d\ndemo_moves: %d\n" % \
                         (self.stats.player_moves, self.stats.demo_moves)
-                d = MfxMessageDialog(self.top, title=TITLE+_(" Autopilot"),
+                d = MfxMessageDialog(self.top,
+                                     title=_("%s Autopilot") % TITLE,
                                      text=text, bitmap=bitmap, strings=(s,),
                                      padx=30, timeout=timeout)
                 status = d.status
@@ -2550,7 +2555,8 @@ class Game(object):
                 s = self.app.miscrandom.choice(
                         (_("&Oh well"), _("&That's life"), _("&Hmm")))
                 # ??? accelerators
-                d = MfxMessageDialog(self.top, title=TITLE+_(" Autopilot"),
+                d = MfxMessageDialog(self.top,
+                                     title=_("%s Autopilot") % TITLE,
                                      text=_("\nThis won't come out...\n"),
                                      bitmap=bitmap, strings=(s,),
                                      padx=30, timeout=timeout)
@@ -2999,7 +3005,7 @@ class Game(object):
         if confirm and self.gsaveinfo.bookmarks.get(n):
             if not self.areYouSure(
                     _("Set bookmark"),
-                    _("Replace existing bookmark %d ?") % (n+1)):
+                    _("Replace existing bookmark %d?") % (n+1)):
                 return 0
         f = BytesIO()
         try:
@@ -3021,7 +3027,7 @@ class Game(object):
             confirm = self.app.opt.confirm
         if confirm:
             if not self.areYouSure(_("Goto bookmark"),
-                                   _("Goto bookmark %d ?") % (n+1)):
+                                   _("Goto bookmark %d?") % (n+1)):
                 return
         try:
             s, moves_index = bm
@@ -3143,9 +3149,9 @@ class Game(object):
         version_tuple = pload(tuple)
         validate(
             version_tuple >= (1, 0),
-            _('''Cannot load games saved with\n%s version %s''') % (
-                PACKAGE,
-                version))
+            _('Cannot load games saved with\n%(app)s version %(ver)s') % {
+                'app': PACKAGE,
+                'ver': version})
         game_version = 1
         bookmark = pload(int)
         validate(0 <= bookmark <= 2, err_txt)

--- a/pysollib/games/matriarchy.py
+++ b/pysollib/games/matriarchy.py
@@ -120,7 +120,8 @@ class Matriarchy_Talon(WasteTalonStack):
             return
         WasteTalonStack.updateText(self, update_rounds=0)
         # t = "Round %d" % self.round
-        t = _("Round %d/%d") % (self.round, self.max_rounds)
+        t = _("Round %(round)d/%(max_rounds)d") % {
+            'round': self.round, 'max_rounds': self.max_rounds}
         self.texts.rounds.config(text=t)
         t = _("Deal %d") % self.DEAL[self.round-1]
         self.texts.misc.config(text=t)

--- a/pysollib/help.py
+++ b/pysollib/help.py
@@ -40,17 +40,18 @@ from pysollib.settings import PACKAGE_URL, TITLE, TOOLKIT, VERSION
 def help_about(app, timeout=0, sound=True):
     if sound:
         app.audio.playSample("about")
-    t = _("A Python Solitaire Game Collection\n")
+    t = _("A Python Solitaire Game Collection")
     if app.miscrandom.random() < 0.8:
-        t = _("A World Domination Project\n")
+        t = _("A World Domination Project")
     strings = (_("&Nice"), _("&Credits..."))
     if timeout:
         strings = (_("&Enjoy"),)
     version = _("Version %s") % VERSION
-    d = PysolAboutDialog(app, app.top, title=_("About ") + TITLE,
+    d = PysolAboutDialog(app, app.top, title=_("About %s") % TITLE,
                          timeout=timeout,
                          text=_('''PySol Fan Club edition
-%s%s
+%(description)s
+%(versioninfo)s
 
 Copyright (C) 1998 - 2003 Markus F.X.J. Oberhumer.
 Copyright (C) 2003 Mt. Hood Playing Card Co.
@@ -60,7 +61,8 @@ All Rights Reserved.
 PySol is free software distributed under the terms
 of the GNU General Public License.
 
-For more information about this application visit''') % (t, version),
+For more information about this application visit''') %
+                         {'description': t, 'versioninfo': version},
                          url=PACKAGE_URL,
                          image=app.gimages.logos[2],
                          strings=strings, default=0,
@@ -86,7 +88,7 @@ def help_credits(app, timeout=0, sound=True):
         t = "kivy"
     d = MfxMessageDialog(
         app.top, title=_("Credits"), timeout=timeout,
-        text=TITLE+_(''' credits go to:
+        text=_('''%(app)s credits go to:
 
 Volker Weidner for getting me into Solitaire
 Guido van Rossum for the initial example program
@@ -95,8 +97,8 @@ Carl Larsson for the background music
 The Gnome AisleRiot team for parts of the documentation
 Natascha
 
-The Python, %s, SDL & Linux crews
-for making this program possible''') % t,
+The Python, %(gui_library)s, SDL & Linux crews
+for making this program possible''') % {'app': TITLE, 'gui_library': t},
         image=app.gimages.logos[3], image_side="right",
         separator=True)
     return d.status
@@ -122,8 +124,8 @@ def help_html(app, document, dir_, top=None):
             document, dir_ = "index.html", "html"
             help_html_index = app.dataloader.findFile(document, dir_)
     except EnvironmentError:
-        MfxMessageDialog(app.top, title=TITLE + _(" HTML Problem"),
-                         text=_("Cannot find help document\n") + document,
+        MfxMessageDialog(app.top, title=_("%s HTML Problem") % TITLE,
+                         text=_("Cannot find help document\n%s") % document,
                          bitmap="warning")
         return None
     # print doc, help_html_index
@@ -136,7 +138,7 @@ def help_html(app, document, dir_, top=None):
         viewer.display(doc, relpath=0)
     except Exception:
         # traceback.print_exc()
-        top = make_help_toplevel(app, title=TITLE+_(" Help"))
+        top = make_help_toplevel(app, title=_("%s Help") % TITLE)
         if top.winfo_screenwidth() < 800 or top.winfo_screenheight() < 600:
             # maximized = 1
             top.wm_minsize(300, 150)

--- a/pysollib/kivy/menubar.py
+++ b/pysollib/kivy/menubar.py
@@ -51,7 +51,6 @@ from pysollib.mygettext import _
 from pysollib.pysoltk import connect_game_find_card_dialog
 from pysollib.settings import SELECT_GAME_MENU
 from pysollib.settings import TITLE
-from pysollib.util import CARDSET
 
 
 # ************************************************************************
@@ -177,34 +176,34 @@ class MainMenuDialog(LMenuDialog):
     def buildTree(self, tv, node):
         rg = tv.add_node(
             LTreeNode(
-                text="File",
+                text=_("File"),
                 command=self.make_game_command(self.menubar.mFileMenuDialog)))
         rg = tv.add_node(
             LTreeNode(
-                text="Games",
+                text=_("Games"),
                 command=self.make_game_command(
                     self.menubar.mSelectGameDialog)))
         rg = tv.add_node(
             LTreeNode(
-                text="Tools",
+                text=_("Tools"),
                 command=self.make_game_command(self.menubar.mEditMenuDialog)))
         rg = tv.add_node(
             LTreeNode(
-                text="Statistics",
+                text=_("Statistics"),
                 command=self.make_game_command(self.menubar.mGameMenuDialog)))
         rg = tv.add_node(
             LTreeNode(
-                text="Assist",
+                text=_("Assist"),
                 command=self.make_game_command(
                     self.menubar.mAssistMenuDialog)))
         rg = tv.add_node(
             LTreeNode(
-                text="Options",
+                text=_("Options"),
                 command=self.make_game_command(
                     self.menubar.mOptionsMenuDialog)))
         rg = tv.add_node(
             LTreeNode(
-                text="Help",
+                text=_("Help"),
                 command=self.make_game_command(self.menubar.mHelpMenuDialog)))
         del rg
 
@@ -225,7 +224,7 @@ class FileMenuDialog(LMenuDialog):
 
     def buildTree(self, tv, node):
         rg = tv.add_node(
-            LTreeNode(text='Recent games'))
+            LTreeNode(text=_('Recent games')))
         # Recent Liste
         recids = self.app.opt.recent_gameid
         # recgames = []
@@ -238,12 +237,12 @@ class FileMenuDialog(LMenuDialog):
                     LTreeNode(text=gi.name, command=command), rg)
 
         rg = tv.add_node(
-            LTreeNode(text='Favorite games'))
+            LTreeNode(text=_('Favorite games')))
         if rg:
             tv.add_node(LTreeNode(
-                text='<Add>', command=self.menubar.mAddFavor), rg)
+                text=_('<Add>'), command=self.menubar.mAddFavor), rg)
             tv.add_node(LTreeNode(
-                text='<Remove>', command=self.menubar.mDelFavor), rg)
+                text=_('<Remove>'), command=self.menubar.mDelFavor), rg)
 
             # Recent Liste
             favids = self.app.opt.favorite_gameid
@@ -289,36 +288,36 @@ class EditMenuDialog(LMenuDialog):  # Tools
 
     def buildTree(self, tv, node):
         tv.add_node(LTreeNode(
-            text='New game', command=self.menubar.mNewGame))
+            text=_('New game'), command=self.menubar.mNewGame))
         tv.add_node(LTreeNode(
-            text='Restart game', command=self.menubar.mRestart))
+            text=_('Restart game'), command=self.menubar.mRestart))
 
         tv.add_node(LTreeNode(
-            text='Undo', command=self.menubar.mUndo))
+            text=_('Undo'), command=self.menubar.mUndo))
         tv.add_node(LTreeNode(
-            text='Redo', command=self.menubar.mRedo))
+            text=_('Redo'), command=self.menubar.mRedo))
         tv.add_node(LTreeNode(
-            text='Redo all', command=self.menubar.mRedoAll))
+            text=_('Redo all'), command=self.menubar.mRedoAll))
 
         tv.add_node(LTreeNode(
-            text='Auto drop', command=self.menubar.mDrop))
+            text=_('Auto drop'), command=self.menubar.mDrop))
         tv.add_node(LTreeNode(
-            text='Shuffle tiles', command=self.menubar.mShuffle))
+            text=_('Shuffle tiles'), command=self.menubar.mShuffle))
         tv.add_node(LTreeNode(
-            text='Deal cards', command=self.menubar.mDeal))
+            text=_('Deal cards'), command=self.menubar.mDeal))
 
         self.addCheckNode(tv, None,
-                          'Pause',
+                          _('Pause'),
                           self.menubar.tkopt.pause,
                           self.menubar.mPause)
 
         tv.add_node(LTreeNode(
-            text='Load game', command=self.menubar.mOpen))
+            text=_('Load game'), command=self.menubar.mOpen))
         tv.add_node(LTreeNode(
-            text='Save game', command=self.menubar.mSaveAs))
+            text=_('Save game'), command=self.menubar.mSaveAs))
 
         tv.add_node(LTreeNode(
-            text='Help', command=self.menubar.mHelpRules))
+            text=_('Help'), command=self.menubar.mHelpRules))
 
         # -------------------------------------------
         # TBD ?
@@ -369,7 +368,7 @@ class GameMenuDialog(LMenuDialog):
 
     def buildTree(self, tv, node):
         tv.add_node(LTreeNode(
-            text='Current game ...',
+            text=_('Current game...'),
             command=self.make_command(101, self.menubar.mPlayerStats)), None)
 
         # tv.add_node(LTreeNode(
@@ -432,16 +431,16 @@ class AssistMenuDialog(LMenuDialog):
 
     def buildTree(self, tv, node):
         tv.add_node(LTreeNode(
-            text='Hint', command=self.menubar.mHint))
+            text=_('Hint'), command=self.menubar.mHint))
 
         tv.add_node(LTreeNode(
-            text='Highlight piles', command=self.menubar.mHighlightPiles))
+            text=_('Highlight piles'), command=self.menubar.mHighlightPiles))
 
         # tv.add_node(LTreeNode(
         #   text='Find Card', command=self.menubar.mFindCard))
 
         tv.add_node(LTreeNode(
-            text='Demo', command=self.menubar.mDemo))
+            text=_('Demo'), command=self.menubar.mDemo))
 
         # -------------------------------------------
         # TBD. How ?
@@ -507,27 +506,27 @@ class OptionsMenuDialog(LMenuDialog):
         # Automatic play settings
 
         rg = tv.add_node(
-            LTreeNode(text='Automatic play'))
+            LTreeNode(text=_('Automatic play')))
         if rg:
             self.addCheckNode(tv, rg,
-                              'Auto face up',
+                              _('Auto face up'),
                               self.menubar.tkopt.autofaceup,
                               self.menubar.mOptAutoFaceUp)
 
             self.addCheckNode(tv, rg,
-                              'Auto drop',
+                              _('Auto drop'),
                               self.menubar.tkopt.autodrop,
                               self.menubar.mOptAutoDrop)
 
             self.addCheckNode(tv, rg,
-                              'Auto deal',
+                              _('Auto deal'),
                               self.menubar.tkopt.autodeal,
                               self.menubar.mOptAutoDeal)
 
             # submenu.add_separator()
 
             self.addCheckNode(tv, rg,
-                              'Quick play',
+                              _('Quick play'),
                               self.menubar.tkopt.quickplay,
                               self.menubar.mOptQuickPlay)
 
@@ -535,57 +534,57 @@ class OptionsMenuDialog(LMenuDialog):
         # Player assistance
 
         rg = tv.add_node(
-            LTreeNode(text='Assist level'))
+            LTreeNode(text=_('Assist level')))
         if rg:
             self.addCheckNode(tv, rg,
-                              'Enable undo',
+                              _('Enable undo'),
                               self.menubar.tkopt.undo,
                               self.menubar.mOptEnableUndo)
 
             self.addCheckNode(tv, rg,
-                              'Enable bookmarks',
+                              _('Enable bookmarks'),
                               self.menubar.tkopt.bookmarks,
                               self.menubar.mOptEnableBookmarks)
 
             self.addCheckNode(tv, rg,
-                              'Enable hint',
+                              _('Enable hint'),
                               self.menubar.tkopt.hint,
                               self.menubar.mOptEnableHint)
 
             self.addCheckNode(tv, rg,
-                              'Enable shuffle',
+                              _('Enable shuffle'),
                               self.menubar.tkopt.shuffle,
                               self.menubar.mOptEnableShuffle)
 
             self.addCheckNode(tv, rg,
-                              'Enable highlight piles',
+                              _('Enable highlight piles'),
                               self.menubar.tkopt.highlight_piles,
                               self.menubar.mOptEnableHighlightPiles)
 
             self.addCheckNode(tv, rg,
-                              'Enable highlight cards',
+                              _('Enable highlight cards'),
                               self.menubar.tkopt.highlight_cards,
                               self.menubar.mOptEnableHighlightCards)
 
             self.addCheckNode(tv, rg,
-                              'Enable highlight same rank',
+                              _('Enable highlight same rank'),
                               self.menubar.tkopt.highlight_samerank,
                               self.menubar.mOptEnableHighlightSameRank)
 
             self.addCheckNode(tv, rg,
-                              'Highlight no matching',
+                              _('Highlight no matching'),
                               self.menubar.tkopt.highlight_not_matching,
                               self.menubar.mOptEnableHighlightNotMatching)
 
             # submenu.add_separator()
 
             self.addCheckNode(tv, rg,
-                              'Show removed tiles (in Mahjongg games)',
+                              _('Show removed tiles (in Mahjongg games)'),
                               self.menubar.tkopt.mahjongg_show_removed,
                               self.menubar.mOptMahjonggShowRemoved)
 
             self.addCheckNode(tv, rg,
-                              'Show hint arrow (in Shisen-Sho games)',
+                              _('Show hint arrow (in Shisen-Sho games)'),
                               self.menubar.tkopt.shisen_show_hint,
                               self.menubar.mOptShisenShowHint)
 
@@ -595,154 +594,154 @@ class OptionsMenuDialog(LMenuDialog):
         # Sound options
 
         rg = tv.add_node(
-            LTreeNode(text='Sound'))
+            LTreeNode(text=_('Sound')))
         if rg:
             self.addCheckNode(tv, rg,
-                              'Enable',
+                              _('Enable'),
                               self.menubar.tkopt.sound,
                               self.menubar.mOptSoundDialog)
 
             rg1 = tv.add_node(
-                LTreeNode(text='Volume'), rg)
+                LTreeNode(text=_('Volume')), rg)
             if rg1:
                 self.addRadioNode(tv, rg1,
-                                  '100%',
+                                  _('100%'),
                                   self.menubar.tkopt.sound_sample_volume, 100,
                                   self.menubar.mOptSoundSampleVol)
                 self.addRadioNode(tv, rg1,
-                                  '75%',
+                                  _('75%'),
                                   self.menubar.tkopt.sound_sample_volume, 75,
                                   self.menubar.mOptSoundSampleVol)
                 self.addRadioNode(tv, rg1,
-                                  '50%',
+                                  _('50%'),
                                   self.menubar.tkopt.sound_sample_volume, 50,
                                   self.menubar.mOptSoundSampleVol)
                 self.addRadioNode(tv, rg1,
-                                  '25%',
+                                  _('25%'),
                                   self.menubar.tkopt.sound_sample_volume, 25,
                                   self.menubar.mOptSoundSampleVol)
 
             rg1 = tv.add_node(
-                LTreeNode(text='Samples'), rg)
+                LTreeNode(text=_('Samples')), rg)
             if rg1:
                 key = 'areyousure'
                 self.addCheckNode(
                     tv, rg1,
-                    'are you sure',
+                    _('are you sure'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'autodrop'
                 self.addCheckNode(
                     tv, rg1,
-                    'auto drop',
+                    _('auto drop'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'autoflip'
                 self.addCheckNode(
                     tv, rg1,
-                    'auto flip',
+                    _('auto flip'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'autopilotlost'
                 self.addCheckNode(
                     tv, rg1,
-                    'auto pilot lost',
+                    _('auto pilot lost'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'autopilotwon'
                 self.addCheckNode(
                     tv, rg1,
-                    'auto pilot won',
+                    _('auto pilot won'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'deal'
                 self.addCheckNode(
                     tv, rg1,
-                    'deal',
+                    _('deal'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'dealwaste'
                 self.addCheckNode(
                     tv, rg1,
-                    'deal waste',
+                    _('deal waste'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'droppair'
                 self.addCheckNode(
                     tv, rg1,
-                    'drop pair',
+                    _('drop pair'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'drop'
                 self.addCheckNode(
                     tv, rg1,
-                    'drop',
+                    _('drop'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'flip'
                 self.addCheckNode(
                     tv, rg1,
-                    'flip',
+                    _('flip'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'move'
                 self.addCheckNode(
                     tv, rg1,
-                    'move',
+                    _('move'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'nomove'
                 self.addCheckNode(
                     tv, rg1,
-                    'no move',
+                    _('no move'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'redo'
                 self.addCheckNode(
                     tv, rg1,
-                    'redo',
+                    _('redo'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'startdrag'
                 self.addCheckNode(
                     tv, rg1,
-                    'start drag',
+                    _('start drag'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'turnwaste'
                 self.addCheckNode(
                     tv, rg1,
-                    'turn waste',
+                    _('turn waste'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'undo'
                 self.addCheckNode(
                     tv, rg1,
-                    'undo',
+                    _('undo'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'gamefinished'
                 self.addCheckNode(
                     tv, rg1,
-                    'game finished',
+                    _('game finished'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'gamelost'
                 self.addCheckNode(
                     tv, rg1,
-                    'game lost',
+                    _('game lost'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'gameperfect'
                 self.addCheckNode(
                     tv, rg1,
-                    'game perfect',
+                    _('game perfect'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
                 key = 'gamewon'
                 self.addCheckNode(
                     tv, rg1,
-                    'game won',
+                    _('game won'),
                     self.menubar.tkopt.sound_sample_vars[key],
                     self.make_vars_command(self.menubar.mOptSoundSample, key))
 
@@ -750,7 +749,7 @@ class OptionsMenuDialog(LMenuDialog):
         # Cardsets and card backside options
 
         rg = tv.add_node(
-            LTreeNode(text='Cardsets'))
+            LTreeNode(text=_('Cardsets')))
         if rg:
             self.menubar.tkopt.cardset.set(self.app.cardset.index)
 
@@ -790,45 +789,45 @@ class OptionsMenuDialog(LMenuDialog):
         # Table background settings
 
         rg = tv.add_node(
-            LTreeNode(text='Table'))
+            LTreeNode(text=_('Table')))
         if rg:
             rg1 = tv.add_node(
-                LTreeNode(text='Solid colors'), rg)
+                LTreeNode(text=_('Solid colors')), rg)
             if rg1:
                 key = 'table'
                 self.addRadioNode(
                     tv, rg1,
-                    'Blue',
+                    _('Blue'),
                     self.menubar.tkopt.color_vars[key], '#0082df',
                     self.menubar.mOptTableColor)
                 self.addRadioNode(
                     tv, rg1,
-                    'Green',
+                    _('Green'),
                     self.menubar.tkopt.color_vars[key], '#008200',
                     self.menubar.mOptTableColor)
                 self.addRadioNode(
                     tv, rg1,
-                    'Navy',
+                    _('Navy'),
                     self.menubar.tkopt.color_vars[key], '#000086',
                     self.menubar.mOptTableColor)
                 self.addRadioNode(
                     tv, rg1,
-                    'Olive',
+                    _('Olive'),
                     self.menubar.tkopt.color_vars[key], '#868200',
                     self.menubar.mOptTableColor)
                 self.addRadioNode(
                     tv, rg1,
-                    'Orange',
+                    _('Orange'),
                     self.menubar.tkopt.color_vars[key], '#f79600',
                     self.menubar.mOptTableColor)
                 self.addRadioNode(
                     tv, rg1,
-                    'Teal',
+                    _('Teal'),
                     self.menubar.tkopt.color_vars[key], '#008286',
                     self.menubar.mOptTableColor)
 
             rg1 = tv.add_node(
-                LTreeNode(text='Tiles and Images'), rg)
+                LTreeNode(text=_('Tiles and Images')), rg)
 
             if rg1:
                 tm = self.app.tabletile_manager
@@ -848,30 +847,30 @@ class OptionsMenuDialog(LMenuDialog):
         # Card view options
 
         rg = tv.add_node(
-            LTreeNode(text='Card view'))
+            LTreeNode(text=_('Card view')))
         if rg:
             self.addCheckNode(tv, rg,
-                              'Card shadow',
+                              _('Card shadow'),
                               self.menubar.tkopt.shadow,
                               self.menubar.mOptShadow)
 
             self.addCheckNode(tv, rg,
-                              'Shade legal moves',
+                              _('Shade legal moves'),
                               self.menubar.tkopt.shade,
                               self.menubar.mOptShade)
 
             self.addCheckNode(tv, rg,
-                              'Negative cards bottom',
+                              _('Negative cards bottom'),
                               self.menubar.tkopt.negative_bottom,
                               self.menubar.mOptNegativeBottom)
 
             self.addCheckNode(tv, rg,
-                              'Shrink face-down cards',
+                              _('Shrink face-down cards'),
                               self.menubar.tkopt.shrink_face_down,
                               self.menubar.mOptShrinkFaceDown)
 
             self.addCheckNode(tv, rg,
-                              'Shade filled stacks',
+                              _('Shade filled stacks'),
                               self.menubar.tkopt.shade_filled_stacks,
                               self.menubar.mOptShadeFilledStacks)
 
@@ -879,47 +878,47 @@ class OptionsMenuDialog(LMenuDialog):
         # Animation settins
 
         rg = tv.add_node(
-            LTreeNode(text='Animations'))
+            LTreeNode(text=_('Animations')))
         if rg:
             self.addRadioNode(tv, rg,
-                              'None',
+                              _('None'),
                               self.menubar.tkopt.animations, 0,
                               self.menubar.mOptAnimations)
 
             self.addRadioNode(tv, rg,
-                              'Very fast',
+                              _('Very fast'),
                               self.menubar.tkopt.animations, 1,
                               self.menubar.mOptAnimations)
 
             self.addRadioNode(tv, rg,
-                              'Fast',
+                              _('Fast'),
                               self.menubar.tkopt.animations, 2,
                               self.menubar.mOptAnimations)
 
             self.addRadioNode(tv, rg,
-                              'Medium',
+                              _('Medium'),
                               self.menubar.tkopt.animations, 3,
                               self.menubar.mOptAnimations)
 
             self.addRadioNode(tv, rg,
-                              'Slow',
+                              _('Slow'),
                               self.menubar.tkopt.animations, 4,
                               self.menubar.mOptAnimations)
 
             self.addRadioNode(tv, rg,
-                              'Very slow',
+                              _('Very slow'),
                               self.menubar.tkopt.animations, 5,
                               self.menubar.mOptAnimations)
 
             # submenu.add_separator()
 
             self.addCheckNode(tv, rg,
-                              'Redeal animation',
+                              _('Redeal animation'),
                               self.menubar.tkopt.redeal_animation,
                               self.menubar.mRedealAnimation)
 
             self.addCheckNode(tv, rg,
-                              'Winning animation',
+                              _('Winning animation'),
                               self.menubar.tkopt.win_animation,
                               self.menubar.mWinAnimation)
 
@@ -927,15 +926,15 @@ class OptionsMenuDialog(LMenuDialog):
         # Touch mode settings
 
         rg = tv.add_node(
-            LTreeNode(text='Touch mode'))
+            LTreeNode(text=_('Touch mode')))
         if rg:
             self.addRadioNode(tv, rg,
-                              'Drag-and-Drop',
+                              _('Drag-and-Drop'),
                               self.menubar.tkopt.mouse_type, 'drag-n-drop',
                               self.menubar.mOptMouseType)
 
             self.addRadioNode(tv, rg,
-                              'Point-and-Click',
+                              _('Point-and-Click'),
                               self.menubar.tkopt.mouse_type, 'point-n-click',
                               self.menubar.mOptMouseType)
 
@@ -969,10 +968,10 @@ class OptionsMenuDialog(LMenuDialog):
         # Toolbar options
 
         rg = tv.add_node(
-            LTreeNode(text='Toolbar'))
+            LTreeNode(text=_('Toolbar')))
         if rg:
             self.addRadioNode(tv, rg,
-                              'Hide',
+                              _('Hide'),
                               self.menubar.tkopt.toolbar, 0,
                               self.menubar.mOptToolbar)
 
@@ -987,11 +986,11 @@ class OptionsMenuDialog(LMenuDialog):
             #   self.menubar.mOptToolbar)
 
             self.addRadioNode(tv, rg,
-                              'Left',
+                              _('Left'),
                               self.menubar.tkopt.toolbar, 3,
                               self.menubar.mOptToolbar)
             self.addRadioNode(tv, rg,
-                              'Right',
+                              _('Right'),
                               self.menubar.tkopt.toolbar, 4,
                               self.menubar.mOptToolbar)
 
@@ -1028,12 +1027,12 @@ class OptionsMenuDialog(LMenuDialog):
         #   self.menubar.mOptDemoLogo)
 
         self.addCheckNode(tv, None,
-                          'Startup splash screen',
+                          _('Startup splash screen'),
                           self.menubar.tkopt.splashscreen,
                           self.menubar.mOptSplashscreen)
 
         self.addCheckNode(tv, None,
-                          'Winning splash',
+                          _('Winning splash'),
                           self.menubar.tkopt.display_win_message,
                           self.menubar.mWinDialog)
 
@@ -1056,23 +1055,23 @@ class HelpMenuDialog(LMenuDialog):
     def buildTree(self, tv, node):
         tv.add_node(
             LTreeNode(
-                text='Contents',
+                text=_('Contents'),
                 command=self.make_help_command(self.menubar.mHelp)))
         tv.add_node(
             LTreeNode(
-                text='How to play',
+                text=_('How to play'),
                 command=self.make_help_command(self.menubar.mHelpHowToPlay)))
         tv.add_node(
             LTreeNode(
-                text='Rules for this game',
+                text=_('Rules for this game'),
                 command=self.make_help_command(self.menubar.mHelpRules)))
         tv.add_node(
             LTreeNode(
-                text='License terms',
+                text=_('License terms'),
                 command=self.make_help_command(self.menubar.mHelpLicense)))
         tv.add_node(
             LTreeNode(
-                text='About' + TITLE + '...',
+                text=_('About %s...') % TITLE,
                 command=self.make_help_command(self.menubar.mHelpAbout)))
 
         # tv.add_node(LTreeNode(
@@ -1346,7 +1345,7 @@ class PysolMenubarTk:
 
         # LMainMenuDialog()
         LMenuItem(self.__menubar.menu,
-                  text="Menu", command=self.mMainMenuDialog)
+                  text=_("Menu"), command=self.mMainMenuDialog)
 
         MfxMenubar.addPath = None
 
@@ -1574,7 +1573,8 @@ class PysolMenubarTk:
         menu.delete(0, 'last')
 
         if len(games) == 0:
-            menu.add_radiobutton(label='<none>', name=None, state='disabled')
+            menu.add_radiobutton(label=_('<none>'), name=None,
+                                 state='disabled')
         elif len(games) > self.__cb_max * 4:
             games.sort(lambda a, b: cmp2(a.name, b.name))
             self._addSelectAllGameSubMenu(games, menu,
@@ -1791,8 +1791,9 @@ class PysolMenubarTk:
     #
 
     DEFAULTEXTENSION = ".pso"
-    FILETYPES = ((TITLE + " files", "*" + DEFAULTEXTENSION),
-                 ("All files", "*"))
+    # TRANSLATORS: Usually, 'PySol files'
+    FILETYPES = ((_("%s files") % TITLE, "*" + DEFAULTEXTENSION),
+                 (_("All files"), "*"))
 
     def mAddFavor(self, *event):
         gameid = self.app.game.id
@@ -2066,10 +2067,9 @@ class PysolMenubarTk:
         # if os.name == "posix":
         strings, default = (None, _("&Load"), _(
             "&Cancel"), _("&Info..."), ), 1
-        t = CARDSET
         key = self.app.nextgame.cardset.index
         d = SelectCardsetDialogWithPreview(
-                self.top, title=_("Select ") + t,
+                self.top, title=_("Select cardset"),
                 app=self.app, manager=self.app.cardset_manager, key=key,
                 strings=strings, default=default)
 

--- a/pysollib/kivy/selectgame.py
+++ b/pysollib/kivy/selectgame.py
@@ -165,7 +165,7 @@ class SelectGameData(SelectDialogTreeData):
             if name is None or not list(filter(
                     select_func, self.all_games_gi)):
                 continue
-            name = _("New games in v. ") + name
+            name = _("New games in v. %(version)s") % {'version': name}
             gg.append(SelectGameNode(None, name, select_func))
         if 1 and gg:
             s_by_pysol_version = SelectGameNode(None, _("by PySol version"),

--- a/pysollib/kivy/tkhtml.py
+++ b/pysollib/kivy/tkhtml.py
@@ -406,7 +406,7 @@ class HTMLViewer:
         # self.defcursor = 'xterm'
         self.handcursor = "hand2"
 
-        self.title = "Browser"
+        self.title = _("Browser")
         self.window = None
         self.running = False
 
@@ -431,11 +431,11 @@ class HTMLViewer:
         #   BoxLayout(orientation='horizontal', size_hint=(1.0, 0.1))
 
         # create buttons
-        self.homeButton = HTMLButton(text="Index", on_release=self.goHome)
-        self.backButton = HTMLButton(text="Back", on_release=self.goBack)
+        self.homeButton = HTMLButton(text=_("Index"), on_release=self.goHome)
+        self.backButton = HTMLButton(text=_("Back"), on_release=self.goBack)
         self.forwardButton = HTMLButton(
-            text="Forward", on_release=self.goForward)
-        self.closeButton = HTMLButton(text="Close", on_release=self.goHome)
+            text=_("Forward"), on_release=self.goForward)
+        self.closeButton = HTMLButton(text=_("Close"), on_release=self.goHome)
 
         '''
         buttonline.add_widget(self.homeButton)
@@ -683,7 +683,8 @@ class HTMLViewer:
             self.display(self.home, relpath=0)
 
     def errorDialog(self, msg):
-        MfxMessageDialog(self.parent, title=TITLE + " HTML Problem",
+        MfxMessageDialog(self.parent,
+                         title=_("%s HTML Problem") % TITLE,
                          text=msg,
                          # bitmap="warning"
                          # FIXME: this interp don't have images

--- a/pysollib/kivy/tkstats.py
+++ b/pysollib/kivy/tkstats.py
@@ -172,8 +172,11 @@ class SingleGame_StatsDialog(MfxDialog):
 
         print('Stats(p): won=%s, lost=%s' % (won, lost))
 
-        text1 = 'Total:\n   won: %s ... %s%%\n   lost: %s ... %s%%\n\n' % (
-            won, int(round(100.0 * pwon)), lost, int(round(100.0 * plost)))
+        text1 = _('Total:\n' +
+                  '   won: %(won)s ... %(percentwon)s%%\n' +
+                  '   lost: %(lost)s ... %(percentlost)s%%\n\n') % dict(
+            won=won, percentwon=int(round(100.0 * pwon)),
+            lost=lost, percentlost=int(round(100.0 * plost)))
 
 #        createChart(app, won, lost, _("Total"))
         won, lost = app.stats.getSessionStats(player, gameid)
@@ -181,9 +184,11 @@ class SingleGame_StatsDialog(MfxDialog):
 
         print('Stats(s): won=%s, lost=%s' % (won, lost))
 
-        text2 = \
-            'Current Session:\n   won: %s ... %s%%\n   lost: %s ... %s%%\n' % \
-            (won, int(round(100.0 * pwon)), lost, int(round(100.0 * plost)))
+        text2 = _('Current Session:\n' +
+                  '   won: %(won)s ... %(percentwon)s%%\n' +
+                  '   lost: %(lost)s ... %(percentlost)s%%\n') % dict(
+            won=won, percentwon=(round(100.0 * pwon)),
+            lost=lost, percentlost=int(round(100.0 * plost)))
         # text2 = 'Current Session:\n   won=%s, lost=%s\n' % (won, lost)
 
 #        createChart(app, won, lost, _("Current session"))

--- a/pysollib/kivy/tkwidget.py
+++ b/pysollib/kivy/tkwidget.py
@@ -167,10 +167,10 @@ class MfxMessageDialog(MfxDialog):
 
         # LB
         # nicht automatisch ein neues spiel laden.
-        if (title == "Game won"):
+        if (title == _("Game won")):
             self.status = 1
             # self.button = 0
-        if (title == "Game finished"):
+        if (title == _("Game finished")):
             self.status = 1
             # self.button =
 
@@ -180,7 +180,7 @@ class MfxMessageDialog(MfxDialog):
 
 
 class MfxExceptionDialog(MfxMessageDialog):
-    def __init__(self, parent, ex, title="Error", **kw):
+    def __init__(self, parent, ex, title=_("Error"), **kw):
         kw = KwStruct(kw, bitmap="error")
         text = kw.get("text", "")
         if not text.endswith("\n"):

--- a/pysollib/kivy/toolbar.py
+++ b/pysollib/kivy/toolbar.py
@@ -203,7 +203,7 @@ class PysolToolbarTk(BoxLayout):
             # (n_("Statistics"), self.mPlayerStats, _("View statistics")),
             (n_("Rules"),    self.mHelpRules, _("Rules for this game")),
             (None,           None,            None),
-            (n_("Quit"),     self.mHoldAndQuit,      _("Quit ") + TITLE),
+            (n_("Quit"),     self.mHoldAndQuit,      _("Quit %s") % TITLE),
         ):
             if label is None:
                 # sep = self._createSeparator()

--- a/pysollib/main.py
+++ b/pysollib/main.py
@@ -56,25 +56,25 @@ if TOOLKIT == 'kivy':
     def fatal_no_cardsets(app):
         app.wm_withdraw()
         MfxMessageDialog(app.top, title=_("%s installation error") % TITLE,
-                         text=_('''No cardsets were found !!!
+                         text=_('''No cardsets were found!!!
 
 Cardsets should be installed into:
-%s/cardsets/
+%(dir)s
 
-Please check your %s installation.
-''') % (getprefdir(PACKAGE), TITLE),
+Please check your %(app)s installation.
+''') % {'dir': getprefdir(PACKAGE) + '/cardsets/', 'app': TITLE},
             bitmap="error", strings=(_("&Quit"),))
 else:
     def fatal_no_cardsets(app):
         app.wm_withdraw()
         MfxMessageDialog(app.top, title=_("%s installation error") % TITLE,
-                         text=_('''No cardsets were found !!!
+                         text=_('''No cardsets were found!!!
 
 Main data directory is:
-%s
+%(dir)s
 
-Please check your %s installation.
-''') % (app.dataloader.dir, TITLE),
+Please check your %(app)s installation.
+''') % {'dir': app.dataloader.dir, 'app': TITLE},
                      bitmap="error", strings=(_("&Quit"),))
 
 
@@ -93,8 +93,8 @@ def parse_option(argv):
                                        "sound-mod=",
                                        "help"])
     except getopt.GetoptError as err:
-        print_err(_("%s\ntry %s --help for more information") %
-                  (err, prog_name), 0)
+        print_err(err + "\n" + _("try %s --help for more information") %
+                  prog_name, 0)
         return None
     opts = {"help": False,
             "deal": None,
@@ -303,13 +303,14 @@ def pysol_init(app, args):
         app.intro.progress.destroy()
         d = MfxMessageDialog(top, title=_("%s installation error") % TITLE,
                              text=_('''
-No games were found !!!
+No games were found!!!
 
 Main data directory is:
-%s
+%(dir)s
 
-Please check your %s installation.
-''') % (app.dataloader.dir, TITLE), bitmap="error", strings=(_("&Quit"),))
+Please check your %(app)s installation.
+''') % {'dir': app.dataloader.dir, 'app': TITLE},
+                             bitmap="error", strings=(_("&Quit"),))
         return 1
 
     # init cardsets

--- a/pysollib/pysolgtk/selectgame.py
+++ b/pysollib/pysolgtk/selectgame.py
@@ -290,7 +290,7 @@ class SelectGameDialogWithPreview(MfxDialog):
         for version, vg in GI.GAMES_BY_PYSOL_VERSION:
             def selecter(gi, vg=vg):
                 return gi.id in vg
-            label = _("New games in v. ") + version
+            label = _("New games in v. %(version)s") % {'version': version}
             data.append((label, selecter))
         self._addGamesFromData(data, store, None,
                                _("by PySol version"), all_games)
@@ -423,7 +423,7 @@ class SelectGameDialogWithPreview(MfxDialog):
         # self.top.wm_title(
         #   "Select Game - " + self.app.getGameTitleName(gameid))
         title = self.app.getGameTitleName(gameid)
-        self.set_title(_("Playable Preview - ") + title)
+        self.set_title(_("Playable Preview - %(game)s") % {'game': title})
         #
         self.preview_game = gi.gameclass(gi)
         self.preview_game.createPreview(self.preview_app)

--- a/pysollib/pysolgtk/tkhtml.py
+++ b/pysollib/pysolgtk/tkhtml.py
@@ -434,13 +434,13 @@ class HTMLViewer:
         for p in REMOTE_PROTOCOLS:
             if url.startswith(p):
                 if not openURL(url):
-                    self.errorDialog(TITLE + _('''HTML limitation:
-The %s protocol is not supported yet.
+                    self.errorDialog(_('''%(app)s HTML limitation:
+The %(protocol)s protocol is not supported yet.
 
 Please use your standard web browser
 to open the following URL:
-%s
-''') % (p, url))
+%(url)s
+''') % {'app': TITLE, 'protocol': p, 'url': url})
                 return
 
         # locate the file relative to the current url

--- a/pysollib/pysolgtk/tkstats.py
+++ b/pysollib/pysolgtk/tkstats.py
@@ -67,7 +67,8 @@ class StatsFormatter(PysolStatsFormatter):
                            6, result[6],
                            7, result[7])
         total, played, won, lost, time, moves, perc = self.getStatSummary()
-        text = _("Total (%d out of %d games)") % (played, total)
+        text = _("Total (%(played)d out of %(total)d games)") % {
+            'played': played, 'total': total}
         iter = self.store.append(None)
         self.store.set(iter,
                        0, text,

--- a/pysollib/stack.py
+++ b/pysollib/stack.py
@@ -1945,7 +1945,7 @@ class TalonStack(Stack,
             nredeals = _('Unlimited redeals.')
         else:
             n = self.max_rounds-1
-            nredeals = ungettext('%d readeal', '%d redeals', n) % n
+            nredeals = ungettext('%d redeal', '%d redeals', n) % n
         # round = _('Round #%d.') % self.round
         return _('Talon.')+' '+nredeals  # +' '+round
 

--- a/pysollib/stats.py
+++ b/pysollib/stats.py
@@ -199,7 +199,7 @@ class FileStatsFormatter(PysolStatsFormatter):
     def writeStats(self, player, sort_by='name'):
         if player is None:
             player = _('Demo')
-        header = _("Statistics for ") + player
+        header = _("Statistics for %(player)s") % {'player': player}
         self.writeHeader(header, 62)
         header = self.getStatHeader()
         self.pstats(*header)
@@ -209,7 +209,8 @@ class FileStatsFormatter(PysolStatsFormatter):
             self.pstats(gameid=gameid, *result)
         self.nl()
         total, played, won, lost, time, moves, perc = self.getStatSummary()
-        self.pstats(_("Total (%d out of %d games)") % (played, total),
+        self.pstats(_("Total (%(played)d out of %(total)d games)") %
+                    {'played': played, 'total': total},
                     won+lost, won, lost, time, moves, perc)
         self.nl(2)
         return played
@@ -231,14 +232,14 @@ class FileStatsFormatter(PysolStatsFormatter):
     def writeFullLog(self, player):
         if player is None:
             player = _('Demo')
-        header = _("Full log for ") + player
+        header = _("Full log for %(player)s") % {'player': player}
         prev_games = self.app.stats.prev_games.get(player)
         return self.writeLog(player, header, prev_games)
 
     def writeSessionLog(self, player):
         if player is None:
             player = _('Demo')
-        header = _("Session log for ") + player
+        header = _("Session log for %(player)s") % {'player': player}
         prev_games = self.app.stats.session_games.get(player)
         return self.writeLog(player, header, prev_games)
 

--- a/pysollib/tile/menubar.py
+++ b/pysollib/tile/menubar.py
@@ -105,8 +105,8 @@ class PysolMenubarTk(PysolMenubarTkCommon):
         self._calc_MfxMessageDialog()(
             self.top, title=_("Change theme"),
             text=_("""\
-This settings will take effect
-the next time you restart """)+TITLE,
+These settings will take effect
+the next time you restart %(app)s""") % {'app': TITLE},
             bitmap="warning",
             default=0, strings=(_("&OK"),))
 

--- a/pysollib/tile/selectgame.py
+++ b/pysollib/tile/selectgame.py
@@ -144,7 +144,7 @@ class SelectGameData(SelectDialogTreeData):
             if name is None or not list(filter(
                     select_func, self.all_games_gi)):
                 continue
-            name = _("New games in v. ") + name
+            name = _("New games in v. %(version)s") % {'version': name}
             gg.append(SelectGameNode(None, name, select_func))
         if 1 and gg:
             s_by_pysol_version = SelectGameNode(None, _("by PySol version"),
@@ -513,7 +513,7 @@ class SelectGameDialogWithPreview(SelectGameDialog):
         # self.top.wm_title("Select Game - " +
         #   self.app.getGameTitleName(gameid))
         title = self.app.getGameTitleName(gameid)
-        self.top.wm_title(_("Playable Preview - ") + title)
+        self.top.wm_title(_("Playable Preview - %(game)s") % {'game': title})
         #
         self.preview_game = gi.gameclass(gi)
         self.preview_game.createPreview(self.preview_app)

--- a/pysollib/tile/tkstats.py
+++ b/pysollib/tile/tkstats.py
@@ -368,7 +368,8 @@ class TreeFormatter(PysolStatsFormatter):
             self.parent_window.games[id] = t8
 
         total, played, won, lost, time_, moves, perc = self.getStatSummary()
-        text = _("Total (%d out of %d games)") % (played, total)
+        text = _("Total (%(played)d out of %(total)d games)") % {
+            'played': played, 'total': total}
         id = self.tree.insert("", "end", text=text,
                               values=(won+lost, won, lost, time_, moves, perc))
         self.parent_window.tree_items.append(id)

--- a/pysollib/tile/toolbar.py
+++ b/pysollib/tile/toolbar.py
@@ -188,7 +188,7 @@ class PysolToolbarTk:
             (n_("Statistics"), self.mPlayerStats, _("View statistics")),
             (n_("Rules"),    self.mHelpRules, _("Rules for this game")),
             (None,           None,            None),
-            (n_("Quit"),     self.mQuit,      _("Quit ")+TITLE),
+            (n_("Quit"),     self.mQuit,      _("Quit %s") % TITLE),
                 ):
             if label is None:
                 sep = self._createSeparator()

--- a/pysollib/tk/selectgame.py
+++ b/pysollib/tk/selectgame.py
@@ -144,7 +144,7 @@ class SelectGameData(SelectDialogTreeData):
             if name is None or not list(filter(
                     select_func, self.all_games_gi)):
                 continue
-            name = _("New games in v. ") + name
+            name = _("New games in v. %(version)s") % {'version': name}
             gg.append(SelectGameNode(None, name, select_func))
         if 1 and gg:
             s_by_pysol_version = SelectGameNode(None, _("by PySol version"),
@@ -514,7 +514,7 @@ class SelectGameDialogWithPreview(SelectGameDialog):
         # self.top.wm_title("Select Game - " +
         #   self.app.getGameTitleName(gameid))
         title = self.app.getGameTitleName(gameid)
-        self.top.wm_title(_("Playable Preview - ") + title)
+        self.top.wm_title(_("Playable Preview - %(game)s") % {'game': title})
         #
         self.preview_game = gi.gameclass(gi)
         self.preview_game.createPreview(self.preview_app)

--- a/pysollib/tk/tkstats.py
+++ b/pysollib/tk/tkstats.py
@@ -410,7 +410,8 @@ class CanvasFormatter(PysolStatsFormatter):
         #
         y += self.h
         total, played, won, lost, time_, moves, perc = self.getStatSummary()
-        s = _("Total (%d out of %d games)") % (played, total)
+        s = _("Total (%(played)d out of %(total)d games)") % {
+            'played': played, 'total': total}
         self.pstats(y, (s, won+lost, won, lost, time_, moves, perc))
 
     def writeLog(self, player, prev_games):

--- a/pysollib/tk/toolbar.py
+++ b/pysollib/tk/toolbar.py
@@ -188,7 +188,7 @@ class PysolToolbarTk:
             (n_("Statistics"), self.mPlayerStats, _("View statistics")),
             (n_("Rules"),    self.mHelpRules, _("Rules for this game")),
             (None,           None,            None),
-            (n_("Quit"),     self.mQuit,      _("Quit ")+TITLE),
+            (n_("Quit"),     self.mQuit,      _("Quit %s") % TITLE),
                 ):
             if label is None:
                 sep = self._createSeparator()

--- a/pysollib/ui/tktile/menubar.py
+++ b/pysollib/ui/tktile/menubar.py
@@ -293,7 +293,7 @@ class PysolMenubarTkCommon:
         if WIN_SYSTEM == "aqua":
             applemenu = MfxMenu(self.menubar, "apple")
             applemenu.add_command(
-                label=_("&About ")+TITLE, command=self.mHelpAbout)
+                label=_("&About %s") % TITLE, command=self.mHelpAbout)
 
         menu = MfxMenu(self.menubar, n_("&File"))
         menu.add_command(
@@ -663,7 +663,7 @@ class PysolMenubarTkCommon:
         if WIN_SYSTEM != "aqua":
             menu.add_separator()
             menu.add_command(
-                label=n_("&About ")+TITLE+"...",
+                label=_("&About %s...") % TITLE,
                 command=self.mHelpAbout)
 
         MfxMenubar.addPath = None
@@ -968,7 +968,8 @@ class PysolMenubarTkCommon:
     def updateGamesMenu(self, menu, games):
         menu.delete(0, 'last')
         if len(games) == 0:
-            menu.add_radiobutton(label='<none>', name=None, state='disabled')
+            menu.add_radiobutton(label=_('<none>'), name=None,
+                                 state='disabled')
         elif len(games) > self.cb_max*4:
             games.sort(key=lambda x: x.name)
             self._addSelectAllGameSubMenu(games, menu,
@@ -1132,7 +1133,8 @@ class PysolMenubarTkCommon:
     #
 
     DEFAULTEXTENSION = ".pso"
-    FILETYPES = ((TITLE+" files", "*"+DEFAULTEXTENSION), ("All files", "*"))
+    FILETYPES = ((_("%s files") % TITLE, "*" + DEFAULTEXTENSION),
+                 (_("All files"), "*"))
 
     def mAddFavor(self, *event):
         gameid = self.app.game.id

--- a/pysollib/ui/tktile/solverdialog.py
+++ b/pysollib/ui/tktile/solverdialog.py
@@ -25,7 +25,7 @@ class BaseSolverDialog:
     def __init__(self, parent, app, **kw):
         self.parent = parent
         self.app = app
-        title = TITLE+' - FreeCell Solver'
+        title = _('%(app)s - FreeCell Solver') % {'app': TITLE}
         kw = self.initKw(kw)
         self._calc_MfxDialog().__init__(
             self, parent, title, kw.resizable, kw.default)

--- a/pysollib/ui/tktile/tkhtml.py
+++ b/pysollib/ui/tktile/tkhtml.py
@@ -311,13 +311,13 @@ class Base_HTMLViewer:
         for p in REMOTE_PROTOCOLS:
             if url.startswith(p):
                 if not openURL(url):
-                    self.errorDialog(TITLE + _('''HTML limitation:
-The %s protocol is not supported yet.
+                    self.errorDialog(_('''%(app)s HTML limitation:
+The %(protocol)s protocol is not supported yet.
 
 Please use your standard web browser
 to open the following URL:
-%s
-''') % (p, url))
+%(url)s
+''') % {'app': TITLE, 'protocol': p, 'url': url})
                 return
 
         # locate the file relative to the current url
@@ -429,7 +429,7 @@ to open the following URL:
 
     def errorDialog(self, msg):
         self._calc_MfxMessageDialog()(
-            self.parent, title=TITLE+" HTML Problem",
+            self.parent, title="%(app)s HTML Problem" % {'app': TITLE},
             text=msg,
             # bitmap="warning", # FIXME: this interp don't have images
             strings=(_("&OK"),), default=0)


### PR DESCRIPTION
Motivation for these changes is to make the kivy UI localizable, as well as give the translators messages that they can more easily understand. In many instances, I have changed string concatenation to `%` formatting. xgettext also previously [complained that format strings with unnamed arguments can't be properly localized](https://ci.appveyor.com/project/shlomif/pysolfc/builds/27097047?fullLog=true#L2084), so those have been changed to named args. 

Due to the massive size of these commits, I didn't push this straight to master.