### PR TITLE
Block card input while paused on Android/Kivy

### DIFF
--- a/pysollib/kivy/LApp.py
+++ b/pysollib/kivy/LApp.py
@@ -763,6 +763,14 @@ class LImageItem(BoxLayout, LBase):
     LB241111.
     '''
 
+    def _is_paused(self):
+        if self.game is not None:
+            return bool(self.game.pause)
+        lapp = App.get_running_app()
+        app = getattr(lapp, 'app', None)
+        game = getattr(app, 'game', None)
+        return bool(game and game.pause)
+
     def send_event_pressed_n(self, event, n):
         r = EVENT_PROPAGATE
         if self.group and n in self.group.bindings:
@@ -787,6 +795,9 @@ class LImageItem(BoxLayout, LBase):
         return r
 
     def on_touch_down(self, touch):
+
+        if self._is_paused():
+            return False
 
         # print('LCardImage: size = %s' % self.size)
         if self.collide_point(*touch.pos):
@@ -846,6 +857,9 @@ class LImageItem(BoxLayout, LBase):
             print('ungrab')
             touch.ungrab(self)
             return True
+
+        if self._is_paused():
+            return False
 
         if self.collide_point(*touch.pos):
 

--- a/pysollib/kivy/tkcanvas.py
+++ b/pysollib/kivy/tkcanvas.py
@@ -921,14 +921,13 @@ class MfxCanvas(LImage):
 
     def hideAllItems(self):
         print('MfxCanvas: hideAllItems')
-        # TBD
-        # Wir lassen das. Das TopImage deckt alles ab. Spielen ist
-        # nicht möglich.
+        # No-op here: the pause overlay (setTopImage) does not consume
+        # touch events on its own, so blocking input during pause is
+        # handled in LImageItem.on_touch_down/on_touch_up (LApp.py).
 
     def showAllItems(self):
         print('MfxCanvas: showAllItems')
-        # TBD
-        # Brauchts darum auch nicht.
+        # See hideAllItems above.
 
     # Erweiterungen fuer Tk Canvas (prüfen was noch nötig!!).
 


### PR DESCRIPTION
Pausing on Android didn't stop the game — cards could still be dragged, so moves kept counting while the timer stayed frozen (could finish with 0.00 time).

The pause overlay in Kivy is just an image on top; it never blocked touches. Cards now check `game.pause` and ignore touches while paused, matching desktop.

Resubmitting this separately, some comment cleanup I did got merged with this and I wanted to correct it. 