### PR TITLE
Window Position Recall

### DIFF
--- a/pysollib/app.py
+++ b/pysollib/app.py
@@ -502,6 +502,10 @@ class Application:
                 self.opt.wm_maximized = True
             elif s == "normal":
                 self.opt.wm_maximized = False
+            if s == "normal" and not self.opt.wm_fullscreen:
+                self.opt.window_geometry = (
+                    self.top.winfo_x(), self.top.winfo_y(),
+                    self.top.winfo_width(), self.top.winfo_height())
 
     def wm_withdraw(self):
         if self.intro.progress:

--- a/pysollib/options.py
+++ b/pysollib/options.py
@@ -124,6 +124,7 @@ use_cardset_bottoms = boolean
 dragcursor = boolean
 save_games_geometry = boolean
 game_geometry = int_list(min=2, max=2)
+window_geometry = int_list(min=4, max=4)
 topmost_dialogs = boolean
 sound = boolean
 sound_mode = integer(0, 1)
@@ -515,6 +516,7 @@ class Options:
         # saved games geometry (gameid: (width, height))
         self.games_geometry = {}
         self.game_geometry = (0, 0)  # game geometry before exit
+        self.window_geometry = (0, 0, 0, 0)
         self.offsets = {}           # cards offsets
         #
         self.randomize_place = False
@@ -730,6 +732,7 @@ class Options:
         for key, val in self.games_geometry.items():
             config['games_geometry'][str(key)] = val
         config['general']['game_geometry'] = self.game_geometry
+        config['general']['window_geometry'] = self.window_geometry
 
         # offsets
         for key, val in self.offsets.items():
@@ -926,6 +929,13 @@ class Options:
         if game_geometry is not None:
             try:
                 self.game_geometry = tuple(int(i) for i in game_geometry)
+            except Exception:
+                traceback.print_exc()
+        window_geometry = self._getOption(
+            'general', 'window_geometry', 'list')
+        if window_geometry is not None:
+            try:
+                self.window_geometry = tuple(int(i) for i in window_geometry)
             except Exception:
                 traceback.print_exc()
 

--- a/pysollib/ui/tktile/menubar.py
+++ b/pysollib/ui/tktile/menubar.py
@@ -912,6 +912,10 @@ class PysolMenubarTkCommon:
         # The tk-provided menu item expects this callback.
         self.top.createcommand('tk::mac::ShowHelp', self.mHelp)
 
+        if WIN_SYSTEM == "aqua":
+            self.top.createcommand(
+                'tk::mac::Quit', lambda: self.top.after_idle(self.mQuit))
+
         menu = MfxMenu(self.menubar, label=n_("&Help"))
         if WIN_SYSTEM != "aqua":
             menu.add_command(

--- a/pysollib/ui/tktile/tkutil.py
+++ b/pysollib/ui/tktile/tkutil.py
@@ -172,6 +172,9 @@ def __getWidgetXY(widget, parent, relx=None, rely=None,
             rely = 0.3
     x = m_x + int((m_width - w_width) * relx)
     y = m_y + int((m_height - w_height) * rely)
+    # let's try this instead in case it ends up outside of screen
+    x = max(m_x, min(x, m_x + m_width - w_width))
+    y = max(m_y, min(y, m_y + m_height - w_height))
     return x, y
 
 

--- a/pysollib/ui/tktile/tkutil.py
+++ b/pysollib/ui/tktile/tkutil.py
@@ -165,8 +165,6 @@ def __getWidgetXY(widget, parent, relx=None, rely=None,
                 relx = 0.5
             if rely is None:
                 rely = 0.5
-        m_x = max(m_x, 0)
-        m_y = max(m_y, 0)
     else:
         if relx is None:
             relx = 0.5
@@ -174,16 +172,6 @@ def __getWidgetXY(widget, parent, relx=None, rely=None,
             rely = 0.3
     x = m_x + int((m_width - w_width) * relx)
     y = m_y + int((m_height - w_height) * rely)
-    # print x, y, w_width, w_height, m_x, m_y, m_width, m_height
-    # make sure the widget is fully on screen
-    if x < 0:
-        x = 0
-    elif x + w_width + 32 > s_width:
-        x = max(0, (s_width - w_width) // 2)
-    if y < 0:
-        y = 0
-    elif y + w_height + 32 > s_height:
-        y = max(0, (s_height - w_height) // 2)
     return x, y
 
 

--- a/pysollib/ui/tktile/tkutil.py
+++ b/pysollib/ui/tktile/tkutil.py
@@ -67,6 +67,18 @@ def wm_get_geometry(window):
     return lst
 
 
+def restore_window_geometry(window, opt):
+    if opt.wm_maximized or opt.wm_fullscreen:
+        return
+    x, y, w, h = opt.window_geometry
+    if w <= 0 or h <= 0:
+        return
+    try:
+        window.wm_geometry("%dx%d+%d+%d" % (w, h, x, y))
+    except tkinter.TclError:
+        pass
+
+
 # ************************************************************************
 # * window util
 # ************************************************************************

--- a/pysollib/winsystems/common.py
+++ b/pysollib/winsystems/common.py
@@ -32,7 +32,7 @@ from pysollib.settings import TOOLKIT, USE_TILE
 from pysollib.settings import VERSION
 
 if TOOLKIT == 'tk':
-    from pysollib.ui.tktile.tkutil import loadImage
+    from pysollib.ui.tktile.tkutil import loadImage, restore_window_geometry
     if USE_TILE:
         import tkinter.ttk as ttk
 
@@ -111,6 +111,9 @@ def base_init_root_window(root, app):
         root.wm_minsize(400, 300)
     else:
         root.wm_minsize(520, 360)
+
+    if TOOLKIT == 'tk':
+        restore_window_geometry(root, app.opt)
 
     if TOOLKIT == 'tk' and USE_TILE:
         theme = app.opt.tile_theme


### PR DESCRIPTION
Remembers where you left the app window (position, size, monitor) and reopens it there next time — previously it always reset to a default spot. Also fixes popup dialogs (like confirmation prompts and the cardset picker) so they show up next to the actual window instead of jumping back toward the primary monitor when the app is on a second screen. Had to change a few lines in tkutil to ensure that it would still work even if the secondary monitor is positioned to the left (creates a -x situation).

**Needs more testing - tested on macOS 27 dev beta and Debian 11 Bullseye. Requesting a few folks give this a try and see how it performs - I already found one issue with it, hence the most recent commit.**

Implements #560  