### PR TITLE
Resolve `unnecessary-dunder-call`

### DIFF
--- a/pysollib/games/klondike.py
+++ b/pysollib/games/klondike.py
@@ -75,7 +75,7 @@ class Klondike(Game):
         # create layout
         lay, s = Layout(self), self.s
         kwdefault(layout, rows=rows, waste=1, texts=1, playcards=16)
-        self.Layout_Method.__get__(lay, lay.__class__)(**layout)
+        self.Layout_Method(lay, **layout)
         # self.__class__.Layout_Method(lay, **layout)
         self.setSize(lay.size[0], lay.size[1])
         # create stacks


### PR DESCRIPTION
This PR resolves [`unnecessary-dunder-call / C2801`](https://pylint.readthedocs.io/en/stable/user_guide/messages/convention/unnecessary-dunder-call.html) warning.