### PR TITLE
Optimise usage of `reverse()`

### DIFF
--- a/pysollib/game/__init__.py
+++ b/pysollib/game/__init__.py
@@ -346,8 +346,7 @@ class StackRegions(NewStruct):
     def optimize(self, remaining):
         """docstring for optimize"""
         # sort data by priority
-        self.data.sort()
-        self.data.reverse()
+        self.data.sort(reverse=True)
         # copy (stacks, rect) to info
         self.info = []
         for d in self.data:

--- a/pysollib/games/acesup.py
+++ b/pysollib/games/acesup.py
@@ -178,9 +178,7 @@ class PerpetualMotion_Talon(DealRowTalonStack):
         if sound:
             self.game.startDealSample()
         game, num_cards = self.game, len(self.cards)
-        rows = list(game.s.rows)[:]
-        rows.reverse()
-        for r in rows:
+        for r in reversed(game.s.rows):
             while r.cards:
                 num_cards = num_cards + 1
                 game.moveMove(1, r, self, frames=4)
@@ -270,8 +268,7 @@ class Valentine_Talon(WasteTalonStack):
         if not self.game.s.waste.cards and self.cards:
             return WasteTalonStack.dealCards(self, sound=sound)
         game, num_cards = self.game, len(self.cards)
-        rows = list(game.s.rows)[:]
-        rows.reverse()
+        rows = list(reversed(game.s.rows))
         for r in rows:
             while r.cards:
                 num_cards = num_cards + 1

--- a/pysollib/games/precedence.py
+++ b/pysollib/games/precedence.py
@@ -126,9 +126,7 @@ class Display_Talon(WasteTalonStack):
         game, num_cards = self.game, len(self.cards)
         if len(self.waste.cards) > 0:
             game.moveMove(1, self.waste, game.s.reserves[0], frames=2)
-        rows = list(game.s.reserves)[:]
-        rows.reverse()
-        for r in rows:
+        for r in reversed(game.s.reserves):
             while r.cards:
                 num_cards = num_cards + 1
                 game.moveMove(1, r, self, frames=2)

--- a/pysollib/games/special/lightsout.py
+++ b/pysollib/games/special/lightsout.py
@@ -96,8 +96,7 @@ class LightsOut_Talon(InitialDealTalonStack):
         assert len(self.cards) >= len(stacks)
         old_state = self.game.enterState(self.game.S_DEAL)
         if reverse:
-            stacks = list(stacks)
-            stacks.reverse()
+            stacks = list(reversed(stacks))
         for r in stacks:
             if self.getCard().face_up:
                 # TODO: This probably needs a refactor.

--- a/pysollib/games/special/pegged.py
+++ b/pysollib/games/special/pegged.py
@@ -181,9 +181,7 @@ class Pegged(Game):
     #
 
     def shuffle(self):
-        cards = list(self.cards)
-        cards.reverse()
-        for card in cards:
+        for card in reversed(self.cards):
             self.s.talon.addCard(card, update=0)
             card.showBack(unhide=0)
 

--- a/pysollib/hint.py
+++ b/pysollib/hint.py
@@ -155,8 +155,7 @@ class AbstractHint(HintInterface):
     def _returnHints(self):
         hints = self.hints
         self.reset()
-        hints.sort()
-        hints.reverse()
+        hints.sort(reverse=True)
         return hints
 
     #

--- a/pysollib/stack.py
+++ b/pysollib/stack.py
@@ -1716,8 +1716,7 @@ class DealRow_StackMethods:
         assert len(self.cards) >= len(stacks)
         old_state = self.game.enterState(self.game.S_DEAL)
         if reverse:
-            stacks = list(stacks)
-            stacks.reverse()
+            stacks = list(reversed(stacks))
         for r in stacks:
             assert not self.getCard().face_up
             assert r is not self
@@ -1741,8 +1740,7 @@ class DealRow_StackMethods:
             return 0
         old_state = self.game.enterState(self.game.S_DEAL)
         if reverse:
-            stacks = list(stacks)
-            stacks.reverse()
+            stacks = list(reversed(stacks))
         n = 0
         for r in stacks:
             assert r is not self

--- a/pysollib/ui/tktile/tkcanvas.py
+++ b/pysollib/ui/tktile/tkcanvas.py
@@ -288,9 +288,7 @@ class MfxCanvas(tkinter.Canvas):
             x = event.x+dx+self.xview()[0]*int(self.cget('width'))
             y = event.y+dy+self.yview()[0]*int(self.cget('height'))
             # x, y = event.x, event.y
-            items = list(self.find_overlapping(x, y, x, y))
-            items.reverse()
-            for item in items:
+            for item in reversed(self.find_overlapping(x, y, x, y)):
                 for i, card in enumerate(stack.cards):
                     if card.item.id == item:
                         return i


### PR DESCRIPTION
The aim of this PR is to _optimise_ the usage of `reverse()` in _easy_ cases. There are few types of changes:
- using `reverse=True` while sorting and then not using `.reverse()` method on the resulting list (this is mostly pure aesthetics),
- reversing the the iterator while creating a list (this might _slightly_ speedup the code),
- not creating a list at all (this might reduce number of allocations).