### PR TITLE
Simplify `Nestor._checkRow` to make it compliant with C0200

### DIFF
--- a/pysollib/games/montecarlo.py
+++ b/pysollib/games/montecarlo.py
@@ -658,10 +658,11 @@ class Nestor(Game):
     #
 
     def _checkRow(self, cards):
-        for i in range(len(cards)):
-            for j in range(i):
-                if cards[i].rank == cards[j].rank:
-                    return j
+        seen = {}
+        for i, card in enumerate(cards):
+            if card.rank in seen:
+                return seen[card.rank]
+            seen[card.rank] = i
         return -1
 
     def _shuffleHook(self, cards):

--- a/pysollib/games/montecarlo.py
+++ b/pysollib/games/montecarlo.py
@@ -658,11 +658,11 @@ class Nestor(Game):
     #
 
     def _checkRow(self, cards):
-        seen = {}
-        for i, card in enumerate(cards):
-            if card.rank in seen:
-                return seen[card.rank]
-            seen[card.rank] = i
+        first_index = {}
+        for ind, card in enumerate(cards):
+            if card.rank in first_index:
+                return first_index[card.rank]
+            first_index[card.rank] = ind
         return -1
 
     def _shuffleHook(self, cards):


### PR DESCRIPTION
The main purpose of this PR is to make the code complaint with [`consider-using-enumerate / C0200`](https://pylint.readthedocs.io/en/latest/user_guide/messages/convention/consider-using-enumerate.html).

This change also reduces the time complexity from $O(n^2)$ to $O(n)$ (average).

Similar to #448.