### PR TITLE
Give cardset-size Medium its own gettext context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ rules:
 
 pot:
 	./scripts/all_games.py gettext > po/games.pot
-	xgettext --keyword=n_ --add-comments=TRANSLATORS: -o po/pysol.pot \
+	xgettext --keyword=n_ --keyword=pgettext:1c,2 --add-comments=TRANSLATORS: -o po/pysol.pot \
 		pysollib/*.py pysollib/*/*.py pysollib/*/*/*.py data/pysolfc.glade
 	set -e; \
 	for lng in de fr pl it ru pt_BR; do \

--- a/po/de_pysol.po
+++ b/po/de_pysol.po
@@ -4036,6 +4036,7 @@ msgstr ""
 msgid "Small"
 msgstr ""
 
+msgctxt "size"
 msgid "Medium"
 msgstr ""
 

--- a/po/fr_pysol.po
+++ b/po/fr_pysol.po
@@ -4081,6 +4081,7 @@ msgstr ""
 msgid "Small"
 msgstr ""
 
+msgctxt "size"
 msgid "Medium"
 msgstr ""
 

--- a/po/it_pysol.po
+++ b/po/it_pysol.po
@@ -4139,6 +4139,7 @@ msgstr ""
 msgid "Small"
 msgstr ""
 
+msgctxt "size"
 msgid "Medium"
 msgstr ""
 

--- a/po/pl_pysol.po
+++ b/po/pl_pysol.po
@@ -4107,6 +4107,7 @@ msgstr ""
 msgid "Small"
 msgstr ""
 
+msgctxt "size"
 msgid "Medium"
 msgstr ""
 

--- a/po/pt_BR_pysol.po
+++ b/po/pt_BR_pysol.po
@@ -4111,6 +4111,7 @@ msgstr ""
 msgid "Small"
 msgstr ""
 
+msgctxt "size"
 msgid "Medium"
 msgstr ""
 

--- a/po/pysol.pot
+++ b/po/pysol.pot
@@ -4442,6 +4442,7 @@ msgstr ""
 msgid "Small"
 msgstr ""
 
+msgctxt "size"
 msgid "Medium"
 msgstr ""
 

--- a/po/ru_pysol.po
+++ b/po/ru_pysol.po
@@ -4149,6 +4149,7 @@ msgstr ""
 msgid "Small"
 msgstr ""
 
+msgctxt "size"
 msgid "Medium"
 msgstr ""
 

--- a/pysollib/mygettext.py
+++ b/pysollib/mygettext.py
@@ -63,3 +63,9 @@ fix_gettext()
 
 _ = gettext.ugettext
 ungettext = gettext.ungettext
+
+
+def pgettext(context, message):
+    key = "%s\x04%s" % (context, message)
+    translated = _(key)
+    return message if translated == key else translated

--- a/pysollib/resource.py
+++ b/pysollib/resource.py
@@ -27,7 +27,7 @@ import re
 import traceback
 
 from pysollib.mfxutil import Image, KwStruct, Struct, USE_PIL
-from pysollib.mygettext import _
+from pysollib.mygettext import _, pgettext
 from pysollib.settings import DEBUG
 
 # ************************************************************************
@@ -392,7 +392,7 @@ class CSI:
     SIZE_NAME = {
         1:  _("Tiny"),
         2:  _("Small"),
-        3:  _("Medium"),
+        3:  pgettext("size", "Medium"),
         4:  _("Large"),
         5:  _("Extra Large"),
         6:  _("Hi-Res"),


### PR DESCRIPTION
5f3d561a added new translatable strings for the cardset size category feature (Tiny/Small/Medium/Large/Extra Large/Hi-Res) in `pysollib/resource.py`. `Medium` was already in use as a translated string for the Kivy speed menu in `pysollib/kivy/menubar.py`. 

Neither one uses `msgctxt`, so gettext treats them as the same key, and the commit ended up appending a second, untranslated `msgid "Medium"` block to `po/pysol.pot` and to `de/fr/it/pl/pt_BR/ru`'s `_pysol.po` files instead of reusing the existing one.

Older `msgcat` just prints a warning for a duplicate message definition and carries on, which is probably why this didn't get caught. Whereas now it is blocking make

```
po/de_pysol.po:4039: duplicate message definition...
po/de_pysol.po:3391: ...this is the location of the first definition
msgcat: found 1 fatal error
make: *** [mo] Error 1
```

I hit this running `make rules mo` on GitHub's `macos-15` runner image as I was doing some work on making it compile as a universal2 binary on mac OS...

This just drops the duplicate, untranslated `Medium` entries and leaves the original (translated) ones alone, so no translation content changes. Verified with the same `msgcat --use-first` / `msgfmt --check` commands the Makefile runs, for all six languages.

