### PR TITLE
Split logic to spread stacks from auto-scale logic

### DIFF
--- a/pysollib/app.py
+++ b/pysollib/app.py
@@ -833,7 +833,8 @@ Please select a %(correct_type)s type cardset.
         changed = False
         if USE_PIL:
             if (self.opt.scale_x, self.opt.scale_y,
-                self.opt.auto_scale, self.opt.preserve_aspect_ratio) != \
+                self.opt.auto_scale, self.opt.spread_stacks,
+                self.opt.preserve_aspect_ratio) != \
                 d.scale_values or \
                     (cs.CARD_XOFFSET, cs.CARD_YOFFSET) != d.cardset_values:
                 changed = True
@@ -843,6 +844,7 @@ Please select a %(correct_type)s type cardset.
             (self.opt.scale_x,
              self.opt.scale_y,
              self.opt.auto_scale,
+             self.opt.spread_stacks,
              self.opt.preserve_aspect_ratio) = d.scale_values
             if not self.opt.auto_scale:
                 self.images.resize(self.opt.scale_x, self.opt.scale_y)

--- a/pysollib/game/__init__.py
+++ b/pysollib/game/__init__.py
@@ -984,7 +984,8 @@ class Game(object):
 
     def resizeImages(self, manually=False):
         # resizing images and cards
-        if self.app.opt.auto_scale and not manually:
+        if (self.app.opt.auto_scale or
+                (self.app.opt.spread_stacks and not manually)):
             if self.canvas.winfo_ismapped():
                 # apparent size of canvas
                 vw = self.canvas.winfo_width()
@@ -1002,10 +1003,12 @@ class Game(object):
             # calculate factor of resizing
             xf = float(vw)/iw
             yf = float(vh)/ih
-            if self.app.opt.preserve_aspect_ratio:
+            if (self.app.opt.preserve_aspect_ratio
+                    and not self.app.opt.spread_stacks):
                 xf = yf = min(xf, yf)
         else:
             xf, yf = self.app.opt.scale_x, self.app.opt.scale_y
+        if (not self.app.opt.spread_stacks or manually):
             # images
             self.app.images.resize(xf, yf)
         # cards
@@ -1024,20 +1027,23 @@ class Game(object):
             x0, y0 = stack.init_coord
             x, y = int(round(x0*xf)), int(round(y0*yf))
 
-            # Do not move Talons
-            # (because one would need to reposition
-            # 'empty cross' and 'redeal' figures)
-            # But in that case,
-            # games with talon not placed top-left corner
-            # will get it misplaced when auto_scale
-            # e.g. Suit Elevens
-            # => player can fix that issue by setting auto_scale false
-            if stack is self.s.talon:
-                # stack.init_coord=(x, y)
-                if card_size_manually:
-                    stack.resize(xf, yf0)
+            if (self.app.opt.spread_stacks):
+                # Do not move Talons
+                # (because one would need to reposition
+                # 'empty cross' and 'redeal' figures)
+                # But in that case,
+                # games with talon not placed top-left corner
+                # will get it misplaced when auto_scale
+                # e.g. Suit Elevens
+                # => player can fix that issue by setting auto_scale false
+                if stack is self.s.talon:
+                    # stack.init_coord=(x, y)
+                    if card_size_manually:
+                        stack.resize(xf, yf0)
+                    else:
+                        stack.resize(xf0, yf0)
                 else:
-                    stack.resize(xf0, yf0)
+                    stack.resize(xf, yf0)
             else:
                 stack.resize(xf, yf0)
             stack.updatePositions()

--- a/pysollib/options.py
+++ b/pysollib/options.py
@@ -435,6 +435,7 @@ class Options:
         self.scale_x = 1.0
         self.scale_y = 1.0
         self.auto_scale = False
+        self.spread_stacks = False
         self.preserve_aspect_ratio = True
         # solver
         self.solver_presets = [
@@ -574,7 +575,8 @@ class Options:
         for key, val in self.cardset.items():
             config['cardsets'][str(key)] = val
         for key in ('scale_cards', 'scale_x', 'scale_y',
-                    'auto_scale', 'preserve_aspect_ratio'):
+                    'auto_scale', 'spread_stacks',
+                    'preserve_aspect_ratio'):
             config['cardsets'][key] = getattr(self, key)
 
         # games_geometry
@@ -744,6 +746,7 @@ class Options:
                        ('scale_x', 'float'),
                        ('scale_y', 'float'),
                        ('auto_scale', 'bool'),
+                       ('spread_stacks', 'bool'),
                        ('preserve_aspect_ratio', 'bool')):
             val = self._getOption('cardsets', key, t)
             if val is not None:

--- a/pysollib/tile/selectcardset.py
+++ b/pysollib/tile/selectcardset.py
@@ -309,6 +309,7 @@ class SelectCardsetDialogWithPreview(MfxDialog):
                 )
             self.aspect_check.grid(row=6, column=0, sticky='ew',
                                    padx=padx, pady=pady)
+
             self._updateAutoScale()
         #
         left_frame.rowconfigure(0, weight=1)
@@ -358,24 +359,27 @@ class SelectCardsetDialogWithPreview(MfxDialog):
 
             if USE_PIL:
                 auto_scale = bool(self.auto_scale.get())
-                if button == 1:  # Cancel
+                if button == 1:
                     # no changes
                     self.cardset_values = None
-                elif button == 0:  # OK
+
+                elif button == 0:
                     self.app.menubar.tkopt.auto_scale.set(auto_scale)
 
-                    self.app.opt.scale_x = self.scale_x.get()
-                    self.app.opt.scale_y = self.scale_y.get()
-                    self.app.opt.preserve_aspect_ratio = \
-                        self.preserve_aspect.get()
-
-                    self.scale_values = (self.app.opt.scale_x,
-                                         self.app.opt.scale_y,
-                                         auto_scale,
-                                         self.app.opt.preserve_aspect_ratio)
-                    self.app.game.resizeGame(card_size_manually=True)
-                    self.app.game.resizeGame(card_size_manually=False)
-
+                    if auto_scale:
+                        self.app.menubar.tkopt.spread_stacks.set(False)
+                        self.scale_values = (self.app.opt.scale_x,
+                                             self.app.opt.scale_y,
+                                             auto_scale,
+                                             False,
+                                             bool(self.preserve_aspect.get()))
+                    else:
+                        self.scale_values = (self.scale_x.get(),
+                                             self.scale_y.get(),
+                                             auto_scale,
+                                             self.app.opt.spread_stacks,
+                                             self.app.opt.
+                                             preserve_aspect_ratio)
         if button == 10:                # Info
             cs = self.manager.get(self.tree.selection_key)
             if not cs:

--- a/pysollib/tk/menubar.py
+++ b/pysollib/tk/menubar.py
@@ -101,6 +101,7 @@ class PysolMenubarTk(PysolMenubarTkCommon):
             changed = (self.app.opt.scale_x,
                        self.app.opt.scale_y,
                        self.app.opt.auto_scale,
+                       self.app.opt.spread_stacks,
                        self.app.opt.preserve_aspect_ratio) != d.scale_values
         else:
             changed = False

--- a/pysollib/ui/tktile/menubar.py
+++ b/pysollib/ui/tktile/menubar.py
@@ -171,6 +171,7 @@ class PysolMenubarTkCommon:
             shisen_show_hint=tkinter.BooleanVar(),
             sound=tkinter.BooleanVar(),
             auto_scale=tkinter.BooleanVar(),
+            spread_stacks=tkinter.BooleanVar(),
             cardback=tkinter.IntVar(),
             tabletile=tkinter.IntVar(),
             animations=tkinter.IntVar(),
@@ -222,6 +223,7 @@ class PysolMenubarTkCommon:
         tkopt.shisen_show_hint.set(opt.shisen_show_hint)
         tkopt.sound.set(opt.sound)
         tkopt.auto_scale.set(opt.auto_scale)
+        tkopt.spread_stacks.set(opt.spread_stacks)
         tkopt.cardback.set(self.app.cardset.backindex)
         tkopt.tabletile.set(self.app.tabletile_index)
         tkopt.animations.set(opt.animations)
@@ -534,6 +536,9 @@ class PysolMenubarTkCommon:
             submenu.add_checkbutton(
                 label=n_("&Auto scaling"), variable=self.tkopt.auto_scale,
                 command=self.mOptAutoScale, accelerator=m+'0')
+            submenu.add_checkbutton(
+                label=n_("&Spread stacks"), variable=self.tkopt.spread_stacks,
+                command=self.mOptSpreadStacks)
         # manager = self.app.cardset_manager
         # n = manager.len()
         menu.add_command(
@@ -1440,7 +1445,7 @@ Unsupported game for import.
                 self.app.canvas.winfo_height())
         self.app.opt.game_geometry = geom
         self.app.game.resizeGame(card_size_manually=True)
-        if self.app.opt.auto_scale:
+        if self.app.opt.auto_scale or self.app.opt.spread_stacks:
             w, h = self.app.opt.game_geometry
             self.app.canvas.setInitialSize(w, h, scrollregion=False)
             # Resize a second time to auto scale
@@ -1463,8 +1468,8 @@ Unsupported game for import.
             self.app.opt.scale_y += 0.1
         else:
             return
-        # self.app.opt.auto_scale = False
-        # self.tkopt.auto_scale.set(False)
+        self.app.opt.auto_scale = False
+        self.tkopt.auto_scale.set(False)
         self._updateCardSize()
 
     def mDecreaseCardset(self, *event):
@@ -1478,16 +1483,36 @@ Unsupported game for import.
             self.app.opt.scale_y -= 0.1
         else:
             return
-        # self.app.opt.auto_scale = False
-        # self.tkopt.auto_scale.set(False)
+        self.app.opt.auto_scale = False
+        self.tkopt.auto_scale.set(False)
         self._updateCardSize()
 
     def mOptAutoScale(self, *event):
         if self._cancelDrag(break_pause=True):
             return
         auto_scale = not self.app.opt.auto_scale
+
+        # In the future, it should be possible to use both options together,
+        # but the current logic conflicts, so not allowed for now.
+        self.app.opt.spread_stacks = False
+        self.tkopt.spread_stacks.set(False)
+
         self.app.opt.auto_scale = auto_scale
         self.tkopt.auto_scale.set(auto_scale)
+        self._updateCardSize()
+
+    def mOptSpreadStacks(self, *event):
+        if self._cancelDrag(break_pause=True):
+            return
+        spread_stacks = not self.app.opt.spread_stacks
+
+        # In the future, it should be possible to use both options together,
+        # but the current logic conflicts, so not allowed for now.
+        self.app.opt.auto_scale = False
+        self.tkopt.auto_scale.set(False)
+
+        self.app.opt.spread_stacks = spread_stacks
+        self.tkopt.spread_stacks.set(spread_stacks)
         self._updateCardSize()
 
     def _mOptCardback(self, index):


### PR DESCRIPTION
Commit 5876134d11ae9e577279d35d4d9e50fd89229b45 added logic to spread the stacks across the screen without changing the card size.  However, this logic replaced the existing auto-scale logic.

With this PR, I moved the logic to spread stacks to a separate option, allowing a user to choose which type of display logic they want to use - I know the previous auto-scale logic is liked by a lot of people and is very helpful when playing in higher resolutions.  Currently, the two display options have conflicting logic, so both can't be used at once, though I plan to further improve this logic in the future.