### PR TITLE
Remove duplicated exception

### DIFF
--- a/pysollib/pysolgtk/tkhtml.py
+++ b/pysollib/pysolgtk/tkhtml.py
@@ -462,11 +462,6 @@ to open the following URL:
             self.errorDialog(
                 _('Unable to service request:\n') + url + '\n\n' + str(ex))
             return
-        except Exception:
-            if file:
-                file.close()
-            self.errorDialog(_('Unable to service request:\n') + url)
-            return
 
         self.url = url
         if self.home is None:

--- a/pysollib/ui/tktile/tkhtml.py
+++ b/pysollib/ui/tktile/tkhtml.py
@@ -348,11 +348,6 @@ to open the following URL:
             self.errorDialog(_("Unable to service request:\n") + url +
                              "\n\n" + str(ex))
             return
-        except Exception:
-            if file:
-                file.close()
-            self.errorDialog(_("Unable to service request:\n") + url)
-            return
 
         self.url = url
         if self.home is None:


### PR DESCRIPTION
This PR removed the _duplicated exceptions_ - they are dead code essentially.

On other words: it resolves [`duplicate-except / W0705`](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/duplicate-except.html) warning.