### PR TITLE
Remove unnecessary lambda

### DIFF
--- a/pysollib/help.py
+++ b/pysollib/help.py
@@ -70,7 +70,7 @@ For more information about this application visit''') %
                          separator=True)
     if d.status == 0 and d.button == 1:
         viewer = help_html(app, "credits.html", "html")
-        viewer.parent.after(2, lambda: viewer.parent.focus_force())
+        viewer.parent.after(2, viewer.parent.focus_force)
         # help_credits(app, sound=sound)
     return d.status
 


### PR DESCRIPTION
The `lambda` is not needed here. One can simply use the function name.

This PR resolves the [`unnecessary-lambda / W0108`](https://pylint.readthedocs.io/en/v3.3.3/user_guide/messages/warning/unnecessary-lambda.html) warning.