### PR TITLE
Restrict permissions for `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI tests at GitHub
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/macos-package.yml
+++ b/.github/workflows/macos-package.yml
@@ -1,5 +1,8 @@
 name: macOS package
 
+permissions:
+  contents: read
+
 on:
   push:
     tags: [ '**' ]


### PR DESCRIPTION
This change resolves the CodeQL "Workflow does not contain permissions" warning: https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/

All of the other permissions are now set to `none`, cf. https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

Side notes: I activated CodeQL scan in my fork for python and github actions. There are no more warning (for the default set of rules), but I would highly recommend to to have it here as well.