### PR TITLE
Fix macOS package build to produce a true universal2 app

### DIFF
--- a/.github/workflows/macos-package.yml
+++ b/.github/workflows/macos-package.yml
@@ -10,16 +10,16 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - uses: actions/checkout@v7
-    - name: Set up python
+    - name: "Set up python (universal2: arm64 + x86_64)"
       env:
-        PYVER: '3.9.7'
-        PYVER_SHORT: '3.9'
+        PYVER: '3.11.9'
+        PYVER_SHORT: '3.11'
       run: |
-        wget -O python.pkg "https://www.python.org/ftp/python/${PYVER}/python-${PYVER}-macosx10.9.pkg"
+        wget -O python.pkg "https://www.python.org/ftp/python/${PYVER}/python-${PYVER}-macos11.pkg"
         sudo installer -pkg python.pkg -target /
         echo "/Library/Frameworks/Python.framework/Versions/${PYVER_SHORT}/bin" >> $GITHUB_PATH
     - name: Install dependencies
@@ -67,6 +67,21 @@ jobs:
         PYTHONPATH="." python3 setup_osx.py py2app
         test -d dist/PySolFC.app
         zip -q -r -X PySolFC-app.zip dist
+    - name: Verify the app is universal2 (arm64 + x86_64)
+      run: |
+        set -euo pipefail
+        check_universal2() {
+          archs="$(lipo -archs "$1" 2>/dev/null || true)"
+          case "$archs" in
+            *arm64*x86_64*|*x86_64*arm64*) ;;
+            *) echo "ERROR: $1 is not universal2 (archs: ${archs:-none})"; exit 1 ;;
+          esac
+        }
+        check_universal2 "dist/PySolFC.app/Contents/MacOS/PySolFC"
+        pygame_ext=$(find dist/PySolFC.app -name 'base.cpython-*-darwin.so' -path '*/pygame/*' | head -1)
+        test -n "$pygame_ext"
+        check_universal2 "$pygame_ext"
+        echo "OK: app and pygame-ce are both universal2."
     - name: Make the .dmg for easy installation
       run:
         create-dmg --volname "Install PySolFC"


### PR DESCRIPTION
CI downloads python.org's Intel-only installer (macosx10.9.pkg) even though the runner is arm64 (macos-14/macos-15), so Rosetta 2 translates the whole build and the packaged .app ends up x86_64-only. That's why the precompiled .dmg needs Rosetta 2 on Apple Silicon Macs and some users have had trouble running it.

- Switch to macos11.pkg, python.org's universal2 installer.
- Bump the runner from macos-14 (deprecated) to macos-15.
- Add a lipo check after packaging that fails the build if the .app binary or its bundled pygame-ce extension aren't actually universal2 (x86_64 + arm64), so a future regression fails CI instead of silently shipping a broken build.

Verified: ran this workflow via workflow_dispatch, confirmed with lipo that both the app and pygame-ce come out universal2, and launched the resulting .app locally.

Depends on #579 — bumping to macos-15 pulls in a newer msgcat that treats the duplicate "Medium" msgid in po/*_pysol.po as a fatal error instead of a warning (the older macos-14 image's msgcat just warned). #579 needs to merge first or this workflow's `make mo` step will fail on this repo's current po files.