### PR TITLE
Simplify logic by using ternary

### DIFF
--- a/pysollib/game/__init__.py
+++ b/pysollib/game/__init__.py
@@ -2829,7 +2829,7 @@ class Game(object):
                                                 text=self.getDemoInfoText())
 
     def getDemoInfoText(self):
-        h = self.Hint_Class is None and 'None' or self.Hint_Class.__name__
+        h = 'None' if self.Hint_Class is None else self.Hint_Class.__name__
         return '%s (%s)' % (self.gameinfo.short_name, h)
 
     def getDemoInfoTextAttr(self, tinfo):

--- a/pysollib/games/grandfathersclock.py
+++ b/pysollib/games/grandfathersclock.py
@@ -442,7 +442,7 @@ class BigBen(Game):
             x = int(x0 + xx*l.XS)
             y = int(y0 + yy*l.YS)
             suit = (3, 0, 2, 1)[rank % 4]
-            max_cards = rank <= 4 and 8 or 9
+            max_cards = 8 if rank <= 4 else 9
             s.foundations.append(SS_FoundationStack(x, y, self, suit=suit,
                                  max_cards=max_cards, base_rank=rank,
                                  mod=13, max_move=0))

--- a/pysollib/tile/fontsdialog.py
+++ b/pysollib/tile/fontsdialog.py
@@ -131,8 +131,8 @@ class FontChooserDialog(MfxDialog):
     def fontupdate(self, *args):
         if self.list_box.curselection():
             self.font_family = self.list_box.get(self.list_box.curselection())
-        self.font_weight = self.weight_var.get() and 'bold' or 'normal'
-        self.font_slant = self.slant_var.get() and 'italic' or 'roman'
+        self.font_weight = 'bold' if self.weight_var.get() else 'normal'
+        self.font_slant = 'italic' if self.slant_var.get() else 'roman'
         self.font_size = self.size_var.get()
         self.entry.configure(font=(self.font_family, self.font_size,
                                    self.font_slant, self.font_weight))

--- a/pysollib/tile/toolbar.py
+++ b/pysollib/tile/toolbar.py
@@ -388,7 +388,7 @@ class PysolToolbarTk:
                 padx, pady = TkSettings.vertical_toolbar_padding
                 pack_func(row=1, column=2, sticky='ns', padx=padx, pady=pady)
             # set orient
-            orient = side in (1, 2) and 'horizontal' or 'vertical'
+            orient = 'horizontal' if side in (1, 2) else 'vertical'
             self._setOrient(orient)
         self.side = side
         return 1

--- a/pysollib/tk/fontsdialog.py
+++ b/pysollib/tk/fontsdialog.py
@@ -123,8 +123,8 @@ class FontChooserDialog(MfxDialog):
     def fontupdate(self, *args):
         if self.list_box.curselection():
             self.font_family = self.list_box.get(self.list_box.curselection())
-        self.font_weight = self.weight_var.get() and 'bold' or 'normal'
-        self.font_slant = self.slant_var.get() and 'italic' or 'roman'
+        self.font_weight = 'bold' if self.weight_var.get() else 'normal'
+        self.font_slant = 'italic' if self.slant_var.get() else 'roman'
         self.font_size = self.size_var.get()
         self.entry.configure(font=(self.font_family, self.font_size,
                                    self.font_slant, self.font_weight))

--- a/pysollib/tk/toolbar.py
+++ b/pysollib/tk/toolbar.py
@@ -396,7 +396,7 @@ class PysolToolbarTk:
                 # right
                 pack_func(row=1, column=2, sticky='ns')
             # set orient
-            orient = side in (1, 2) and 'horizontal' or 'vertical'
+            orient = 'horizontal' if side in (1, 2) else 'vertical'
             self._setOrient(orient)
         self.side = side
         return 1


### PR DESCRIPTION
This PR simplifies some of the expressions by using _ternary_.

It resolves the [`consider-using-ternary / R1706`](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/consider-using-ternary.html) warning.