### PR TITLE
fix android edge-to-edge issue

### DIFF
--- a/pysollib/kivy/LApp.py
+++ b/pysollib/kivy/LApp.py
@@ -1885,6 +1885,13 @@ class LApp(App):
         logging.info('top = %s', str(self.baseWindow))
 
         self.mainWindow = LMainWindow()
+        self.androidSafeArea = None
+        if platform == 'android':
+            from pysollib.kivy.androidsafearea import AndroidSafeArea
+            self.androidSafeArea = AndroidSafeArea()
+            self._androidSafeAreaTries = 0
+            self._applyAndroidSafeArea()
+            Window.bind(on_resize=self._applyAndroidSafeArea)
         Cache.register('LAppCache', limit=10)
         Cache.append('LAppCache', 'baseWindow', self.baseWindow, timeout=0)
         Cache.append('LAppCache', 'mainWindow', self.mainWindow, timeout=0)
@@ -1912,6 +1919,23 @@ class LApp(App):
         anim = Animation(opacity=1,duration=0.7) # noqa
         Clock.schedule_once(lambda dt: anim.start(self.baseWindow),0.3) # noqa
         Clock.schedule_once(lambda dt: set_fullscreen(True),0.0) # noqa
+
+    def _applyAndroidSafeArea(self, *args):
+        safe_area = self.androidSafeArea
+        if safe_area is None:
+            return
+        if safe_area.refresh():
+            self._androidSafeAreaTries = 0
+            self.mainWindow.padding = [
+                safe_area.left, safe_area.top,
+                safe_area.right, safe_area.bottom]
+            logging.info('LApp: mainWindow.padding set to %s',
+                         self.mainWindow.padding)
+        elif self._androidSafeAreaTries < 25:
+            self._androidSafeAreaTries += 1
+            Clock.schedule_once(self._applyAndroidSafeArea, 0.2)
+        else:
+            logging.info('LApp: _applyAndroidSafeArea gave up retrying')
 
     def on_start(self):
         logging.info("LApp: on_start")

--- a/pysollib/kivy/LImage.py
+++ b/pysollib/kivy/LImage.py
@@ -48,6 +48,8 @@ class LImage(Widget, LBase):
         self.rect.pos = p
 
     def make_contain(self, s, p):
+        if s[0] <= 0 or s[1] <= 0:
+            return
         taspect = self.texture.size[0]/self.texture.size[1]
         waspect = s[0]/s[1]
         r = self.rect
@@ -61,6 +63,8 @@ class LImage(Widget, LBase):
             r.pos = (p[0]+(s[0]-s0)/2.0, p[1])
 
     def make_cover(self, s, p):
+        if self.size[0] <= 0 or self.size[1] <= 0:
+            return
         aspect = self.texture.size[0]/self.texture.size[1]
         waspect = self.size[0]/self.size[1]
 

--- a/pysollib/kivy/androidsafearea.py
+++ b/pysollib/kivy/androidsafearea.py
@@ -1,0 +1,65 @@
+import logging
+
+from kivy.utils import platform
+
+try:
+    import jnius
+except ImportError:
+    jnius = None
+
+
+class AndroidSafeArea:
+
+    def __init__(self):
+        self.left = 0
+        self.top = 0
+        self.right = 0
+        self.bottom = 0
+        self._decor_view = None
+        if platform != 'android' or jnius is None:
+            return
+        try:
+            PythonActivity = jnius.autoclass('org.kivy.android.PythonActivity')
+            activity = PythonActivity.mActivity
+            self._decor_view = activity.getWindow().getDecorView()
+        except Exception:
+            logging.exception('AndroidSafeArea: failed to access decor view')
+
+    def refresh(self):
+        if self._decor_view is None:
+            return False
+        try:
+            window_insets = self._decor_view.getRootWindowInsets()
+            if window_insets is None:
+                return False
+            VERSION = jnius.autoclass('android.os.Build$VERSION')
+            sdk_int = VERSION.SDK_INT
+            if sdk_int >= 30:
+                WindowInsetsType = jnius.autoclass(
+                    'android.view.WindowInsets$Type')
+                mask = (WindowInsetsType.systemBars()
+                        | WindowInsetsType.displayCutout())
+                insets = window_insets.getInsets(mask)
+                left, top = insets.left, insets.top
+                right, bottom = insets.right, insets.bottom
+            else:
+                left = window_insets.getSystemWindowInsetLeft()
+                top = window_insets.getSystemWindowInsetTop()
+                right = window_insets.getSystemWindowInsetRight()
+                bottom = window_insets.getSystemWindowInsetBottom()
+                if sdk_int >= 28:
+                    cutout = window_insets.getDisplayCutout()
+                    if cutout is not None:
+                        left = max(left, cutout.getSafeInsetLeft())
+                        top = max(top, cutout.getSafeInsetTop())
+                        right = max(right, cutout.getSafeInsetRight())
+                        bottom = max(bottom, cutout.getSafeInsetBottom())
+            self.left, self.top = left, top
+            self.right, self.bottom = right, bottom
+            logging.info(
+                'AndroidSafeArea: left=%s top=%s right=%s bottom=%s',
+                self.left, self.top, self.right, self.bottom)
+            return True
+        except Exception:
+            logging.exception('AndroidSafeArea: failed to read window insets')
+            return False

--- a/pysollib/kivy/tkwidget.py
+++ b/pysollib/kivy/tkwidget.py
@@ -510,12 +510,13 @@ class LScatterFrame(Scatter):
             self.offset = (offx/offmx,offy/offmy)
 
         # update persistent zoom parameters
-        zoom = self.bbox[1][0]/float(self.size[0])
-        if self.offset is not None:
-            zoominfo = [zoom, self.offset[0], self.offset[1]]
-        else:
-            zoominfo = [zoom, 0.0, 0.0]
-        self.tkopt.table_zoom.value = zoominfo
+        if self.size[0] > 0:
+            zoom = self.bbox[1][0]/float(self.size[0])
+            if self.offset is not None:
+                zoominfo = [zoom, self.offset[0], self.offset[1]]
+            else:
+                zoominfo = [zoom, 0.0, 0.0]
+            self.tkopt.table_zoom.value = zoominfo
 
         # remove lock
         self.lock_chk = None


### PR DESCRIPTION
androidsafearea.py (new file) figures out size of notch/status bar/nav bar, then LApp.py uses that to pad the game so nothing sits under the notch, and keeps it updated when you rotate the screen. Claude based this on a fix I used with iOS of just padding the area around the notch - spent some time testing it on Android today, but not an android daily user so would appreciate someone taking another look at it. 

Fixes #593.

<img width="25%" height="25%" alt="Portrait" src="https://github.com/user-attachments/assets/82fb3d20-0be5-4cd6-8842-682d04c17a8e" />
<img width="25%" height="25%" alt="Landscape" src="https://github.com/user-attachments/assets/344326a2-e2b2-42dd-afa9-8dc78b25c5f9" />
