### PR TITLE
Resolve `useless-object-inheritance`

### DIFF
--- a/pysollib/kivy/androidrot.py
+++ b/pysollib/kivy/androidrot.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     jnius = None
 
-class AndroidRot(object):
+class AndroidRot:
     def __init__(self):
         self.locked = False
         if jnius is None:

--- a/pysollib/kivy/androidtoast.py
+++ b/pysollib/kivy/androidtoast.py
@@ -9,7 +9,7 @@ except ImportError:
     def run_on_ui_thread(a):
         pass
 
-class AndroidToast(object):
+class AndroidToast:
     def __init__(self):
         if jnius is None:
             return

--- a/pysollib/kivy/tkutil.py
+++ b/pysollib/kivy/tkutil.py
@@ -213,7 +213,7 @@ def after_cancel(t):
 
 LCoreImage = CoreImage  # noqa
 
-class LImageInfo(object):   # noqa
+class LImageInfo:
     def __init__(self, arg):
         if isinstance(arg, Texture):
             self.filename = None


### PR DESCRIPTION
This PR resolves the [`useless-object-inheritance / R0205`](https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/useless-object-inheritance.html) warning.

Similar to #486 - I am not sure why I omitted these classes back then.