### PR TITLE
Remove redundant semicolon

### DIFF
--- a/pysollib/kivy/tkcanvas.py
+++ b/pysollib/kivy/tkcanvas.py
@@ -406,7 +406,7 @@ class MfxCanvasImage(object):
                 if self.group is None: break            # noqa
                 stack = self.group.stack
                 if stack is None: break                 # noqa
-                if type(stack) not in specials: break;  # noqa
+                if type(stack) not in specials: break   # noqa
 
                 cards = self.group.stack.cards
                 card = self.image.card


### PR DESCRIPTION
This PR resolves [`unnecessary-semicolon / W0301`](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/unnecessary-semicolon.html).