### PR TITLE
Organized the "Special Games" category

### DIFF
--- a/pysollib/gamedb.py
+++ b/pysollib/gamedb.py
@@ -85,6 +85,8 @@ class GI:
     GT_TERRACE = 32
     GT_YUKON = 33
     GT_SHISEN_SHO = 34
+    GT_HANOI = 35
+    GT_PEGGED = 36
     GT_CUSTOM = 40
     # extra flags
     GT_BETA = 1 << 12      # beta version of game driver
@@ -228,15 +230,19 @@ class GI:
     )
 
     SELECT_SPECIAL_GAME_BY_TYPE = (
-        (n_("Shisen-Sho"), lambda gi, gt=GT_SHISEN_SHO: gi.si.game_type == gt),
         (n_("Hex A Deck type"),
             lambda gi, gt=GT_HEXADECK: gi.si.game_type == gt),
         (n_("Matrix type"), lambda gi, gt=GT_MATRIX: gi.si.game_type == gt),
         (n_("Memory type"), lambda gi, gt=GT_MEMORY: gi.si.game_type == gt),
+        (n_("Pegged type"), lambda gi, gt=GT_PEGGED: gi.si.game_type == gt),
         (n_("Poker type"), lambda gi, gt=GT_POKER_TYPE: gi.si.game_type == gt),
         (n_("Puzzle type"),
             lambda gi, gt=GT_PUZZLE_TYPE: gi.si.game_type == gt),
+        (n_("Shisen-Sho type"),
+            lambda gi, gt=GT_SHISEN_SHO: gi.si.game_type == gt),
         (n_("Tarock type"), lambda gi, gt=GT_TAROCK: gi.si.game_type == gt),
+        (n_("Tower of Hanoi type"),
+            lambda gi, gt=GT_HANOI: gi.si.game_type == gt),
     )
 
     # These obsolete gameids have been used in previous versions of

--- a/pysollib/games/special/hanoi.py
+++ b/pysollib/games/special/hanoi.py
@@ -136,6 +136,18 @@ class HanoiPuzzle6(HanoiPuzzle4):
     pass
 
 
+class HanoiPuzzle3(HanoiPuzzle4):
+    pass
+
+
+class HanoiPuzzle7(HanoiPuzzle4):
+    pass
+
+
+class HanoiPuzzle8(HanoiPuzzle4):
+    pass
+
+
 # ************************************************************************
 # * Hanoi Sequence
 # ************************************************************************
@@ -150,20 +162,32 @@ class HanoiSequence(TowerOfHanoy):
 
 # register the game
 registerGame(GameInfo(124, TowerOfHanoy, "Tower of Hanoy",
-                      GI.GT_PUZZLE_TYPE, 1, 0, GI.SL_SKILL,
+                      GI.GT_HANOI, 1, 0, GI.SL_SKILL,
                       suits=(2,), ranks=list(range(9))))
 registerGame(GameInfo(207, HanoiPuzzle4, "Hanoi Puzzle 4",
-                      GI.GT_PUZZLE_TYPE, 1, 0, GI.SL_SKILL,
+                      GI.GT_HANOI, 1, 0, GI.SL_SKILL,
                       suits=(2,), ranks=list(range(4)),
                       rules_filename="hanoipuzzle.html"))
 registerGame(GameInfo(208, HanoiPuzzle5, "Hanoi Puzzle 5",
-                      GI.GT_PUZZLE_TYPE, 1, 0, GI.SL_SKILL,
+                      GI.GT_HANOI, 1, 0, GI.SL_SKILL,
                       suits=(2,), ranks=list(range(5)),
                       rules_filename="hanoipuzzle.html"))
 registerGame(GameInfo(209, HanoiPuzzle6, "Hanoi Puzzle 6",
-                      GI.GT_PUZZLE_TYPE, 1, 0, GI.SL_SKILL,
+                      GI.GT_HANOI, 1, 0, GI.SL_SKILL,
                       suits=(2,), ranks=list(range(6)),
                       rules_filename="hanoipuzzle.html"))
+registerGame(GameInfo(779, HanoiPuzzle3, "Hanoi Puzzle 3",
+                      GI.GT_HANOI, 1, 0, GI.SL_SKILL,
+                      suits=(2,), ranks=list(range(3)),
+                      rules_filename="hanoipuzzle.html"))
+registerGame(GameInfo(780, HanoiPuzzle7, "Hanoi Puzzle 7",
+                      GI.GT_HANOI, 1, 0, GI.SL_SKILL,
+                      suits=(2,), ranks=list(range(7)),
+                      rules_filename="hanoipuzzle.html"))
+registerGame(GameInfo(781, HanoiPuzzle8, "Hanoi Puzzle 8",
+                      GI.GT_HANOI, 1, 0, GI.SL_SKILL,
+                      suits=(2,), ranks=list(range(8)),
+                      rules_filename="hanoipuzzle.html"))
 registerGame(GameInfo(769, HanoiSequence, "Hanoi Sequence",
-                      GI.GT_PUZZLE_TYPE, 1, 0, GI.SL_SKILL,
+                      GI.GT_HANOI, 1, 0, GI.SL_SKILL,
                       suits=(2,), ranks=list(range(9))))

--- a/pysollib/games/special/pegged.py
+++ b/pysollib/games/special/pegged.py
@@ -246,7 +246,7 @@ def r(id, gameclass, name):
         ncards += n
     ncards -= 1
     gi = GameInfo(id, gameclass, name,
-                  GI.GT_PUZZLE_TYPE, 1, 0, GI.SL_SKILL,
+                  GI.GT_PEGGED, 1, 0, GI.SL_SKILL,
                   category=GI.GC_TRUMP_ONLY,
                   suits=(), ranks=(), trumps=list(range(ncards)),
                   si={"decks": 1, "ncards": ncards},

--- a/scripts/all_games.py
+++ b/scripts/all_games.py
@@ -73,6 +73,8 @@ GAME_BY_TYPE = {
     GI.GT_MAHJONGG: "Mahjongg",
     GI.GT_MUGHAL_GANJIFA: "Mughal Ganjifa",
     GI.GT_SHISEN_SHO: "Shisen-Sho",
+    GI.GT_HANOI: "Tower of Hanoi",
+    GI.GT_PEGGED: "Pegged",
 
 }
 


### PR DESCRIPTION
I made some changes to improve the organization of the "Special Games" category to make it more consistent and accurate.

- I moved the Shisen-Sho category to its correct place in the list alphabetically, and changed the verbiage to better match the other game categories.
- The Puzzle Type category is a bit of a vague description, as many solitaire games could qualify as puzzles.  As this category is currently used for both the Tower of Hanoi and the Pegged type games, I split this category into two separate categories for each of those game types to make the categorization more accurate and intuitive.

I added a couple more Hanoi Puzzle variations while I was working on this to help with testing.