### PR TITLE
pycotap is not need to run PySolFC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ kw = {
     'install_requires': [
         'attrs>=18.2.0',
         'configobj',
-        'pycotap',
         'pysol_cards',
         'random2',
         'six',


### PR DESCRIPTION
pycotap is only needed for the single unittest, tap_unittests.py