### PR TITLE
PySolFC does translate all texts in the Game Finished window

### DIFF
--- a/pysollib/game/__init__.py
+++ b/pysollib/game/__init__.py
@@ -2136,9 +2136,8 @@ class Game(object):
         else:
             self.finished = True
             self.playSample("gamelost", priority=1000)
-            text = "Game finished, but not without my help..."
-            hintsused = ("You used %(h)s hint(s) during this game."
-                         % {'h': self.stats.hints})
+            text = _("Game finished, but not without my help...")
+            hintsused = _("You used %(h)s hint(s) during this game.") % {'h': self.stats.hints}
             d = MfxMessageDialog(
                 self.top, title=_("Game finished"), bitmap="info",
                 text=_(text + '\n\n' + hintsused),

--- a/pysollib/game/__init__.py
+++ b/pysollib/game/__init__.py
@@ -2137,7 +2137,8 @@ class Game(object):
             self.finished = True
             self.playSample("gamelost", priority=1000)
             text = _("Game finished, but not without my help...")
-            hintsused = _("You used %(h)s hint(s) during this game.") % {'h': self.stats.hints}
+            hintsused = _("You used %(h)s hint(s) during this game.") % {
+                'h': self.stats.hints}
             d = MfxMessageDialog(
                 self.top, title=_("Game finished"), bitmap="info",
                 text=_(text + '\n\n' + hintsused),


### PR DESCRIPTION
I am using the Polish language. 

Before change not all texts of the Game Finised window are translated:
![image](https://github.com/shlomif/PySolFC/assets/85434237/70edcdb8-07cd-4116-a9dd-a18a1e2302b9)


After this fix:
![image](https://github.com/shlomif/PySolFC/assets/85434237/209061ed-d2ba-49c8-b962-5c5fa6fd6934)



A game where I have tested the fix:

[Spider (1 Suit)-31071662912480092160.zip](https://github.com/shlomif/PySolFC/files/11593992/Spider.1.Suit.-31071662912480092160.zip)
