### PR TITLE
Crispy: fix hint/demo stuck check for picture-card moves

### DIFF
--- a/pysollib/games/montecarlo.py
+++ b/pysollib/games/montecarlo.py
@@ -413,7 +413,6 @@ class Crispy_Hint(MonteCarlo_Hint):
                 )
             else:
                 if not t.cards:
-                    # Crispy needs whole-stack-to-empty moves for picture cards.
                     if lp != lr:
                         continue
 
@@ -423,11 +422,9 @@ class Crispy_Hint(MonteCarlo_Hint):
 
                     dest_ids = PICTURE_DESTS[rank]
 
-                    # Enforce designated destinations (Crispy_RowStack does too).
                     if t.id not in dest_ids:
                         continue
 
-                    # Avoid shuffling picture cards between already-correct slots.
                     if r.id in dest_ids:
                         continue
 


### PR DESCRIPTION
Allows required picture-card moves to empty target slots so demo and stuck check no longer report false stuck states.

Fixes #546.