### PR TITLE
Configure Dependabot to keep actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows/"
+    schedule:
+      interval: "weekly"
+...


### PR DESCRIPTION
Some of the github actions:
- https://github.com/shlomif/PySolFC/blob/2b525aef4ca79a7f99006cfb78faeb1a33370286/.github/workflows/ci.yml#L17
- https://github.com/shlomif/PySolFC/blob/2b525aef4ca79a7f99006cfb78faeb1a33370286/.github/workflows/ci.yml#L19
- https://github.com/shlomif/PySolFC/blob/2b525aef4ca79a7f99006cfb78faeb1a33370286/.github/workflows/macos-package.yml#L13

are no longer up to date. This PR configures the Dependabot to keep them updated.

After it will be merged, the dependabot should create pull-requests updating the mentioned dependencies.