### PR TITLE
Spread stacks over x axis of canvas

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
 # Shamelessly taken from https://github.com/plicease/Dist-Zilla-PluginBundle-Author-Plicease/blob/master/.appveyor.yml
 # Thanks!
 install:
-    - choco install strawberryperl
+    - choco install strawberryperl --version 5.32.0.1
     - copy %PYTHON%\python.exe %PYTHON%\python3.exe
     - SET PATH=%PYTHON%;%PYTHON%\Scripts;C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
     - python3 -mpip install Pillow attrs configobj flake8 flake8-import-order
@@ -65,7 +65,5 @@ artifacts:
       name: pysol_win_installer
 cache:
     # - C:\_P5 -> .appveyor.yml
-    # https://www.appveyor.com/docs/build-cache/
-    # the next time the build is run the cache item will be invalidated/deleted in the beginning of the build.    
-    - C:\strawberry -> .appveyor.yml
+    # - C:\strawberry -> .appveyor.yml
 shallow_clone: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,8 +5,7 @@ environment:
 # Shamelessly taken from https://github.com/plicease/Dist-Zilla-PluginBundle-Author-Plicease/blob/master/.appveyor.yml
 # Thanks!
 install:
-    - choco install strawberryperl --version 5.30.0.1
-    # - choco install strawberryperl --version 5.32.0.1
+    - choco install strawberryperl
     - copy %PYTHON%\python.exe %PYTHON%\python3.exe
     - SET PATH=%PYTHON%;%PYTHON%\Scripts;C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
     - python3 -mpip install Pillow attrs configobj flake8 flake8-import-order

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,8 @@ environment:
 # Shamelessly taken from https://github.com/plicease/Dist-Zilla-PluginBundle-Author-Plicease/blob/master/.appveyor.yml
 # Thanks!
 install:
-    - choco install strawberryperl --version 5.32.0.1
+    - choco install strawberryperl --version 5.30.0.1
+    # - choco install strawberryperl --version 5.32.0.1
     - copy %PYTHON%\python.exe %PYTHON%\python3.exe
     - SET PATH=%PYTHON%;%PYTHON%\Scripts;C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
     - python3 -mpip install Pillow attrs configobj flake8 flake8-import-order

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,5 +65,7 @@ artifacts:
       name: pysol_win_installer
 cache:
     # - C:\_P5 -> .appveyor.yml
-    # - C:\strawberry -> .appveyor.yml
+    # https://www.appveyor.com/docs/build-cache/
+    # the next time the build is run the cache item will be invalidated/deleted in the beginning of the build.    
+    - C:\strawberry -> .appveyor.yml
 shallow_clone: true

--- a/pysollib/game/__init__.py
+++ b/pysollib/game/__init__.py
@@ -1024,9 +1024,14 @@ class Game(object):
             x0, y0 = stack.init_coord
             x, y = int(round(x0*xf)), int(round(y0*yf))
 
-            # Do not move Talons (because one would need to reposition 'empty cross' and 'redeal' figures)
-            # But in that case, games with talon not placed top-left corner will get it misplaced when auto_scale
-            # e.g. Suit Elevens => player can fix that issue by setting auto_scale false
+            # Do not move Talons
+            # (because one would need to reposition
+            # 'empty cross' and 'redeal' figures)
+            # But in that case,
+            # games with talon not placed top-left corner
+            # will get it misplaced when auto_scale
+            # e.g. Suit Elevens
+            # => player can fix that issue by setting auto_scale false
             if stack is self.s.talon:
                 # stack.init_coord=(x, y)
                 if card_size_manually:

--- a/pysollib/tile/selectcardset.py
+++ b/pysollib/tile/selectcardset.py
@@ -358,15 +358,16 @@ class SelectCardsetDialogWithPreview(MfxDialog):
 
             if USE_PIL:
                 auto_scale = bool(self.auto_scale.get())
-                if button == 1: # Cancel
+                if button == 1:  # Cancel
                     # no changes
                     self.cardset_values = None
-                elif button == 0: # OK
+                elif button == 0:  # OK
                     self.app.menubar.tkopt.auto_scale.set(auto_scale)
 
-                    self.app.opt.scale_x=self.scale_x.get()
-                    self.app.opt.scale_y=self.scale_y.get()
-                    self.app.opt.preserve_aspect_ratio=self.preserve_aspect.get()
+                    self.app.opt.scale_x = self.scale_x.get()
+                    self.app.opt.scale_y = self.scale_y.get()
+                    self.app.opt.preserve_aspect_ratio = \
+                        self.preserve_aspect.get()
 
                     self.scale_values = (self.app.opt.scale_x,
                                          self.app.opt.scale_y,

--- a/pysollib/tile/selectcardset.py
+++ b/pysollib/tile/selectcardset.py
@@ -358,22 +358,22 @@ class SelectCardsetDialogWithPreview(MfxDialog):
 
             if USE_PIL:
                 auto_scale = bool(self.auto_scale.get())
-                if button == 1:
-                    self.app.menubar.tkopt.auto_scale.set(auto_scale)
-
+                if button == 1: # Cancel
                     # no changes
                     self.cardset_values = None
+                elif button == 0: # OK
+                    self.app.menubar.tkopt.auto_scale.set(auto_scale)
 
-                if auto_scale:
+                    self.app.opt.scale_x=self.scale_x.get()
+                    self.app.opt.scale_y=self.scale_y.get()
+                    self.app.opt.preserve_aspect_ratio=self.preserve_aspect.get()
+
                     self.scale_values = (self.app.opt.scale_x,
                                          self.app.opt.scale_y,
                                          auto_scale,
-                                         bool(self.preserve_aspect.get()))
-                else:
-                    self.scale_values = (self.scale_x.get(),
-                                         self.scale_y.get(),
-                                         auto_scale,
                                          self.app.opt.preserve_aspect_ratio)
+                    self.app.game.resizeGame(card_size_manually=True)
+
         if button == 10:                # Info
             cs = self.manager.get(self.tree.selection_key)
             if not cs:

--- a/pysollib/tile/selectcardset.py
+++ b/pysollib/tile/selectcardset.py
@@ -373,6 +373,7 @@ class SelectCardsetDialogWithPreview(MfxDialog):
                                          auto_scale,
                                          self.app.opt.preserve_aspect_ratio)
                     self.app.game.resizeGame(card_size_manually=True)
+                    self.app.game.resizeGame(card_size_manually=False)
 
         if button == 10:                # Info
             cs = self.manager.get(self.tree.selection_key)

--- a/pysollib/ui/tktile/menubar.py
+++ b/pysollib/ui/tktile/menubar.py
@@ -1462,8 +1462,8 @@ Unsupported game for import.
             self.app.opt.scale_y += 0.1
         else:
             return
-        self.app.opt.auto_scale = False
-        self.tkopt.auto_scale.set(False)
+        # self.app.opt.auto_scale = False
+        # self.tkopt.auto_scale.set(False)
         self._updateCardSize()
 
     def mDecreaseCardset(self, *event):
@@ -1477,8 +1477,8 @@ Unsupported game for import.
             self.app.opt.scale_y -= 0.1
         else:
             return
-        self.app.opt.auto_scale = False
-        self.tkopt.auto_scale.set(False)
+        # self.app.opt.auto_scale = False
+        # self.tkopt.auto_scale.set(False)
         self._updateCardSize()
 
     def mOptAutoScale(self, *event):

--- a/pysollib/ui/tktile/menubar.py
+++ b/pysollib/ui/tktile/menubar.py
@@ -1443,7 +1443,8 @@ Unsupported game for import.
         if self.app.opt.auto_scale:
             w, h = self.app.opt.game_geometry
             self.app.canvas.setInitialSize(w, h, scrollregion=False)
-            self.app.game.resizeGame(card_size_manually=False) # Resize a second time to auto scale
+            # Resize a second time to auto scale
+            self.app.game.resizeGame(card_size_manually=False)
         else:
             w = int(round(self.app.game.width * self.app.opt.scale_x))
             h = int(round(self.app.game.height * self.app.opt.scale_y))

--- a/pysollib/ui/tktile/menubar.py
+++ b/pysollib/ui/tktile/menubar.py
@@ -1439,10 +1439,11 @@ Unsupported game for import.
         geom = (self.app.canvas.winfo_width(),
                 self.app.canvas.winfo_height())
         self.app.opt.game_geometry = geom
-        self.app.game.resizeGame()
+        self.app.game.resizeGame(card_size_manually=True)
         if self.app.opt.auto_scale:
             w, h = self.app.opt.game_geometry
             self.app.canvas.setInitialSize(w, h, scrollregion=False)
+            self.app.game.resizeGame(card_size_manually=False) # Resize a second time to auto scale
         else:
             w = int(round(self.app.game.width * self.app.opt.scale_x))
             h = int(round(self.app.game.height * self.app.opt.scale_y))


### PR DESCRIPTION
Following our dialog in https://github.com/shlomif/PySolFC/issues/195.

This modifies the auto_scale control. I only changed things for the x axis.

Currently, this is not perfect for games with talons placed at a different position than the top left corner. A CTRL+0 will disable auto_scale in that case.

A screenshot of what I wanted to achieve:
![MS_XP_Spider_short_large](https://user-images.githubusercontent.com/8808589/99696084-947ee980-2a8e-11eb-9ab4-2e9f31078ee9.png)

A screenshot of what I had first:
![PySolFC_Spider_Autoscale_dont_preserve_AR](https://user-images.githubusercontent.com/8808589/99696210-bd06e380-2a8e-11eb-8156-b15352e7f880.png)

And current situation:
![PySol_PR](https://user-images.githubusercontent.com/8808589/99696954-8c737980-2a8f-11eb-8c45-64dd8d733e3d.png)

 