### PR TITLE
Improved support for ultra large cardsets

### DIFF
--- a/pysollib/game/__init__.py
+++ b/pysollib/game/__init__.py
@@ -997,7 +997,7 @@ class Game(object):
                 vw, vh = self.app.opt.game_geometry
                 if not vw:
                     # first run of the game
-                    return 1, 1
+                    return 1, 1, 1, 1
             # requested size of canvas (createGame -> setSize)
             iw, ih = self.init_size
             # calculate factor of resizing
@@ -1045,7 +1045,7 @@ class Game(object):
                 else:
                     stack.resize(xf, yf0)
             else:
-                stack.resize(xf, yf0)
+                stack.resize(xf, yf)
             stack.updatePositions()
         self.regions.calc_info(xf, yf)
         # texts
@@ -1862,7 +1862,10 @@ class Game(object):
         # for InvisibleStack, etc
         # x, y = -500, -500 - len(game.allstacks)
         cardw, cardh = self.app.images.CARDW, self.app.images.CARDH
-        x, y = cardw + self.canvas.xmargin, cardh + self.canvas.ymargin
+        xoffset = self.app.images.CARD_XOFFSET
+        yoffset = self.app.images.CARD_YOFFSET
+        x = cardw + xoffset + self.canvas.xmargin
+        y = cardh + yoffset + self.canvas.ymargin
         return -x-10, -y-10
 
     #

--- a/pysollib/games/hitormiss.py
+++ b/pysollib/games/hitormiss.py
@@ -115,10 +115,9 @@ class HitOrMiss(Game):
         x += layout.XS * 1.1
         y = layout.YM + 1.4 * layout.YS
         if self.preview <= 1:
-            self.texts.rank = \
+            self.texts.base_rank = \
                 MfxCanvasText(self.canvas, x, y, anchor="nw",
-                              font=self.app.getFont("canvas_default"),
-                              text=_(""))
+                              font=self.app.getFont("canvas_large"))
 
         # define stack-groups
         layout.defaultStackGroups()
@@ -133,7 +132,7 @@ class HitOrMiss(Game):
     def updateText(self):
         if self.preview > 1:
             return
-        self.texts.rank.config(text=RANKS[self.rank])
+        self.texts.base_rank.config(text=RANKS[self.rank])
 
     def _restoreGameHook(self, game):
         self.rank = game.loadinfo.dval.get('Rank')

--- a/pysollib/games/special/poker.py
+++ b/pysollib/games/special/poker.py
@@ -72,16 +72,16 @@ class PokerSquare(Game):
                               text=_('''\
 Royal Flush
 Straight Flush
-Four of a Kind
+4 of a Kind
 Full House
 Flush
 Straight
-Three of a Kind
+3 of a Kind
 Two Pair
 One Pair'''))
             self.texts.list.append(t)
             bb = t.bbox()
-            x = bb[1][0] + 16
+            x = bb[1][0] + l.CW * 1.3
             h = bb[1][1] - bb[0][1]
             if h >= 2*l.YS:
                 ta = "e"
@@ -91,7 +91,7 @@ One Pair'''))
                               font=self.app.getFont("canvas_default"),
                               text="100\n75\n50\n25\n20\n15\n10\n5\n2")
             self.texts.list.append(t)
-            x = t.bbox()[1][0] + 16
+            x = t.bbox()[1][0] + l.CW * .6
             self.texts.misc = MfxCanvasText(
                 self.canvas, x, y, anchor="nw",
                 font=self.app.getFont("canvas_default"),

--- a/pysollib/layout.py
+++ b/pysollib/layout.py
@@ -27,7 +27,6 @@
 # PySol imports
 from pysollib.mfxutil import Struct
 from pysollib.pysoltk import MfxCanvasText
-from pysollib.resource import CSI
 
 
 # ************************************************************************
@@ -68,22 +67,11 @@ class Layout:
         self.regions = []
         # set visual constants
         images = self.game.app.images
-        cardset_size = images.cs.si.size
-        if cardset_size in (CSI.SIZE_TINY, CSI.SIZE_SMALL):
-            layout_x_margin = 6
-            layout_y_margin = 6
-            layout_card_x_space = 6
-            layout_card_y_space = 10
-        elif cardset_size in (CSI.SIZE_MEDIUM,):
-            layout_x_margin = 8
-            layout_y_margin = 8
-            layout_card_x_space = 8
-            layout_card_y_space = 12
-        else:  # CSI.SIZE_LARGE, CSI.SIZE_XLARGE
-            layout_x_margin = 10
-            layout_y_margin = 10
-            layout_card_x_space = 10
-            layout_card_y_space = 14
+
+        layout_x_margin = images.CARDW // 9
+        layout_y_margin = layout_x_margin
+        layout_card_x_space = images.CARDW // 9
+        layout_card_y_space = images.CARDH // 8
 
         self.CW = images.CARDW
         self.CH = images.CARDH

--- a/pysollib/pysolgtk/selectcardset.py
+++ b/pysollib/pysolgtk/selectcardset.py
@@ -161,7 +161,9 @@ class SelectCardsetDialogWithPreview(MfxDialog):
             (_("Small cardsets"), lambda cs: cs.si.size == CSI.SIZE_SMALL),
             (_("Medium cardsets"), lambda cs: cs.si.size == CSI.SIZE_MEDIUM),
             (_("Large cardsets"), lambda cs: cs.si.size == CSI.SIZE_LARGE),
-            (_("XLarge cardsets"), lambda cs: cs.si.size == CSI.SIZE_XLARGE),
+            (_("Extra Large cardsets"),
+                lambda cs: cs.si.size == CSI.SIZE_XLARGE),
+            (_("Hi-Res cardsets"), lambda cs: cs.si.size == CSI.SIZE_HIRES),
                 ):
             cs = self._selectCardset(all_cardsets, selecter)
             if cs:

--- a/pysollib/resource.py
+++ b/pysollib/resource.py
@@ -168,6 +168,7 @@ class CSI:
     SIZE_MEDIUM = 3
     SIZE_LARGE = 4
     SIZE_XLARGE = 5
+    SIZE_HIRES = 6
 
     # cardset types
     TYPE_FRENCH = 1
@@ -477,8 +478,10 @@ class CardsetManager(ResourceManager):
                 cs.si.size = CSI.SIZE_MEDIUM
             elif CW <= 90 and CH <= 125:
                 cs.si.size = CSI.SIZE_LARGE
-            else:
+            elif CW <= 150 and CH <= 210:
                 cs.si.size = CSI.SIZE_XLARGE
+            else:
+                cs.si.size = CSI.SIZE_HIRES
         #
         keys = cs.styles[:]
         cs.si.styles = tuple([s for s in keys if s in CSI.STYLE])

--- a/pysollib/tile/selectcardset.py
+++ b/pysollib/tile/selectcardset.py
@@ -152,8 +152,11 @@ class SelectCardsetData(SelectDialogTreeData):
                     None, _("Large cardsets"),
                     lambda cs: cs.si.size == CSI.SIZE_LARGE),
                  SelectCardsetNode(
-                    None, _("XLarge cardsets"),
+                    None, _("Extra Large cardsets"),
                     lambda cs: cs.si.size == CSI.SIZE_XLARGE),
+                 SelectCardsetNode(
+                    None, _("Hi-Res cardsets"),
+                    lambda cs: cs.si.size == CSI.SIZE_HIRES),
                  ), expanded=1),
             select_by_type,
             select_by_style,

--- a/pysollib/tk/selectcardset.py
+++ b/pysollib/tk/selectcardset.py
@@ -150,8 +150,11 @@ class SelectCardsetData(SelectDialogTreeData):
                     None, _("Large cardsets"),
                     lambda cs: cs.si.size == CSI.SIZE_LARGE),
                 SelectCardsetNode(
-                    None, _("XLarge cardsets"),
+                    None, _("Extra Large cardsets"),
                     lambda cs: cs.si.size == CSI.SIZE_XLARGE),
+                SelectCardsetNode(
+                    None, _("Hi-Res cardsets"),
+                    lambda cs: cs.si.size == CSI.SIZE_HIRES),
             ), expanded=1),
             select_by_type,
             select_by_style,


### PR DESCRIPTION
To help PySol look better on larger screens, I'm working on improving how PySol can handle ultra large cardsets.  I'm eventually hoping to make the PySol default display a combination of a higher res cardset plus auto-scaling, which has been requested in a number of issues and comments.

For the moment, I've done the following:

- Added a card size category for hi-res cardsets, as these can be much larger than the current PySol extra large cardsets (there currently aren't any such cardsets in the cardset repo, but I know a few exist and I plan to add my test cardset once I finish it).
- Made the logic used to determine the margins and spacing scale based on the exact size of the cardset rather than the size category - currently, these margins can get really tiny when using ultra large cardsets.
- Moved the invisible stack location to use the exact card size to determine its location, as if the cardset is too big, a corner of the invisible stack may be visible..
- Tweaked the display logic of a couple games that have display issues with auto-scaling.