### PR TITLE
The `u` prefix is no longer necessary

### DIFF
--- a/pysollib/kivy/LApp.py
+++ b/pysollib/kivy/LApp.py
@@ -1069,7 +1069,7 @@ class LTreeNode(ButtonBehavior, TreeViewLabel, LBase):
             # self.text = u'\u25cf '+self.title  # unicode filled circle
         else:
             self.text = self.title
-            self.text = u'    ' + self.title
+            self.text = '    ' + self.title
             # self.text = u'\u25cb  '+self.title # unicode open circle
         self.texture_update()
 


### PR DESCRIPTION
This PR resolves the [`redundant-u-string-prefix / W1406`](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/redundant-u-string-prefix.html) warning.