### PR TITLE
Resolve `useless-return`

### DIFF
--- a/pysollib/games/mahjongg/mahjongg.py
+++ b/pysollib/games/mahjongg/mahjongg.py
@@ -115,7 +115,6 @@ class Mahjongg_Foundation(OpenStack):
                 n = i*9+j
                 if fnds[n].cards:
                     fnds[n].group.tkraise()
-        return
 
     def getHelp(self):
         return ''

--- a/pysollib/hint.py
+++ b/pysollib/hint.py
@@ -888,12 +888,10 @@ class FreeCellSolver_Hint(Base_Solver_Hint):
 
     def _addBoardLine(self, line):
         self.board += line + '\n'
-        return
 
     def _addPrefixLine(self, prefix, b):
         if b:
             self._addBoardLine(prefix + b)
-        return
 
     def importFileHelper(solver, fh, s_game):
         game = s_game.s

--- a/pysollib/kivy/LApp.py
+++ b/pysollib/kivy/LApp.py
@@ -1534,13 +1534,11 @@ class LTkBase:
         # logging.info('LTkBase: interruptSleep')
         self.update_idletasks()
         # self.sleep_var = 1
-        return
 
     def mainquit(self):
         logging.info('LTkBase: mainquit')
         lapp = App.get_running_app()
         lapp.mainloop.send(None)    # Spielprozess verlassen
-        return
 
     def onWakeUp(self, dt):
         self.sleeping = False

--- a/pysollib/kivy/colorsdialog.py
+++ b/pysollib/kivy/colorsdialog.py
@@ -34,7 +34,6 @@ class ColorsDialog(MfxDialog):
         kw = self.initKw(kw)
         MfxDialog.__init__(self, parent, title, kw.resizable, kw.default)
         # not used in kivy version.
-        return
 
 
 '''end of file'''

--- a/pysollib/kivy/progressbar.py
+++ b/pysollib/kivy/progressbar.py
@@ -33,7 +33,6 @@ class PysolProgressBar(Popup):
     def __init__(self, app, parent, title=None, images=None, color="blue",
                  width=300, height=25, show_text=1, norm=1):
         self.percent = 100
-        return
 
     def update(self, **kw):
         return

--- a/pysollib/kivy/selectcardset.py
+++ b/pysollib/kivy/selectcardset.py
@@ -41,7 +41,6 @@ class SelectCardsetDialogWithPreview(MfxDialog):
         self.key = key
         self.app = app
         self.manager = manager
-        return
 
     def getSelected(self):
         return None

--- a/pysollib/kivy/tkcanvas.py
+++ b/pysollib/kivy/tkcanvas.py
@@ -849,7 +849,6 @@ class MfxCanvas(LImage):
         self.r_width = width
         self.r_height = height
         self.update_widget(self.pos, self.size)
-        return
 
     # delete all CanvasItems, but keep the background and top tiles
     def deleteAllItems(self):

--- a/pysollib/kivy/tkutil.py
+++ b/pysollib/kivy/tkutil.py
@@ -370,7 +370,6 @@ def shadowImage(image, color='#3896f8', factor=0.3):
 
     logging.info("shadowImage: ")
     # TBD.
-    return None
     # Kivy nicht benötigt. aber - was tut das ?
     # wurde aufgerufen, als der erste König auf die Foundation
     # gezogen wurde. (möglicherweise eine Gewonnen! - Markierung).
@@ -378,7 +377,6 @@ def shadowImage(image, color='#3896f8', factor=0.3):
 
 def markImage(image):
     logging.info("markImage: ")
-    return None
 
 
 def _createImageMask(texture, color):

--- a/pysollib/pysolgtk/selectgame.py
+++ b/pysollib/pysolgtk/selectgame.py
@@ -319,7 +319,6 @@ class SelectGameDialogWithPreview(MfxDialog):
         #               None, _("Contrib Game"), all_games)
 
         SelectGameDialogWithPreview.game_store = store
-        return
 
     def initKw(self, kw):
         kwdefault(kw,

--- a/pysollib/pysolgtk/tkcanvas.py
+++ b/pysollib/pysolgtk/tkcanvas.py
@@ -101,7 +101,6 @@ class _CanvasItem:
 
     def lower(self, positions=None):
         print('lower', self, positions)
-        return  # don't need?
         #  if positions is None:
         #      pass
         #      ##self._item.lower_to_bottom()
@@ -324,7 +323,6 @@ class MfxCanvas(gnomecanvas.Canvas):
         assert add is None
         # FIXME
         print('TkCanvas bind:', sequence)
-        return
 
     def cget(self, attr):
         if attr == 'cursor':

--- a/pysollib/pysolgtk/tkutil.py
+++ b/pysollib/pysolgtk/tkutil.py
@@ -304,7 +304,6 @@ def after(widget, ms, func, *args):
 
 def after_idle(widget, func, *args):
     gobject.idle_add(func, *args)
-    return None
 
 
 def after_cancel(t):


### PR DESCRIPTION
This PR resolves the [`useless-return / R1711`](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/useless-return.html) warning.

I realize that the impact of that change is limited, but I could not hesitate to remove these 15 lines.