### PR TITLE
Intuitive Menu Navigation for Mobile (Add "Back" Button) + Buildozer portability

### DIFF
--- a/buildozer/aversion
+++ b/buildozer/aversion
@@ -14,6 +14,14 @@ sversion=$(echo $version  | sed -E "s:(.*)\..*:\1:")
 tuple=$(echo $version | sed -E "s:(.*)\.(.*)\.(.*):(\1, \2, \3):")
 
 # patch different version info accordingly.
-sed -E "s:VERSION_TUPLE =.*:VERSION_TUPLE = $tuple:" -i $appdir/pysollib/settings.py
-sed -E "s:(.*\(')dev(',.*):\1fc-$sversion\2:" -i $appdir/pysollib/gamedb.py
+tmp1=$(mktemp)
+sed -E "s:VERSION_TUPLE =.*:VERSION_TUPLE = $tuple:" \
+    $appdir/pysollib/settings.py > "$tmp1"
+mv "$tmp1" $appdir/pysollib/settings.py
+
+tmp2=$(mktemp)
+sed -E "s:(.*\(')dev(',.*):\1fc-$sversion\2:" \
+    $appdir/pysollib/gamedb.py > "$tmp2"
+mv "$tmp2" $appdir/pysollib/gamedb.py
+
 echo "VERSION = $version"

--- a/buildozer/resize4k
+++ b/buildozer/resize4k
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 location='.'
 if [ $1 ]

--- a/po/de_pysol.po
+++ b/po/de_pysol.po
@@ -2819,6 +2819,10 @@ msgstr ""
 msgid "Full picture"
 msgstr ""
 
+#: pysollib\kivy\menubar.py:146 pysollib\kivy\selectgame.py:493
+msgid "< Back"
+msgstr ""
+
 #: pysollib\kivy\menubar.py:265
 msgid "File"
 msgstr "Datei"

--- a/po/fr_pysol.po
+++ b/po/fr_pysol.po
@@ -2860,6 +2860,10 @@ msgstr ""
 msgid "Full picture"
 msgstr ""
 
+#: pysollib\kivy\menubar.py:146 pysollib\kivy\selectgame.py:493
+msgid "< Back"
+msgstr ""
+
 #: pysollib\kivy\menubar.py:265
 msgid "File"
 msgstr "Fichier"

--- a/po/it_pysol.po
+++ b/po/it_pysol.po
@@ -2866,6 +2866,10 @@ msgstr ""
 msgid "Full picture"
 msgstr ""
 
+#: pysollib\kivy\menubar.py:146 pysollib\kivy\selectgame.py:493
+msgid "< Back"
+msgstr ""
+
 #: pysollib\kivy\menubar.py:265
 msgid "File"
 msgstr ""

--- a/po/pl_pysol.po
+++ b/po/pl_pysol.po
@@ -2881,6 +2881,10 @@ msgstr ""
 msgid "Full picture"
 msgstr ""
 
+#: pysollib\kivy\menubar.py:146 pysollib\kivy\selectgame.py:493
+msgid "< Back"
+msgstr ""
+
 #: pysollib\kivy\menubar.py:265
 msgid "File"
 msgstr "Plik"

--- a/po/pt_BR_pysol.po
+++ b/po/pt_BR_pysol.po
@@ -2888,6 +2888,10 @@ msgstr ""
 msgid "Full picture"
 msgstr ""
 
+#: pysollib\kivy\menubar.py:146 pysollib\kivy\selectgame.py:493
+msgid "< Back"
+msgstr ""
+
 #: pysollib\kivy\menubar.py:265
 msgid "File"
 msgstr "Arquivo"

--- a/po/pysol.pot
+++ b/po/pysol.pot
@@ -3005,6 +3005,10 @@ msgstr ""
 msgid "Full picture"
 msgstr ""
 
+#: pysollib\kivy\menubar.py:146 pysollib\kivy\selectgame.py:493
+msgid "< Back"
+msgstr ""
+
 #: pysollib\kivy\menubar.py:265
 msgid "File"
 msgstr ""

--- a/po/ru_pysol.po
+++ b/po/ru_pysol.po
@@ -2867,6 +2867,10 @@ msgstr ""
 msgid "Full picture"
 msgstr ""
 
+#: pysollib\kivy\menubar.py:146 pysollib\kivy\selectgame.py:493
+msgid "< Back"
+msgstr ""
+
 #: pysollib\kivy\menubar.py:265
 msgid "File"
 msgstr "Файл"

--- a/pysollib/kivy/LApp.py
+++ b/pysollib/kivy/LApp.py
@@ -1788,8 +1788,8 @@ class LMainWindow(BoxLayout, LTkBase):
 
     def pushWork(self, key, widget):
         if (widget):
-            if key != 'playground' and not getattr(widget, 'is_overlay',
-                                                     False):
+            is_overlay = getattr(widget, 'is_overlay', False)
+            if key != 'playground' and not is_overlay:
                 for k, w in list(self.workStack.items):
                     if k not in ('playground', key) and not getattr(
                             w, 'is_overlay', False):

--- a/pysollib/kivy/LApp.py
+++ b/pysollib/kivy/LApp.py
@@ -1197,6 +1197,7 @@ class LTopLevel0(LTopLevelBase, LBase):
         super().__init__(title=title, **kw)
 
         self.main = top
+        self.is_overlay = True
         self.titleline.bind(on_press=self.onClick)
         self.main.pushWork(self.title, self)
 
@@ -1787,6 +1788,12 @@ class LMainWindow(BoxLayout, LTkBase):
 
     def pushWork(self, key, widget):
         if (widget):
+            if key != 'playground' and not getattr(widget, 'is_overlay',
+                                                     False):
+                for k, w in list(self.workStack.items):
+                    if k not in ('playground', key) and not getattr(
+                            w, 'is_overlay', False):
+                        self.workStack.pop(k)
             self.workStack.push(key, widget)
             self.rebuildContainer()
 

--- a/pysollib/kivy/menubar.py
+++ b/pysollib/kivy/menubar.py
@@ -453,7 +453,7 @@ class GameMenuDialog(LMenuDialog):
         super().__init__(
             menubar, parent, title, app, **kw)
 
-    def make_command(self, key, command):
+    def make_stats_command(self, key, command):
         def stats_command():
             kw = {}
             kw['mode'] = key
@@ -466,11 +466,13 @@ class GameMenuDialog(LMenuDialog):
         tv.add_node(LTreeNode(
             text=_('Current game...'),
             command=self.auto_close(
-                self.make_command(101, self.menubar.mPlayerStats))), None)
+                self.make_stats_command(101, self.menubar.mPlayerStats))),
+            None)
 
         # tv.add_node(LTreeNode(
         #   text='All games ...',
-        #   command=self.make_command(102, self.menubar.mPlayerStats)), None)
+        #   command=self.make_stats_command(102, self.menubar.mPlayerStats)),
+        #   None)
 
     # -------------------------------------------
     # TBD ? - just to remember original tk code.

--- a/pysollib/kivy/menubar.py
+++ b/pysollib/kivy/menubar.py
@@ -142,7 +142,7 @@ class LMenuBase:
 
     def addBackNode(self, tv):
         tv.add_node(LTreeNode(
-            text=_('< Back'),
+            text='[b]' + _('< Back') + '[/b]',
             command=self.make_command(self.menubar.mMainMenuDialog)))
 
 # ************************************************************************

--- a/pysollib/kivy/menubar.py
+++ b/pysollib/kivy/menubar.py
@@ -140,6 +140,11 @@ class LMenuBase:
             LTreeSliderNode(variable=auto_var, setup=auto_setup), rg)
         return rg1
 
+    def addBackNode(self, tv):
+        tv.add_node(LTreeNode(
+            text=_('< Back'),
+            command=self.make_command(self.menubar.mMainMenuDialog)))
+
 # ************************************************************************
 # * Tree Generators
 # ************************************************************************
@@ -323,6 +328,8 @@ class FileMenuDialog(LMenuDialog):
         return doit
 
     def buildTree(self, tv, node):
+        self.addBackNode(tv)
+
         rg = tv.add_node(
             LTreeNode(text=_('Recent games')))
         recids = self.app.opt.recent_gameid
@@ -370,6 +377,8 @@ class EditMenuDialog(LMenuDialog):  # Tools
             menubar, parent, title, app, **kw)
 
     def buildTree(self, tv, node):
+        self.addBackNode(tv)
+
         tv.add_node(LTreeNode(
             text=_('New game'), command=self.menubar.mNewGame))
         tv.add_node(LTreeNode(
@@ -452,6 +461,8 @@ class GameMenuDialog(LMenuDialog):
         return stats_command
 
     def buildTree(self, tv, node):
+        self.addBackNode(tv)
+
         tv.add_node(LTreeNode(
             text=_('Current game...'),
             command=self.auto_close(
@@ -515,6 +526,8 @@ class AssistMenuDialog(LMenuDialog):
             menubar, parent, title, app, **kw)
 
     def buildTree(self, tv, node):
+        self.addBackNode(tv)
+
         tv.add_node(LTreeNode(
             text=_('Hint'), command=self.menubar.mHint))
 
@@ -552,6 +565,8 @@ class AssistMenuDialog(LMenuDialog):
 
 class LOptionsMenuGenerator(LTreeGenerator):
     def buildTree(self, tv, node):
+        self.addBackNode(tv)
+
         # -------------------------------------------
         # Automatic play settings
 
@@ -1344,6 +1359,8 @@ class HelpMenuDialog(LMenuDialog):
         super().__init__(menubar, parent, title, app, **kw)
 
     def buildTree(self, tv, node):
+        self.addBackNode(tv)
+
         tv.add_node(
             LTreeNode(
                 text=_('Contents'),

--- a/pysollib/kivy/selectgame.py
+++ b/pysollib/kivy/selectgame.py
@@ -490,7 +490,8 @@ class SelectGameDialog:
         def back_command():
             parent.popWork('SelectGame')
             self.app.menubar.mMainMenuDialog()
-        tv.add_node(LTreeNode(text=_('< Back'), command=back_command))
+        tv.add_node(LTreeNode(
+            text='[b]' + _('< Back') + '[/b]', command=back_command))
 
         # tree in einem Scrollwindow präsentieren.
 

--- a/pysollib/kivy/selectgame.py
+++ b/pysollib/kivy/selectgame.py
@@ -487,6 +487,11 @@ class SelectGameDialog:
         tv.load_func = loaderCB
         tv.bind(minimum_height=tv.setter('height'))
 
+        def back_command():
+            parent.popWork('SelectGame')
+            self.app.menubar.mMainMenuDialog()
+        tv.add_node(LTreeNode(text=_('< Back'), command=back_command))
+
         # tree in einem Scrollwindow präsentieren.
 
         root = LScrollView(pos=(0, 0))


### PR DESCRIPTION
On the mobile/Kivy UI, opening a menu, then opening a submenu, then tapping the menu button again would stack a second menu panel side-by-side with the first instead of replacing it. 

The fix: only one navigational panel (main menu, a submenu, the game picker, help, or about) is ever shown at a time. Opening a new one now automatically closes whatever panel was already open, so navigation always feels like moving to a new screen rather than piling windows up. Confirmation dialogs/notes are unaffected and still will appear next to the menu.

Adds feature requested in #551 

Also added a "< Back" entry at the top of every submenu, so you can jump straight back to the main menu without needing to close the submenu and tap the hamburger icon again.

Separately, fixed two small portability bugs in the buildozer/ build scripts that broke Android builds on macOS. Mainly `sed -i ` doesn't function quite the same on macOS. 

Requesting people to test this prior to potential merge. 