### PR TITLE
Use `max` to resolve pylint R1731

### DIFF
--- a/scripts/mahjongg_utils.py
+++ b/scripts/mahjongg_utils.py
@@ -92,8 +92,7 @@ def parse_ace(filename):
         if x <= 0:
             x = -x
             y, z = int(mylist.pop()), int(mylist.pop())
-            if layer < z:
-                layer = z
+            layer = max(layer, z)
         layout.append((z, x, y))
     layout.sort()
     return normalize(layout)


### PR DESCRIPTION
This PR resolves [`consider-using-max-builtin / R1731`](https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/consider-using-max-builtin.html).

Similar to #447.