### PR TITLE
Use `isinstance` to resolve `unidiomatic-typecheck / C0123`

### DIFF
--- a/pysollib/games/special/hexadeck.py
+++ b/pysollib/games/special/hexadeck.py
@@ -417,9 +417,9 @@ class BitsNBytes(AbstractHexADeckGame):
         return 1
 
     def parseEmptyStack(self, stack):
-        if type(stack) is Bits_RowStack:
+        if isinstance(stack, Bits_RowStack):
             return _("Bit stack") + " - " + str(stack.getBit())
-        if type(stack) is Bytes_RowStack:
+        if isinstance(stack, Bytes_RowStack):
             return _("Byte stack") + " - " + self.RANKS[stack.getByte()]
         return Game.parseEmptyStack(self, stack)
 


### PR DESCRIPTION
This PR resolves the [`unidiomatic-typecheck / C0123`](https://pylint.pycqa.org/en/latest/user_guide/messages/convention/unidiomatic-typecheck.html) warning.

Similar to #451.