### PR TITLE
Do not install `six`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ install:
     - copy %PYTHON%\python.exe %PYTHON%\python3.exe
     - SET PATH=%PYTHON%;%PYTHON%\Scripts;C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
     - python3 -mpip install Pillow attrs configobj flake8 flake8-import-order
-        pycotap pygame pyinstaller pysol-cards setuptools six
+        pycotap pygame pyinstaller pysol-cards setuptools
         ttkthemes
     - perl -v
     - copy C:\msys64\mingw64\bin\mingw32-make.exe C:\msys64\mingw64\bin\make.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 flake8-import-order \
-          attrs configobj pycotap pysol-cards setuptools six
+          attrs configobj pycotap pysol-cards setuptools
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.github/workflows/macos-package.yml
+++ b/.github/workflows/macos-package.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install --no-binary=Pillow \
-          Pillow attrs configobj py2app pycotap pygame pysol-cards setuptools six ttkthemes
+          Pillow attrs configobj py2app pycotap pygame pysol-cards setuptools ttkthemes
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         brew install create-dmg
     - name: Get cardsets

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
     # Tests are failing for them sometimes
     - cpanm --notest Capture::Tiny IPC::System::Simple
     - cpanm Code::TidyAll::Plugin::Flake8 Perl::Tidy Test::Code::TidyAll Test::Differences Test::TrailingSpace
-    - export PY_MODS='attrs configobj pycotap pysol-cards setuptools six'
+    - export PY_MODS='attrs configobj pycotap pysol-cards setuptools'
     - if test "$TRAVIS_OS_NAME" = "osx" ; then export PY_MODS="--no-binary=Pillow Pillow $PY_MODS" ; fi
     - sudo -H pip3 install --upgrade wheel
     - sudo -H pip3 install --upgrade $PY_MODS flake8 flake8-import-order

--- a/contrib/install-pysolfc.sh
+++ b/contrib/install-pysolfc.sh
@@ -6,7 +6,7 @@ PIP="${PKGTREE}/env/bin/pip"
 PYPROG="${PKGTREE}/env/bin/python"
 VERSION="$(env PYTHONPATH=`pwd` "$PYPROG" -c 'from pysollib.settings import VERSION ; print(VERSION)')"
 XZBALL="dist/PySolFC-${VERSION}.tar.xz"
-reqs=(pillow pygame six)
+reqs=(pillow pygame)
 
 make dist
 


### PR DESCRIPTION
It seams that [`six`](https://pypi.org/project/six/) is not longer needed. However it is still installed. This PR removes it.
 
Some PR in context:
- #403
- #382