### PR TITLE
Run ci on several python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,31 @@ on:
 jobs:
   check:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+        python-version:
+          - 3.7
+          - 3.8
+          - 3.9
+          - '3.10'
+          - 3.11
+          - 3.12
+          - 3.13
+        exclude:
+          - os: ubuntu-24.04
+            python-version: 3.7
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.x'
+        python-version: ${{matrix.python-version}}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
In order to avoid such commits in the future fcad6e88af4a473734186f9baac50ca529c273f9 (sorry for introducing that bug by the way), I suggest to expand the _ci matrix_.