### PR TITLE
remove usage of old Random2 backport

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ install:
     - copy %PYTHON%\python.exe %PYTHON%\python3.exe
     - SET PATH=%PYTHON%;%PYTHON%\Scripts;C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
     - python3 -mpip install Pillow attrs configobj flake8 flake8-import-order
-        pycotap pygame pyinstaller pysol-cards random2 setuptools six
+        pycotap pygame pyinstaller pysol-cards setuptools six
         ttkthemes
     - perl -v
     - copy C:\msys64\mingw64\bin\mingw32-make.exe C:\msys64\mingw64\bin\make.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 flake8-import-order \
-          attrs configobj pycotap pysol-cards random2 setuptools six
+          attrs configobj pycotap pysol-cards setuptools six
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.github/workflows/macos-package.yml
+++ b/.github/workflows/macos-package.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install --no-binary=Pillow \
-          Pillow attrs configobj py2app pycotap pygame pysol-cards random2 setuptools six ttkthemes
+          Pillow attrs configobj py2app pycotap pygame pysol-cards setuptools six ttkthemes
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         brew install create-dmg
     - name: Get cardsets

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
     # Tests are failing for them sometimes
     - cpanm --notest Capture::Tiny IPC::System::Simple
     - cpanm Code::TidyAll::Plugin::Flake8 Perl::Tidy Test::Code::TidyAll Test::Differences Test::TrailingSpace
-    - export PY_MODS='attrs configobj pycotap pysol-cards random2 setuptools six'
+    - export PY_MODS='attrs configobj pycotap pysol-cards setuptools six'
     - if test "$TRAVIS_OS_NAME" = "osx" ; then export PY_MODS="--no-binary=Pillow Pillow $PY_MODS" ; fi
     - sudo -H pip3 install --upgrade wheel
     - sudo -H pip3 install --upgrade $PY_MODS flake8 flake8-import-order

--- a/README.md
+++ b/README.md
@@ -118,21 +118,19 @@ per the instructions above.
 At the moment, this only works on POSIX (Linux, FreeBSD and similar) systems.
 Windows and Mac users - you'll need to chip in with a script for your system.
 
-#### 1 - Install build prerequisites: six, random2 and pysol-cards
+#### 1 - Install build prerequisites: six and pysol-cards
 
 This is kind of stupid and maybe it can be fixed in the future, but for now:
 
 ```
 pip install six
-pip install random2
 pip install pysol-cards
 ```
 
 You may want to use your OS distribution package system instead, for example:
 
 ```
-sudo apt-get install python-six
-sudo apt-get install python-random2
+sudo apt-get install python3-six
 ```
 
 For Pillow compilation, libjpeg headers and libraries need to be available:

--- a/buildozer/buildozer.spec
+++ b/buildozer/buildozer.spec
@@ -38,7 +38,7 @@ version.filename = %(source.dir)s/version.txt
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3,kivy,pysol-cards,random2,configobj,attrs
+requirements = python3,kivy,pysol-cards,configobj,attrs
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes

--- a/contrib/install-pysolfc.sh
+++ b/contrib/install-pysolfc.sh
@@ -6,7 +6,7 @@ PIP="${PKGTREE}/env/bin/pip"
 PYPROG="${PKGTREE}/env/bin/python"
 VERSION="$(env PYTHONPATH=`pwd` "$PYPROG" -c 'from pysollib.settings import VERSION ; print(VERSION)')"
 XZBALL="dist/PySolFC-${VERSION}.tar.xz"
-reqs=(pillow pygame random2 six)
+reqs=(pillow pygame six)
 
 make dist
 

--- a/pysollib/game/__init__.py
+++ b/pysollib/game/__init__.py
@@ -23,6 +23,7 @@
 
 
 import math
+import random
 import time
 import traceback
 from pickle import Pickler, Unpickler, UnpicklingError
@@ -66,8 +67,6 @@ from pysollib.settings import DEBUG
 from pysollib.settings import PACKAGE, TITLE, TOOLKIT, TOP_SIZE
 from pysollib.settings import VERSION, VERSION_TUPLE
 from pysollib.struct_new import NewStruct
-
-import random2
 
 import six
 from six import BytesIO
@@ -3363,7 +3362,7 @@ class Game(object):
         game.random = construct_random(initial_seed)
         state = pload()
         if (game.random is not None and
-                not isinstance(game.random, random2.Random) and
+                not isinstance(game.random, random.Random) and
                 isinstance(state, int)):
             game.random.setstate(state)
         # if not hasattr(game.random, "origin"):

--- a/setup.py
+++ b/setup.py
@@ -71,11 +71,13 @@ kw = {
     'author': 'Skomoroh',
     'author_email': 'skomoroh@gmail.com',
     'description': 'a Python solitaire game collection',
+    'classifiers': [
+        'Programming Language :: Python :: 3',
+    ],
     'install_requires': [
         'attrs>=18.2.0',
         'configobj',
         'pysol_cards',
-        'random2',
         'six',
     ],
     'long_description': long_description,


### PR DESCRIPTION
random2 was packaged in Debian for PySolFC and was only used by PySolFC.

A patch similiar to this one has already been applied in the distriubtion packaging and I have requested the removal of python3-random2.